### PR TITLE
Javadoc tweaks.

### DIFF
--- a/okio/src/main/java/okio/BufferedSink.java
+++ b/okio/src/main/java/okio/BufferedSink.java
@@ -30,14 +30,14 @@ public interface BufferedSink extends Sink {
   BufferedSink write(ByteString byteString) throws IOException;
 
   /**
-   * Like {@link OutputStream#write}, this writes a complete byte array to this
-   * sink.
+   * Like {@link OutputStream#write(byte[])}, this writes a complete byte array to
+   * this sink.
    */
   BufferedSink write(byte[] source) throws IOException;
 
   /**
-   * Like {@link OutputStream#write}, this writes {@code byteCount} bytes
-   * of {@code source}, starting at {@code offset}.
+   * Like {@link OutputStream#write(byte[], int, int)}, this writes {@code byteCount}
+   * bytes of {@code source}, starting at {@code offset}.
    */
   BufferedSink write(byte[] source, int offset, int byteCount) throws IOException;
 

--- a/okio/src/main/java/okio/Sink.java
+++ b/okio/src/main/java/okio/Sink.java
@@ -39,7 +39,7 @@ import java.io.IOException;
  * BufferedOutputStream} for buffering, and {@code OutputStreamWriter} for
  * charset encoding. This class uses {@code BufferedSink} for all of the above.
  *
- * <p>Sink is also easier to layer: there is no {@link
+ * <p>Sink is also easier to layer: there is no {@linkplain
  * java.io.OutputStream#write(int) single-byte write} method that is awkward to
  * implement efficiently.
  *

--- a/okio/src/main/java/okio/Source.java
+++ b/okio/src/main/java/okio/Source.java
@@ -39,15 +39,15 @@ import java.io.IOException;
  * BufferedInputStream} for buffering, and {@code InputStreamReader} for
  * strings. This class uses {@code BufferedSource} for all of the above.
  *
- * <p>Source avoids the impossible-to-implement {@link
+ * <p>Source avoids the impossible-to-implement {@linkplain
  * java.io.InputStream#available available()} method. Instead callers specify
  * how many bytes they {@link BufferedSource#require require}.
  *
- * <p>Source omits the unsafe-to-compose {@link java.io.InputStream#mark mark
- * and reset} state that's tracked by {@code InputStream}; callers instead just
- * buffer what they need.
+ * <p>Source omits the unsafe-to-compose {@linkplain java.io.InputStream#mark
+ * mark and reset} state that's tracked by {@code InputStream}; callers instead
+ * just buffer what they need.
  *
- * <p>When implementing a source, you need not worry about the {@link
+ * <p>When implementing a source, you need not worry about the {@linkplain
  * java.io.InputStream#read single-byte read} method that is awkward to
  * implement efficiently and that returns one of 257 possible values.
  *


### PR DESCRIPTION
- Use 'linkplain' when the linked text are normal words.
- Disambiguate method references. Otherwise, multiple matches always use the first _(write(int) in this case)_.
