### PR TITLE
Small changes to the way deadlines are managed.

### DIFF
--- a/okio/src/main/java/okio/Timeout.java
+++ b/okio/src/main/java/okio/Timeout.java
@@ -50,7 +50,7 @@ public class Timeout {
       return this;
     }
 
-    @Override public Timeout deadline(long duration, TimeUnit unit) {
+    @Override public Timeout deadlineNanoTime(long deadlineNanoTime) {
       return this;
     }
 
@@ -58,8 +58,12 @@ public class Timeout {
     }
   };
 
-  private long deadlineStart;
-  private long deadlineDurationNanos = -1;
+  /**
+   * True if {@code deadlineNanoTime} is defined. There is no equivalent to null
+   * or -1 for {@link System#nanoTime}.
+   */
+  private boolean hasDeadline;
+  private long deadlineNanoTime;
   private long timeoutNanos = -1;
 
   public Timeout() {
@@ -81,37 +85,48 @@ public class Timeout {
     return timeoutNanos;
   }
 
-  /**
-   * Returns the {@linkplain System#nanoTime() time} that a deadline was most
-   * recently started.
-   */
-  public long deadlineStart() {
-    return deadlineStart;
-  }
-
-  /** Returns the deadline duration in nanoseconds, or {@code -1} for no deadline. */
-  public long deadlineDurationNanos() {
-    return deadlineDurationNanos;
+  /** Returns true if a deadline is enabled. */
+  public boolean hasDeadline() {
+    return hasDeadline;
   }
 
   /**
-   * Set a deadline of now plus {@code duration} time. All operations must
-   * complete before the deadline is reached. Use a deadline to set a maximum
-   * bound on the time spent on a sequence of operations.
+   * Returns the {@linkplain System#nanoTime() nano time} when the deadline will
+   * be reached.
+   *
+   * @throws IllegalStateException if no deadline is set.
    */
-  public Timeout deadline(long duration, TimeUnit unit) {
-    if (duration <= 0) throw new IllegalArgumentException("duration <= 0: " + duration);
-    this.deadlineStart = System.nanoTime();
-    this.deadlineDurationNanos = unit.toNanos(duration);
+  public long deadlineNanoTime() {
+    if (!hasDeadline) throw new IllegalStateException();
+    return deadlineNanoTime;
+  }
+
+  /**
+   * Sets the {@linkplain System#nanoTime() nano time} when the deadline will be
+   * reached. All operations must complete before this time. Use a deadline to
+   * set a maximum bound on the time spent on a sequence of operations.
+   */
+  public Timeout deadlineNanoTime(long deadlineNanoTime) {
+    this.hasDeadline = true;
+    this.deadlineNanoTime = deadlineNanoTime;
     return this;
   }
 
-  /**
-   * Clears the timeout and deadline. Operating system timeouts may still apply.
-   */
-  public Timeout clear() {
-    this.deadlineDurationNanos = -1;
+  /** Set a deadline of now plus {@code duration} time. */
+  public final Timeout deadline(long duration, TimeUnit unit) {
+    if (duration <= 0) throw new IllegalArgumentException("duration <= 0: " + duration);
+    return deadlineNanoTime(System.nanoTime() + unit.toNanos(duration));
+  }
+
+  /** Clears the timeout. Operating system timeouts may still apply. */
+  public Timeout clearTimeout() {
     this.timeoutNanos = -1;
+    return this;
+  }
+
+  /** Clears the deadline. */
+  public Timeout clearDeadline() {
+    this.hasDeadline = false;
     return this;
   }
 
@@ -126,10 +141,8 @@ public class Timeout {
       throw new InterruptedIOException();
     }
 
-    if (deadlineDurationNanos != -1) {
-      long now = System.nanoTime();
-      long elapsed = now - deadlineStart;
-      if (elapsed > deadlineDurationNanos) throw new IOException("deadline reached");
+    if (hasDeadline && System.nanoTime() > deadlineNanoTime) {
+      throw new IOException("deadline reached");
     }
   }
 }

--- a/okio/src/test/java/okio/AsyncTimeoutTest.java
+++ b/okio/src/test/java/okio/AsyncTimeoutTest.java
@@ -159,6 +159,15 @@ public class AsyncTimeoutTest {
     assertTimedOut(timeout);
   }
 
+  @Test public void deadlineInThePast() throws Exception {
+    RecordingAsyncTimeout timeout = new RecordingAsyncTimeout();
+    timeout.deadlineNanoTime(System.nanoTime() - 1);
+    timeout.enter();
+    Thread.sleep(250);
+    assertTrue(timeout.exit());
+    assertTimedOut(timeout);
+  }
+
   /** Asserts which timeouts fired, and in which order. */
   private void assertTimedOut(Timeout... expected) {
     assertEquals(Arrays.asList(expected), timedOut);


### PR DESCRIPTION
Previously we kept a start + offset. With this change we keep the deadline time
plus a boolean indicating whether the deadline is enabled.

The motivation is to enable push/pop style access to deadlines: code using
deadlines can set a custom deadline, use it, and then restore the previous
configuration.
