### PR TITLE
Fix problems with code that skips segments.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -629,7 +629,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     long offset = 0L;
     do {
       int segmentByteCount = s.limit - s.pos;
-      if (fromIndex > segmentByteCount) {
+      if (fromIndex >= segmentByteCount) {
         fromIndex -= segmentByteCount;
       } else {
         byte[] data = s.data;


### PR DESCRIPTION
Fix correctness problems that aren't exercised due to the current
calling patterns.
