### PR TITLE
Make deflate/gzip sources and sinks package-private.

### DIFF
--- a/okio/src/main/java/okio/DeflaterSink.java
+++ b/okio/src/main/java/okio/DeflaterSink.java
@@ -35,12 +35,12 @@ import static okio.Util.checkOffsetAndCount;
  * This class does not offer any partial flush mechanism. For best performance,
  * only call {@link #flush} when application behavior requires it.
  */
-public final class DeflaterSink implements Sink {
+final class DeflaterSink implements Sink {
   private final BufferedSink sink;
   private final Deflater deflater;
   private boolean closed;
 
-  public DeflaterSink(Sink sink, Deflater deflater) {
+  DeflaterSink(Sink sink, Deflater deflater) {
     this(Okio.buffer(sink), deflater);
   }
 

--- a/okio/src/main/java/okio/GzipSink.java
+++ b/okio/src/main/java/okio/GzipSink.java
@@ -35,7 +35,7 @@ import static java.util.zip.Deflater.DEFAULT_COMPRESSION;
  * This class does not offer any partial flush mechanism. For best performance,
  * only call {@link #flush} when application behavior requires it.
  */
-public final class GzipSink implements Sink {
+final class GzipSink implements Sink {
   /** Sink into which the GZIP format is written. */
   private final BufferedSink sink;
 
@@ -53,7 +53,7 @@ public final class GzipSink implements Sink {
   /** Checksum calculated for the compressed body. */
   private final CRC32 crc = new CRC32();
 
-  public GzipSink(Sink sink) {
+  GzipSink(Sink sink) {
     if (sink == null) throw new IllegalArgumentException("sink == null");
     this.deflater = new Deflater(DEFAULT_COMPRESSION, true /* No wrap */);
     this.sink = Okio.buffer(sink);

--- a/okio/src/main/java/okio/GzipSource.java
+++ b/okio/src/main/java/okio/GzipSource.java
@@ -24,7 +24,7 @@ import java.util.zip.Inflater;
  * A source that uses <a href="http://www.ietf.org/rfc/rfc1952.txt">GZIP</a> to
  * decompress data read from another source.
  */
-public final class GzipSource implements Source {
+final class GzipSource implements Source {
   private static final byte FHCRC = 1;
   private static final byte FEXTRA = 2;
   private static final byte FNAME = 3;
@@ -57,7 +57,7 @@ public final class GzipSource implements Source {
   /** Checksum used to check both the GZIP header and decompressed body. */
   private final CRC32 crc = new CRC32();
 
-  public GzipSource(Source source) {
+  GzipSource(Source source) {
     if (source == null) throw new IllegalArgumentException("source == null");
     this.inflater = new Inflater(true);
     this.source = Okio.buffer(source);

--- a/okio/src/main/java/okio/InflaterSource.java
+++ b/okio/src/main/java/okio/InflaterSource.java
@@ -24,7 +24,7 @@ import java.util.zip.Inflater;
  * A source that uses <a href="http://tools.ietf.org/html/rfc1951">DEFLATE</a>
  * to decompress data read from another source.
  */
-public final class InflaterSource implements Source {
+final class InflaterSource implements Source {
   private final BufferedSource source;
   private final Inflater inflater;
 
@@ -36,7 +36,7 @@ public final class InflaterSource implements Source {
   private int bufferBytesHeldByInflater;
   private boolean closed;
 
-  public InflaterSource(Source source, Inflater inflater) {
+  InflaterSource(Source source, Inflater inflater) {
     this(Okio.buffer(source), inflater);
   }
 

--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -28,6 +28,9 @@ import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 import static okio.Util.checkOffsetAndCount;
@@ -208,5 +211,58 @@ public final class Okio {
         }
       }
     };
+  }
+
+  /**
+   * Returns a source that uses <a href="http://tools.ietf.org/html/rfc1951">DEFLATE</a>
+   * to decompress data read from the given {@code source}.
+   */
+  public static Source inflate(Source source, Inflater inflater) {
+    return new InflaterSource(source, inflater);
+  }
+
+  /**
+   * Returns a sink that uses <a href="http://tools.ietf.org/html/rfc1951">DEFLATE</a>
+   * to compress written data to the given {@code sink}.
+   *
+   * <h3>Sync flush</h3>
+   * Aggressive flushing of the returned sink may result in reduced compression.
+   * Each call to {@link Sink#flush flush} immediately compresses all
+   * currently-buffered data; this early compression may be less effective than
+   * compression performed without flushing.
+   *
+   * <p>This is equivalent to using {@link Deflater} with the sync flush option.
+   * The returned sink does not offer any partial flush mechanism. For best
+   * performance, only call {@link Sink#flush flush} when application behavior
+   * requires it.
+   */
+  public static Sink deflate(Sink sink, Deflater deflater) {
+    return new DeflaterSink(sink, deflater);
+  }
+
+  /**
+   * Returns a source that uses <a href="http://www.ietf.org/rfc/rfc1952.txt">GZIP</a>
+   * to decompress data read from the given {@code source}.
+   */
+  public static Source gzip(Source source) {
+    return new GzipSource(source);
+  }
+
+  /**
+   * Returns a sink that uses <a href="http://www.ietf.org/rfc/rfc1952.txt">GZIP</a>
+   * to compress written data to the given {@code sink}.
+   *
+   * <h3>Sync flush</h3>
+   * Aggressive flushing of this stream may result in reduced compression. Each
+   * call to {@link Sink#flush flush} immediately compresses all currently-buffered
+   * data; this early compression may be less effective than compression performed
+   * without flushing.
+   *
+   * <p>This is equivalent to using {@link Deflater} with the sync flush option.
+   * This class does not offer any partial flush mechanism. For best performance,
+   * only call {@link Sink#flush flush} when application behavior requires it.
+   */
+  public static Sink gzip(Sink sink) {
+    return new GzipSink(sink);
   }
 }


### PR DESCRIPTION
Just wanted to see what you thought of this. I generally prefer to avoid public types when they aren't needed to provide additional methods. Also, Okio.gzip(Source) should perhaps be called something like "ungzip" instead.
