### PR TITLE
Remove the length-only byte array read variant for parity with buffered ...

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -486,10 +486,6 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return read(sink, 0, sink.length);
   }
 
-  @Override public int read(byte[] sink, long byteCount) {
-    return read(sink, 0, byteCount);
-  }
-
   @Override public int read(byte[] sink, int offset, long byteCount) {
     checkOffsetAndCount(sink.length, offset, byteCount);
 

--- a/okio/src/main/java/okio/BufferedSource.java
+++ b/okio/src/main/java/okio/BufferedSource.java
@@ -88,12 +88,6 @@ public interface BufferedSource extends Source {
   int read(byte[] sink) throws IOException;
 
   /**
-   * Removes up to {@code byteCount} bytes from this and copies them into {@code sink}.
-   * Returns the number of bytes read, or -1 if this source is exhausted.
-   */
-  int read(byte[] sink, long byteCount) throws IOException;
-
-  /**
    * Removes up to {@code byteCount} bytes from this and copies them into {@code sink} at
    * {@code offset}. Returns the number of bytes read, or -1 if this source is exhausted.
    */

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -97,10 +97,6 @@ final class RealBufferedSource implements BufferedSource {
     return read(sink, 0, sink.length);
   }
 
-  @Override public int read(byte[] sink, long byteCount) throws IOException {
-    return read(sink, 0, byteCount);
-  }
-
   @Override public int read(byte[] sink, int offset, long byteCount) throws IOException {
     checkOffsetAndCount(sink.length, offset, byteCount);
 

--- a/okio/src/test/java/okio/RealBufferedSourceTest.java
+++ b/okio/src/test/java/okio/RealBufferedSourceTest.java
@@ -299,17 +299,6 @@ public final class RealBufferedSourceTest {
     assertByteArraysEquals(expected, sink);
   }
 
-  @Test public void readIntoByteArrayCount() throws IOException {
-    Buffer buffer = new Buffer().writeUtf8("abcd");
-    BufferedSource source = Okio.buffer((Source) buffer);
-
-    byte[] sink = new byte[5];
-    int read = source.read(sink, 3);
-    assertEquals(3, read);
-    byte[] expected = { 'a', 'b', 'c', 0, 0 };
-    assertByteArraysEquals(expected, sink);
-  }
-
   @Test public void readIntoByteArrayOffsetAndCount() throws IOException {
     Buffer buffer = new Buffer().writeUtf8("abcd");
     BufferedSource source = Okio.buffer((Source) buffer);


### PR DESCRIPTION
...sink's writes.
