### PR TITLE
Buffer should EOF if it cannot fulfill readFully.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -373,6 +373,10 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
   }
 
   @Override public void readFully(Buffer sink, long byteCount) throws IOException {
+    if (size() < byteCount) {
+      sink.write(this, size());
+      throw new EOFException();
+    }
     sink.write(this, byteCount);
   }
 

--- a/okio/src/test/java/okio/BufferTest.java
+++ b/okio/src/test/java/okio/BufferTest.java
@@ -17,6 +17,7 @@ package okio;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -885,6 +886,17 @@ public final class BufferTest {
     assertEquals("abc", buffer.readByteString(3).utf8());
     assertEquals("d", buffer.readUtf8(1));
     assertEquals(Segment.SIZE, buffer.size());
+  }
+
+  @Test public void readFullyTooShortThrows() throws IOException {
+    Buffer source = new Buffer().writeUtf8("Hi");
+    Buffer sink = new Buffer();
+    try {
+      source.readFully(sink, 5);
+      fail();
+    } catch (EOFException ignored) {
+    }
+    assertEquals("Hi", sink.readUtf8());
   }
 
   /**


### PR DESCRIPTION
Prior to this change an ArrayIndexOutOfBounds exception would be thrown in side the write call to which readFully delegates.
