### PR TITLE
Upfront null argument checks.

### DIFF
--- a/src/main/java/okio/DeflaterSink.java
+++ b/src/main/java/okio/DeflaterSink.java
@@ -41,6 +41,8 @@ public final class DeflaterSink implements Sink {
   private boolean closed;
 
   public DeflaterSink(Sink sink, Deflater deflater) {
+    if (sink == null) throw new IllegalArgumentException("sink == null");
+    if (deflater == null) throw new IllegalArgumentException("deflater == null");
     this.sink = Okio.buffer(sink);
     this.deflater = deflater;
   }

--- a/src/main/java/okio/GzipSource.java
+++ b/src/main/java/okio/GzipSource.java
@@ -58,6 +58,7 @@ public final class GzipSource implements Source {
   private final CRC32 crc = new CRC32();
 
   public GzipSource(Source source) {
+    if (source == null) throw new IllegalArgumentException("source == null");
     this.inflater = new Inflater(true);
     this.source = Okio.buffer(source);
     this.inflaterSource = new InflaterSource(this.source, inflater);


### PR DESCRIPTION
@swankjesse 

This matches the behavior of other classes by immediately failing on `null`.
