### PR TITLE
Eagerly verify preconditions on public APIs.

### DIFF
--- a/okio/src/main/java/okio/ByteString.java
+++ b/okio/src/main/java/okio/ByteString.java
@@ -27,6 +27,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
+import static okio.Util.checkOffsetAndCount;
+
 /**
  * An immutable sequence of bytes.
  *
@@ -58,6 +60,7 @@ public final class ByteString implements Serializable {
    * Returns a new byte string containing a clone of the bytes of {@code data}.
    */
   public static ByteString of(byte... data) {
+    if (data == null) throw new IllegalArgumentException("data == null");
     return new ByteString(data.clone());
   }
 
@@ -66,6 +69,9 @@ public final class ByteString implements Serializable {
    * at {@code offset}.
    */
   public static ByteString of(byte[] data, int offset, int byteCount) {
+    if (data == null) throw new IllegalArgumentException("data == null");
+    checkOffsetAndCount(data.length, offset, byteCount);
+
     byte[] copy = new byte[byteCount];
     System.arraycopy(data, offset, copy, 0, byteCount);
     return new ByteString(copy);
@@ -73,6 +79,7 @@ public final class ByteString implements Serializable {
 
   /** Returns a new byte string containing the {@code UTF-8} bytes of {@code s}. */
   public static ByteString encodeUtf8(String s) {
+    if (s == null) throw new IllegalArgumentException("s == null");
     ByteString byteString = new ByteString(s.getBytes(Util.UTF_8));
     byteString.utf8 = s;
     return byteString;
@@ -99,6 +106,7 @@ public final class ByteString implements Serializable {
    * Returns null if {@code base64} is not a Base64-encoded sequence of bytes.
    */
   public static ByteString decodeBase64(String base64) {
+    if (base64 == null) throw new IllegalArgumentException("base64 == null");
     byte[] decoded = Base64.decode(base64);
     return decoded != null ? new ByteString(decoded) : null;
   }
@@ -116,6 +124,7 @@ public final class ByteString implements Serializable {
 
   /** Decodes the hex-encoded bytes and returns their value a byte string. */
   public static ByteString decodeHex(String hex) {
+    if (hex == null) throw new IllegalArgumentException("hex == null");
     if (hex.length() % 2 != 0) throw new IllegalArgumentException("Unexpected hex string: " + hex);
 
     byte[] result = new byte[hex.length() / 2];
@@ -141,6 +150,9 @@ public final class ByteString implements Serializable {
    *     bytes to read.
    */
   public static ByteString read(InputStream in, int byteCount) throws IOException {
+    if (in == null) throw new IllegalArgumentException("in == null");
+    if (byteCount < 0) throw new IllegalArgumentException("byteCount < 0: " + byteCount);
+
     byte[] result = new byte[byteCount];
     for (int offset = 0, read; offset < byteCount; offset += read) {
       read = in.read(result, offset, byteCount - offset);
@@ -220,6 +232,7 @@ public final class ByteString implements Serializable {
 
   /** Writes the contents of this byte string to {@code out}. */
   public void write(OutputStream out) throws IOException {
+    if (out == null) throw new IllegalArgumentException("out == null");
     out.write(data);
   }
 

--- a/okio/src/main/java/okio/ForwardingSink.java
+++ b/okio/src/main/java/okio/ForwardingSink.java
@@ -22,6 +22,7 @@ public abstract class ForwardingSink implements Sink {
   private final Sink delegate;
 
   public ForwardingSink(Sink delegate) {
+    if (delegate == null) throw new IllegalArgumentException("delegate == null");
     this.delegate = delegate;
   }
 

--- a/okio/src/main/java/okio/ForwardingSource.java
+++ b/okio/src/main/java/okio/ForwardingSource.java
@@ -22,6 +22,7 @@ public abstract class ForwardingSource implements Source {
   private final Source delegate;
 
   public ForwardingSource(Source delegate) {
+    if (delegate == null) throw new IllegalArgumentException("delegate == null");
     this.delegate = delegate;
   }
 

--- a/okio/src/main/java/okio/GzipSink.java
+++ b/okio/src/main/java/okio/GzipSink.java
@@ -54,6 +54,7 @@ public final class GzipSink implements Sink {
   private final CRC32 crc = new CRC32();
 
   public GzipSink(Sink sink) {
+    if (sink == null) throw new IllegalArgumentException("sink == null");
     this.deflater = new Deflater(DEFAULT_COMPRESSION, true /* No wrap */);
     this.sink = Okio.buffer(sink);
     this.deflaterSink = new DeflaterSink(this.sink, deflater);

--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -45,6 +45,7 @@ public final class Okio {
    * you read a source to get an ergonomic and efficient access to data.
    */
   public static BufferedSource buffer(Source source) {
+    if (source == null) throw new IllegalArgumentException("source == null");
     return new RealBufferedSource(source);
   }
 
@@ -54,6 +55,7 @@ public final class Okio {
    * get an ergonomic and efficient access to data.
    */
   public static BufferedSink buffer(Sink sink) {
+    if (sink == null) throw new IllegalArgumentException("sink == null");
     return new RealBufferedSink(sink);
   }
 
@@ -63,6 +65,9 @@ public final class Okio {
   }
 
   private static Sink sink(final OutputStream out, final Timeout timeout) {
+    if (out == null) throw new IllegalArgumentException("out == null");
+    if (timeout == null) throw new IllegalArgumentException("timeout == null");
+
     return new Sink() {
       @Override public void write(Buffer source, long byteCount) throws IOException {
         checkOffsetAndCount(source.size, 0, byteCount);
@@ -107,6 +112,8 @@ public final class Okio {
    * write times out, the socket is asynchronously closed by a watchdog thread.
    */
   public static Sink sink(final Socket socket) throws IOException {
+    if (socket == null) throw new IllegalArgumentException("socket == null");
+
     final AsyncTimeout timeout = timeout(socket);
     final Sink sink = sink(socket.getOutputStream(), timeout);
     return new Sink() {
@@ -159,6 +166,9 @@ public final class Okio {
   }
 
   private static Source source(final InputStream in, final Timeout timeout) {
+    if (in == null) throw new IllegalArgumentException("in == null");
+    if (timeout == null) throw new IllegalArgumentException("timeout == null");
+
     return new Source() {
       @Override public long read(Buffer sink, long byteCount) throws IOException {
         if (byteCount < 0) throw new IllegalArgumentException("byteCount < 0: " + byteCount);
@@ -188,28 +198,33 @@ public final class Okio {
 
   /** Returns a source that reads from {@code file}. */
   public static Source source(File file) throws FileNotFoundException {
+    if (file == null) throw new IllegalArgumentException("file == null");
     return source(new FileInputStream(file));
   }
 
   /** Returns a source that reads from {@code path}. */
   @IgnoreJRERequirement // Should only be invoked on Java 7+.
   public static Source source(Path path, OpenOption... options) throws IOException {
+    if (path == null) throw new IllegalArgumentException("path == null");
     return source(Files.newInputStream(path, options));
   }
 
   /** Returns a sink that writes to {@code file}. */
   public static Sink sink(File file) throws FileNotFoundException {
+    if (file == null) throw new IllegalArgumentException("file == null");
     return sink(new FileOutputStream(file));
   }
 
   /** Returns a sink that appends to {@code file}. */
   public static Sink appendingSink(File file) throws FileNotFoundException {
+    if (file == null) throw new IllegalArgumentException("file == null");
     return sink(new FileOutputStream(file, true));
   }
 
   /** Returns a sink that writes to {@code path}. */
   @IgnoreJRERequirement // Should only be invoked on Java 7+.
   public static Sink sink(Path path, OpenOption... options) throws IOException {
+    if (path == null) throw new IllegalArgumentException("path == null");
     return sink(Files.newOutputStream(path, options));
   }
 
@@ -219,6 +234,8 @@ public final class Okio {
    * read times out, the socket is asynchronously closed by a watchdog thread.
    */
   public static Source source(final Socket socket) throws IOException {
+    if (socket == null) throw new IllegalArgumentException("socket == null");
+
     final AsyncTimeout timeout = timeout(socket);
     final Source source = source(socket.getInputStream(), timeout);
     return new Source() {

--- a/okio/src/main/java/okio/RealBufferedSink.java
+++ b/okio/src/main/java/okio/RealBufferedSink.java
@@ -76,6 +76,7 @@ final class RealBufferedSink implements BufferedSink {
   }
 
   @Override public long writeAll(Source source) throws IOException {
+    if (source == null) throw new IllegalArgumentException("source == null");
     long totalBytesRead = 0;
     for (long readCount; (readCount = source.read(buffer, Segment.SIZE)) != -1; ) {
       totalBytesRead += readCount;

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -42,6 +42,7 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public long read(Buffer sink, long byteCount) throws IOException {
+    if (sink == null) throw new IllegalArgumentException("sink == null");
     if (byteCount < 0) throw new IllegalArgumentException("byteCount < 0: " + byteCount);
     if (closed) throw new IllegalStateException("closed");
 
@@ -60,6 +61,7 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public void require(long byteCount) throws IOException {
+    if (byteCount < 0) throw new IllegalArgumentException("byteCount < 0: " + byteCount);
     if (closed) throw new IllegalStateException("closed");
     while (buffer.size < byteCount) {
       if (source.read(buffer, Segment.SIZE) == -1) throw new EOFException();
@@ -97,6 +99,8 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public long readAll(Sink sink) throws IOException {
+    if (sink == null) throw new IllegalArgumentException("sink == null");
+
     long totalBytesWritten = 0;
     while (source.read(buffer, Segment.SIZE) != -1) {
       long emitByteCount = buffer.completeSegmentByteCount();
@@ -123,12 +127,15 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public String readString(Charset charset) throws IOException {
+    if (charset == null) throw new IllegalArgumentException("charset == null");
+
     buffer.writeAll(source);
     return buffer.readString(charset);
   }
 
   @Override public String readString(long byteCount, Charset charset) throws IOException {
     require(byteCount);
+    if (charset == null) throw new IllegalArgumentException("charset == null");
     return buffer.readString(byteCount, charset);
   }
 

--- a/okio/src/main/java/okio/Timeout.java
+++ b/okio/src/main/java/okio/Timeout.java
@@ -76,6 +76,7 @@ public class Timeout {
    */
   public Timeout timeout(long timeout, TimeUnit unit) {
     if (timeout <= 0) throw new IllegalArgumentException("timeout <= 0: " + timeout);
+    if (unit == null) throw new IllegalArgumentException("unit == null");
     this.timeoutNanos = unit.toNanos(timeout);
     return this;
   }
@@ -97,7 +98,7 @@ public class Timeout {
    * @throws IllegalStateException if no deadline is set.
    */
   public long deadlineNanoTime() {
-    if (!hasDeadline) throw new IllegalStateException();
+    if (!hasDeadline) throw new IllegalStateException("No deadline");
     return deadlineNanoTime;
   }
 
@@ -115,6 +116,7 @@ public class Timeout {
   /** Set a deadline of now plus {@code duration} time. */
   public final Timeout deadline(long duration, TimeUnit unit) {
     if (duration <= 0) throw new IllegalArgumentException("duration <= 0: " + duration);
+    if (unit == null) throw new IllegalArgumentException("unit == null");
     return deadlineNanoTime(System.nanoTime() + unit.toNanos(duration));
   }
 


### PR DESCRIPTION
Closes #48. 

Alright, @swankjesse, do your worst! Here's my opinion in implementing this change: Seeing a `NullPointerException` which throws both without a message and after an additional method call or two internally places doubt in the user's mind as to whether or not the problem is their fault (passing `null`) or shoddy programming in the library. 
