### PR TITLE
API to read a byte[] directly.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -362,7 +362,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
   }
 
   @Override public ByteString readByteString(long byteCount) {
-    return new ByteString(readBytes(byteCount));
+    return new ByteString(readByteArray(byteCount));
   }
 
   @Override public void readFully(Buffer sink, long byteCount) throws IOException {
@@ -389,7 +389,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     Segment head = this.head;
     if (head.pos + byteCount > head.limit) {
       // If the string spans multiple segments, delegate to readBytes().
-      return new String(readBytes(byteCount), charset);
+      return new String(readByteArray(byteCount), charset);
     }
 
     String result = new String(head.data, head.pos, (int) byteCount, charset);
@@ -435,7 +435,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     }
   }
 
-  private byte[] readBytes(long byteCount) {
+  @Override public byte[] readByteArray(long byteCount) {
     checkOffsetAndCount(this.size, 0, byteCount);
     if (byteCount > Integer.MAX_VALUE) {
       throw new IllegalArgumentException("byteCount > Integer.MAX_VALUE: " + byteCount);

--- a/okio/src/main/java/okio/BufferedSource.java
+++ b/okio/src/main/java/okio/BufferedSource.java
@@ -72,6 +72,9 @@ public interface BufferedSource extends Source {
   /** Removes {@code byteCount} bytes from this and returns them as a byte string. */
   ByteString readByteString(long byteCount) throws IOException;
 
+  /** Removes {@code byteCount} bytes from this and returns them as a byte array. */
+  byte[] readByteArray(long byteCount) throws IOException;
+
   /**
    * Removes exactly {@code byteCount} bytes from this and appends them to
    * {@code sink}. Throws an {@link java.io.EOFException} if the requested

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -76,6 +76,11 @@ final class RealBufferedSource implements BufferedSource {
     return buffer.readByteString(byteCount);
   }
 
+  @Override public byte[] readByteArray(long byteCount) throws IOException {
+    require(byteCount);
+    return buffer.readByteArray(byteCount);
+  }
+
   @Override public void readFully(Buffer sink, long byteCount) throws IOException {
     require(byteCount);
     buffer.readFully(sink, byteCount);

--- a/okio/src/test/java/okio/BufferTest.java
+++ b/okio/src/test/java/okio/BufferTest.java
@@ -17,6 +17,7 @@ package okio;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -837,6 +838,12 @@ public final class BufferTest {
     assertEquals(Segment.SIZE * 3, sink.writeAll(source));
     assertEquals(0, source.size());
     assertEquals(TestUtil.repeat('a', Segment.SIZE * 3), sink.readUtf8(sink.size()));
+  }
+
+  @Test public void readByteArray() throws IOException {
+    Buffer buffer = new Buffer().writeUtf8("abcd");
+    assertEquals("[97, 98, 99]", Arrays.toString(buffer.readByteArray(3)));
+    assertEquals("d", buffer.readUtf8(1));
   }
 
   /**

--- a/okio/src/test/java/okio/RealBufferedSourceTest.java
+++ b/okio/src/test/java/okio/RealBufferedSourceTest.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import org.junit.Test;
 
 import static okio.TestUtil.repeat;
@@ -246,5 +247,11 @@ public final class RealBufferedSourceTest {
         "write(" + write1 + ", " + write1.size() + ")",
         "write(" + write2 + ", " + write2.size() + ")",
         "write(" + write3 + ", " + write3.size() + ")");
+  }
+
+  @Test public void readByteArray() throws IOException {
+    BufferedSource source = Okio.buffer((Source) new Buffer().writeUtf8("abcd"));
+    assertEquals("[97, 98, 99]", Arrays.toString(source.readByteArray(3)));
+    assertEquals("d", source.readUtf8(1));
   }
 }


### PR DESCRIPTION
Currently this is possible by reading through a ByteString, but that
costs a copy of the underlying bytes.
