### PR TITLE
Use 0 as a sentinel for no timeout.

### DIFF
--- a/okio/src/main/java/okio/AsyncTimeout.java
+++ b/okio/src/main/java/okio/AsyncTimeout.java
@@ -62,7 +62,7 @@ public class AsyncTimeout extends Timeout {
     if (inQueue) throw new IllegalStateException("Unbalanced enter/exit");
     long timeoutNanos = timeoutNanos();
     boolean hasDeadline = hasDeadline();
-    if (timeoutNanos == -1 && !hasDeadline) {
+    if (timeoutNanos == 0 && !hasDeadline) {
       return; // No timeout and no deadline? Don't bother with the queue.
     }
     inQueue = true;
@@ -78,11 +78,11 @@ public class AsyncTimeout extends Timeout {
     }
 
     long now = System.nanoTime();
-    if (timeoutNanos != -1 && hasDeadline) {
+    if (timeoutNanos != 0 && hasDeadline) {
       // Compute the earliest event; either timeout or deadline. Because nanoTime can wrap around,
       // Math.min() is undefined for absolute values, but meaningful for relative ones.
       node.timeoutAt = now + Math.min(timeoutNanos, node.deadlineNanoTime() - now);
-    } else if (timeoutNanos != -1) {
+    } else if (timeoutNanos != 0) {
       node.timeoutAt = now + timeoutNanos;
     } else if (hasDeadline) {
       node.timeoutAt = node.deadlineNanoTime();

--- a/okio/src/main/java/okio/Timeout.java
+++ b/okio/src/main/java/okio/Timeout.java
@@ -60,11 +60,11 @@ public class Timeout {
 
   /**
    * True if {@code deadlineNanoTime} is defined. There is no equivalent to null
-   * or -1 for {@link System#nanoTime}.
+   * or 0 for {@link System#nanoTime}.
    */
   private boolean hasDeadline;
   private long deadlineNanoTime;
-  private long timeoutNanos = -1;
+  private long timeoutNanos;
 
   public Timeout() {
   }
@@ -73,15 +73,18 @@ public class Timeout {
    * Wait at most {@code timeout} time before aborting an operation. Using a
    * per-operation timeout means that as long as forward progress is being made,
    * no sequence of operations will fail.
+   *
+   * <p>If {@code timeout == 0}, operations will run indefinitely. (Operating
+   * system timeouts may still apply.)
    */
   public Timeout timeout(long timeout, TimeUnit unit) {
-    if (timeout <= 0) throw new IllegalArgumentException("timeout <= 0: " + timeout);
+    if (timeout < 0) throw new IllegalArgumentException("timeout < 0: " + timeout);
     if (unit == null) throw new IllegalArgumentException("unit == null");
     this.timeoutNanos = unit.toNanos(timeout);
     return this;
   }
 
-  /** Returns the timeout in nanoseconds, or {@code -1} for no timeout. */
+  /** Returns the timeout in nanoseconds, or {@code 0} for no timeout. */
   public long timeoutNanos() {
     return timeoutNanos;
   }
@@ -122,7 +125,7 @@ public class Timeout {
 
   /** Clears the timeout. Operating system timeouts may still apply. */
   public Timeout clearTimeout() {
-    this.timeoutNanos = -1;
+    this.timeoutNanos = 0;
     return this;
   }
 

--- a/okio/src/test/java/okio/AsyncTimeoutTest.java
+++ b/okio/src/test/java/okio/AsyncTimeoutTest.java
@@ -47,6 +47,15 @@ public class AsyncTimeoutTest {
     d.timeout(1000, TimeUnit.MILLISECONDS);
   }
 
+  @Test public void zeroTimeoutIsNoTimeout() throws Exception {
+    AsyncTimeout timeout = new RecordingAsyncTimeout();
+    timeout.timeout(0, TimeUnit.MILLISECONDS);
+    timeout.enter();
+    Thread.sleep(250);
+    assertFalse(timeout.exit());
+    assertTimedOut();
+  }
+
   @Test public void singleInstanceTimedOut() throws Exception {
     a.enter();
     Thread.sleep(500);


### PR DESCRIPTION
That's what everything else does for timeouts. -1 is more conventional
for non-timeout things, but these are timeouts.
