### PR TITLE
Add append variant of Okio.sink for File.

### DIFF
--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -202,6 +202,11 @@ public final class Okio {
     return sink(new FileOutputStream(file));
   }
 
+  /** Returns a sink that appends to {@code file}. */
+  public static Sink appendingSink(File file) throws FileNotFoundException {
+    return sink(new FileOutputStream(file, true));
+  }
+
   /** Returns a sink that writes to {@code path}. */
   @IgnoreJRERequirement // Should only be invoked on Java 7+.
   public static Sink sink(Path path, OpenOption... options) throws IOException {

--- a/okio/src/test/java/okio/OkioTest.java
+++ b/okio/src/test/java/okio/OkioTest.java
@@ -48,6 +48,25 @@ public final class OkioTest {
     source.close();
   }
 
+  @Test public void appendFile() throws Exception {
+    File file = temporaryFolder.newFile();
+
+    BufferedSink sink = Okio.buffer(Okio.appendingSink(file));
+    sink.writeUtf8("Hello, ");
+    sink.close();
+    assertTrue(file.exists());
+    assertEquals(7, file.length());
+
+    sink = Okio.buffer(Okio.appendingSink(file));
+    sink.writeUtf8("java.io file!");
+    sink.close();
+    assertEquals(20, file.length());
+
+    BufferedSource source = Okio.buffer(Okio.source(file));
+    assertEquals("Hello, java.io file!", source.readUtf8());
+    source.close();
+  }
+
   @Test public void readWritePath() throws Exception {
     Path path = temporaryFolder.newFile().toPath();
 


### PR DESCRIPTION
...because I hate having to break the mental model living in Okio by doing `Okio.sink(new FileInputStream(file, true));` in calling code.
