### PR TITLE
Test Buffer and 'Real' versions of buffered wrappers together.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -364,41 +364,51 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return Util.reverseBytesLong(readLong());
   }
 
-  @Override public ByteString readByteString() throws IOException {
+  @Override public ByteString readByteString() {
     return new ByteString(readByteArray());
   }
 
-  @Override public ByteString readByteString(long byteCount) throws IOException {
+  @Override public ByteString readByteString(long byteCount) throws EOFException {
     return new ByteString(readByteArray(byteCount));
   }
 
-  @Override public void readFully(Buffer sink, long byteCount) throws IOException {
-    if (size() < byteCount) {
-      sink.write(this, size());
+  @Override public void readFully(Buffer sink, long byteCount) throws EOFException {
+    if (size < byteCount) {
+      sink.write(this, size); // Exhaust ourselves.
       throw new EOFException();
     }
     sink.write(this, byteCount);
   }
 
   @Override public long readAll(Sink sink) throws IOException {
-    long totalBytesWritten = size();
-    sink.write(this, totalBytesWritten);
-    return totalBytesWritten;
+    long byteCount = size;
+    if (byteCount > 0) {
+      sink.write(this, byteCount);
+    }
+    return byteCount;
   }
 
-  @Override public String readUtf8() throws IOException {
-    return readString(size, Util.UTF_8);
+  @Override public String readUtf8() {
+    try {
+      return readString(size, Util.UTF_8);
+    } catch (EOFException e) {
+      throw new AssertionError(e);
+    }
   }
 
-  @Override public String readUtf8(long byteCount) throws IOException {
+  @Override public String readUtf8(long byteCount) throws EOFException {
     return readString(byteCount, Util.UTF_8);
   }
 
-  @Override public String readString(Charset charset) throws IOException {
-    return readString(size, charset);
+  @Override public String readString(Charset charset) {
+    try {
+      return readString(size, charset);
+    } catch (EOFException e) {
+      throw new AssertionError(e);
+    }
   }
 
-  @Override public String readString(long byteCount, Charset charset) throws IOException {
+  @Override public String readString(long byteCount, Charset charset) throws EOFException {
     checkOffsetAndCount(size, 0, byteCount);
     if (charset == null) throw new IllegalArgumentException("charset == null");
     if (byteCount > Integer.MAX_VALUE) {
@@ -424,7 +434,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return result;
   }
 
-  @Override public String readUtf8Line() throws IOException {
+  @Override public String readUtf8Line() throws EOFException {
     long newline = indexOf((byte) '\n');
 
     if (newline == -1) {
@@ -434,13 +444,13 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return readUtf8Line(newline);
   }
 
-  @Override public String readUtf8LineStrict() throws IOException {
+  @Override public String readUtf8LineStrict() throws EOFException {
     long newline = indexOf((byte) '\n');
     if (newline == -1) throw new EOFException();
     return readUtf8Line(newline);
   }
 
-  String readUtf8Line(long newline) throws IOException {
+  String readUtf8Line(long newline) throws EOFException {
     if (newline > 0 && getByte(newline - 1) == '\r') {
       // Read everything until '\r\n', then skip the '\r\n'.
       String result = readUtf8((newline - 1));
@@ -455,11 +465,15 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     }
   }
 
-  @Override public byte[] readByteArray() throws IOException {
-    return readByteArray(size);
+  @Override public byte[] readByteArray() {
+    try {
+      return readByteArray(size);
+    } catch (EOFException e) {
+      throw new AssertionError(e);
+    }
   }
 
-  @Override public byte[] readByteArray(long byteCount) throws IOException {
+  @Override public byte[] readByteArray(long byteCount) throws EOFException {
     checkOffsetAndCount(this.size, 0, byteCount);
     if (byteCount > Integer.MAX_VALUE) {
       throw new IllegalArgumentException("byteCount > Integer.MAX_VALUE: " + byteCount);
@@ -474,7 +488,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return read(sink, 0, sink.length);
   }
 
-  @Override public void readFully(byte[] sink) throws IOException {
+  @Override public void readFully(byte[] sink) throws EOFException {
     int offset = 0;
     while (offset < sink.length) {
       int read = read(sink, offset, sink.length - offset);
@@ -507,16 +521,20 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
    * with a buffer will return its segments to the pool.
    */
   public void clear() {
-    skip(size);
+    try {
+      skip(size);
+    } catch (EOFException e) {
+      throw new AssertionError(e);
+    }
   }
 
   /** Discards {@code byteCount} bytes from the head of this buffer. */
-  @Override public void skip(long byteCount) {
-    checkOffsetAndCount(this.size, 0, byteCount);
-
-    this.size -= byteCount;
+  @Override public void skip(long byteCount) throws EOFException {
     while (byteCount > 0) {
+      if (head == null) throw new EOFException();
+
       int toSkip = (int) Math.min(byteCount, head.limit - head.pos);
+      size -= toSkip;
       byteCount -= toSkip;
       head.pos += toSkip;
 
@@ -861,12 +879,8 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     }
 
     if (size <= 16) {
-      try {
-        ByteString data = clone().readByteString(size);
-        return String.format("Buffer[size=%s data=%s]", size, data.hex());
-      } catch (IOException e) {
-        throw new AssertionError(e);
-      }
+      ByteString data = clone().readByteString();
+      return String.format("Buffer[size=%s data=%s]", size, data.hex());
     }
 
     try {

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -98,7 +98,18 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public void readFully(byte[] sink) throws IOException {
-    require(sink.length);
+    try {
+      require(sink.length);
+    } catch (EOFException e) {
+      // The underlying source is exhausted. Copy the bytes we got before rethrowing.
+      int offset = 0;
+      while (buffer.size > 0) {
+        int read = buffer.read(sink, offset, (int) buffer.size - offset);
+        if (read == -1) throw new AssertionError();
+        offset += read;
+      }
+      throw e;
+    }
     buffer.readFully(sink);
   }
 
@@ -115,7 +126,13 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public void readFully(Buffer sink, long byteCount) throws IOException {
-    require(byteCount);
+    try {
+      require(byteCount);
+    } catch (EOFException e) {
+      // The underlying source is exhausted. Copy the bytes we got before rethrowing.
+      sink.writeAll(buffer);
+      throw e;
+    }
     buffer.readFully(sink, byteCount);
   }
 

--- a/okio/src/test/java/okio/BufferTest.java
+++ b/okio/src/test/java/okio/BufferTest.java
@@ -17,17 +17,14 @@ package okio;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
-import static okio.TestUtil.assertByteArraysEquals;
 import static okio.TestUtil.repeat;
 import static okio.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
@@ -53,27 +50,6 @@ public final class BufferTest {
     }
   }
 
-  @Test public void readSpecificCharsetPartial() throws Exception {
-    Buffer buffer = new Buffer();
-    buffer.write(ByteString.decodeHex("0000007600000259000002c80000006c000000e40000007300000259"
-        + "000002cc000000720000006100000070000000740000025900000072"));
-    assertEquals("vəˈläsə", buffer.readString(7 * 4, Charset.forName("utf-32")));
-  }
-
-  @Test public void readSpecificCharset() throws Exception {
-    Buffer buffer = new Buffer();
-    buffer.write(ByteString.decodeHex("0000007600000259000002c80000006c000000e40000007300000259"
-        + "000002cc000000720000006100000070000000740000025900000072"));
-    assertEquals("vəˈläsəˌraptər", buffer.readString(Charset.forName("utf-32")));
-  }
-
-  @Test public void writeSpecificCharset() throws Exception {
-    Buffer buffer = new Buffer();
-    buffer.writeString("təˈranəˌsôr", Charset.forName("utf-32"));
-    assertEquals(ByteString.decodeHex("0000007400000259000002c800000072000000610000006e00000259"
-        + "000002cc00000073000000f400000072"), buffer.readByteString(buffer.size()));
-  }
-
   @Test public void completeSegmentByteCountOnEmptyBuffer() throws Exception {
     Buffer buffer = new Buffer();
     assertEquals(0, buffer.completeSegmentByteCount());
@@ -89,31 +65,6 @@ public final class BufferTest {
     Buffer buffer = new Buffer();
     buffer.writeUtf8(repeat('a', Segment.SIZE * 4 - 10));
     assertEquals(Segment.SIZE * 3, buffer.completeSegmentByteCount());
-  }
-
-  @Test public void readUtf8SpansSegments() throws Exception {
-    Buffer buffer = new Buffer();
-    buffer.writeUtf8(repeat('a', Segment.SIZE * 2));
-    buffer.readUtf8(Segment.SIZE - 1);
-    assertEquals("aa", buffer.readUtf8(2));
-  }
-
-  @Test public void readUtf8Segment() throws Exception {
-    Buffer buffer = new Buffer();
-    buffer.writeUtf8(repeat('a', Segment.SIZE));
-    assertEquals(repeat('a', Segment.SIZE), buffer.readUtf8(Segment.SIZE));
-  }
-
-  @Test public void readUtf8PartialBuffer() throws Exception {
-    Buffer buffer = new Buffer();
-    buffer.writeUtf8(repeat('a', Segment.SIZE + 20));
-    assertEquals(repeat('a', Segment.SIZE + 10), buffer.readUtf8(Segment.SIZE + 10));
-  }
-
-  @Test public void readUtf8EntireBuffer() throws Exception {
-    Buffer buffer = new Buffer();
-    buffer.writeUtf8(repeat('a', Segment.SIZE * 2));
-    assertEquals(repeat('a', Segment.SIZE * 2), buffer.readUtf8());
   }
 
   @Test public void toStringOnEmptyBuffer() throws Exception {
@@ -344,30 +295,6 @@ public final class BufferTest {
     assertEquals("hello, wor", out);
   }
 
-  @Test public void readExhaustedSource() throws Exception {
-    Buffer sink = new Buffer();
-    sink.writeUtf8(repeat('a', 10));
-
-    Buffer source = new Buffer();
-
-    assertEquals(-1, source.read(sink, 10));
-    assertEquals(10, sink.size());
-    assertEquals(0, source.size());
-  }
-
-  @Test public void readZeroBytesFromSource() throws Exception {
-    Buffer sink = new Buffer();
-    sink.writeUtf8(repeat('a', 10));
-
-    Buffer source = new Buffer();
-
-    // Either 0 or -1 is reasonable here. For consistency with Android's
-    // ByteArrayInputStream we return 0.
-    assertEquals(-1, source.read(sink, 0));
-    assertEquals(10, sink.size());
-    assertEquals(0, source.size());
-  }
-
   @Test public void moveAllRequestedBytesWithRead() throws Exception {
     Buffer sink = new Buffer();
     sink.writeUtf8(repeat('a', 10));
@@ -394,48 +321,6 @@ public final class BufferTest {
     assertEquals(repeat('a', 10) + repeat('b', 20), sink.readUtf8(30));
   }
 
-  @Test public void indexOf() throws Exception {
-    Buffer buffer = new Buffer();
-
-    // The segment is empty.
-    assertEquals(-1, buffer.indexOf((byte) 'a'));
-
-    // The segment has one value.
-    buffer.writeUtf8("a"); // a
-    assertEquals(0, buffer.indexOf((byte) 'a'));
-    assertEquals(-1, buffer.indexOf((byte) 'b'));
-
-    // The segment has lots of data.
-    buffer.writeUtf8(repeat('b', Segment.SIZE - 2)); // ab...b
-    assertEquals(0, buffer.indexOf((byte) 'a'));
-    assertEquals(1, buffer.indexOf((byte) 'b'));
-    assertEquals(-1, buffer.indexOf((byte) 'c'));
-
-    // The segment doesn't start at 0, it starts at 2.
-    buffer.readUtf8(2); // b...b
-    assertEquals(-1, buffer.indexOf((byte) 'a'));
-    assertEquals(0, buffer.indexOf((byte) 'b'));
-    assertEquals(-1, buffer.indexOf((byte) 'c'));
-
-    // The segment is full.
-    buffer.writeUtf8("c"); // b...bc
-    assertEquals(-1, buffer.indexOf((byte) 'a'));
-    assertEquals(0, buffer.indexOf((byte) 'b'));
-    assertEquals(Segment.SIZE - 3, buffer.indexOf((byte) 'c'));
-
-    // The segment doesn't start at 2, it starts at 4.
-    buffer.readUtf8(2); // b...bc
-    assertEquals(-1, buffer.indexOf((byte) 'a'));
-    assertEquals(0, buffer.indexOf((byte) 'b'));
-    assertEquals(Segment.SIZE - 5, buffer.indexOf((byte) 'c'));
-
-    // Two segments.
-    buffer.writeUtf8("d"); // b...bcd, d is in the 2nd segment.
-    assertEquals(asList(Segment.SIZE - 4, 1), buffer.segmentSizes());
-    assertEquals(Segment.SIZE - 4, buffer.indexOf((byte) 'd'));
-    assertEquals(-1, buffer.indexOf((byte) 'e'));
-  }
-
   @Test public void indexOfWithOffset() throws Exception {
     Buffer buffer = new Buffer();
     int halfSegment = Segment.SIZE / 2;
@@ -451,193 +336,6 @@ public final class BufferTest {
     assertEquals(halfSegment * 3, buffer.indexOf((byte) 'd', halfSegment * 2));
     assertEquals(halfSegment * 3, buffer.indexOf((byte) 'd', halfSegment * 3));
     assertEquals(halfSegment * 4 - 1, buffer.indexOf((byte) 'd', halfSegment * 4 - 1));
-  }
-
-  @Test public void writeBytes() throws Exception {
-    Buffer data = new Buffer();
-    data.writeByte(0xab);
-    data.writeByte(0xcd);
-    assertEquals("Buffer[size=2 data=abcd]", data.toString());
-  }
-
-  @Test public void writeLastByteInSegment() throws Exception {
-    Buffer data = new Buffer();
-    data.writeUtf8(repeat('a', Segment.SIZE - 1));
-    data.writeByte(0x20);
-    data.writeByte(0x21);
-    assertEquals(asList(Segment.SIZE, 1), data.segmentSizes());
-    assertEquals(repeat('a', Segment.SIZE - 1), data.readUtf8(Segment.SIZE - 1));
-    assertEquals("Buffer[size=2 data=2021]", data.toString());
-  }
-
-  @Test public void writeShort() throws Exception {
-    Buffer data = new Buffer();
-    data.writeShort(0xabcd);
-    data.writeShort(0x4321);
-    assertEquals("Buffer[size=4 data=abcd4321]", data.toString());
-  }
-
-  @Test public void writeShortLe() throws Exception {
-    Buffer data = new Buffer();
-    data.writeShortLe(0xabcd);
-    data.writeShortLe(0x4321);
-    assertEquals("Buffer[size=4 data=cdab2143]", data.toString());
-  }
-
-  @Test public void writeInt() throws Exception {
-    Buffer data = new Buffer();
-    data.writeInt(0xabcdef01);
-    data.writeInt(0x87654321);
-    assertEquals("Buffer[size=8 data=abcdef0187654321]", data.toString());
-  }
-
-  @Test public void writeLastIntegerInSegment() throws Exception {
-    Buffer data = new Buffer();
-    data.writeUtf8(repeat('a', Segment.SIZE - 4));
-    data.writeInt(0xabcdef01);
-    data.writeInt(0x87654321);
-    assertEquals(asList(Segment.SIZE, 4), data.segmentSizes());
-    assertEquals(repeat('a', Segment.SIZE - 4), data.readUtf8(Segment.SIZE - 4));
-    assertEquals("Buffer[size=8 data=abcdef0187654321]", data.toString());
-  }
-
-  @Test public void writeIntegerDoesntQuiteFitInSegment() throws Exception {
-    Buffer data = new Buffer();
-    data.writeUtf8(repeat('a', Segment.SIZE - 3));
-    data.writeInt(0xabcdef01);
-    data.writeInt(0x87654321);
-    assertEquals(asList(Segment.SIZE - 3, 8), data.segmentSizes());
-    assertEquals(repeat('a', Segment.SIZE - 3), data.readUtf8(Segment.SIZE - 3));
-    assertEquals("Buffer[size=8 data=abcdef0187654321]", data.toString());
-  }
-
-  @Test public void writeIntLe() throws Exception {
-    Buffer data = new Buffer();
-    data.writeIntLe(0xabcdef01);
-    data.writeIntLe(0x87654321);
-    assertEquals("Buffer[size=8 data=01efcdab21436587]", data.toString());
-  }
-
-  @Test public void writeLong() throws Exception {
-    Buffer data = new Buffer();
-    data.writeLong(0xabcdef0187654321L);
-    data.writeLong(0xcafebabeb0b15c00L);
-    assertEquals("Buffer[size=16 data=abcdef0187654321cafebabeb0b15c00]", data.toString());
-  }
-
-  @Test public void writeLongLe() throws Exception {
-    Buffer data = new Buffer();
-    data.writeLongLe(0xabcdef0187654321L);
-    data.writeLongLe(0xcafebabeb0b15c00L);
-    assertEquals("Buffer[size=16 data=2143658701efcdab005cb1b0bebafeca]", data.toString());
-  }
-
-  @Test public void readByte() throws Exception {
-    Buffer data = new Buffer();
-    data.write(new byte[] { (byte) 0xab, (byte) 0xcd });
-    assertEquals(0xab, data.readByte() & 0xff);
-    assertEquals(0xcd, data.readByte() & 0xff);
-    assertEquals(0, data.size());
-  }
-
-  @Test public void readShort() throws Exception {
-    Buffer data = new Buffer();
-    data.write(new byte[] {
-        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x01
-    });
-    assertEquals((short) 0xabcd, data.readShort());
-    assertEquals((short) 0xef01, data.readShort());
-    assertEquals(0, data.size());
-  }
-
-  @Test public void readShortLe() throws Exception {
-    Buffer data = new Buffer();
-    data.write(new byte[] {
-        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x10
-    });
-    assertEquals((short) 0xcdab, data.readShortLe());
-    assertEquals((short) 0x10ef, data.readShortLe());
-    assertEquals(0, data.size());
-  }
-
-  @Test public void readShortSplitAcrossMultipleSegments() throws Exception {
-    Buffer data = new Buffer();
-    data.writeUtf8(repeat('a', Segment.SIZE - 1));
-    data.write(new byte[] { (byte) 0xab, (byte) 0xcd });
-    data.readUtf8(Segment.SIZE - 1);
-    assertEquals((short) 0xabcd, data.readShort());
-    assertEquals(0, data.size());
-  }
-
-  @Test public void readInt() throws Exception {
-    Buffer data = new Buffer();
-    data.write(new byte[] {
-        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x01,
-        (byte) 0x87, (byte) 0x65, (byte) 0x43, (byte) 0x21
-    });
-    assertEquals(0xabcdef01, data.readInt());
-    assertEquals(0x87654321, data.readInt());
-    assertEquals(0, data.size());
-  }
-
-  @Test public void readIntLe() throws Exception {
-    Buffer data = new Buffer();
-    data.write(new byte[] {
-        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x10,
-        (byte) 0x87, (byte) 0x65, (byte) 0x43, (byte) 0x21
-    });
-    assertEquals(0x10efcdab, data.readIntLe());
-    assertEquals(0x21436587, data.readIntLe());
-    assertEquals(0, data.size());
-  }
-
-  @Test public void readIntSplitAcrossMultipleSegments() throws Exception {
-    Buffer data = new Buffer();
-    data.writeUtf8(repeat('a', Segment.SIZE - 3));
-    data.write(new byte[] {
-        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x01
-    });
-    data.readUtf8(Segment.SIZE - 3);
-    assertEquals(0xabcdef01, data.readInt());
-    assertEquals(0, data.size());
-  }
-
-  @Test public void readLong() throws Exception {
-    Buffer data = new Buffer();
-    data.write(new byte[] {
-        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x10,
-        (byte) 0x87, (byte) 0x65, (byte) 0x43, (byte) 0x21,
-        (byte) 0x36, (byte) 0x47, (byte) 0x58, (byte) 0x69,
-        (byte) 0x12, (byte) 0x23, (byte) 0x34, (byte) 0x45
-    });
-    assertEquals(0xabcdef1087654321L, data.readLong());
-    assertEquals(0x3647586912233445L, data.readLong());
-    assertEquals(0, data.size());
-  }
-
-  @Test public void readLongLe() throws Exception {
-    Buffer data = new Buffer();
-    data.write(new byte[] {
-        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x10,
-        (byte) 0x87, (byte) 0x65, (byte) 0x43, (byte) 0x21,
-        (byte) 0x36, (byte) 0x47, (byte) 0x58, (byte) 0x69,
-        (byte) 0x12, (byte) 0x23, (byte) 0x34, (byte) 0x45
-    });
-    assertEquals(0x2143658710efcdabL, data.readLongLe());
-    assertEquals(0x4534231269584736L, data.readLongLe());
-    assertEquals(0, data.size());
-  }
-
-  @Test public void readLongSplitAcrossMultipleSegments() throws Exception {
-    Buffer data = new Buffer();
-    data.writeUtf8(repeat('a', Segment.SIZE - 7));
-    data.write(new byte[] {
-        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x01,
-        (byte) 0x87, (byte) 0x65, (byte) 0x43, (byte) 0x21,
-    });
-    data.readUtf8(Segment.SIZE - 7);
-    assertEquals(0xabcdef0187654321L, data.readLong());
-    assertEquals(0, data.size());
   }
 
   @Test public void byteAt() throws Exception {
@@ -659,19 +357,6 @@ public final class BufferTest {
       fail();
     } catch (IndexOutOfBoundsException expected) {
     }
-  }
-
-  @Test public void skip() throws Exception {
-    Buffer buffer = new Buffer();
-    buffer.writeUtf8("a");
-    buffer.writeUtf8(repeat('b', Segment.SIZE));
-    buffer.writeUtf8("c");
-    buffer.skip(1);
-    assertEquals('b', buffer.readByte() & 0xff);
-    buffer.skip(Segment.SIZE - 2);
-    assertEquals('b', buffer.readByte() & 0xff);
-    buffer.skip(1);
-    assertEquals(0, buffer.size());
   }
 
   @Test public void testWritePrefixToEmptyBuffer() throws IOException {
@@ -798,22 +483,6 @@ public final class BufferTest {
     assertEquals("[-7, -7, -7, -7]", Arrays.toString(byteArray));
   }
 
-  @Test public void readAll() throws Exception {
-    Buffer source = new Buffer().writeUtf8("abcdef");
-    Buffer sink = new Buffer();
-
-    assertEquals(6, source.readAll(sink));
-    assertEquals(0, source.size());
-    assertEquals("abcdef", sink.readUtf8(6));
-  }
-
-  @Test public void readAllExhausted() throws Exception {
-    Buffer source = new Buffer();
-    Buffer sink = new Buffer();
-    assertEquals(0, source.readAll(sink));
-    assertEquals(0, source.size());
-  }
-
   /**
    * When writing data that's already buffered, there's no reason to page the
    * data by segment.
@@ -836,22 +505,6 @@ public final class BufferTest {
     mockSink.assertLog("write(" + write1 + ", " + write1.size() + ")");
   }
 
-  @Test public void writeAll() throws Exception {
-    Buffer source = new Buffer().writeUtf8("abcdef");
-    Buffer sink = new Buffer();
-
-    assertEquals(6, sink.writeAll(source));
-    assertEquals(0, source.size());
-    assertEquals("abcdef", sink.readUtf8(6));
-  }
-
-  @Test public void writeAllExhausted() throws Exception {
-    Buffer source = new Buffer();
-    Buffer sink = new Buffer();
-    assertEquals(0, sink.writeAll(source));
-    assertEquals(0, source.size());
-  }
-
   @Test public void writeAllMultipleSegments() throws Exception {
     Buffer source = new Buffer().writeUtf8(TestUtil.repeat('a', Segment.SIZE * 3));
     Buffer sink = new Buffer();
@@ -861,67 +514,11 @@ public final class BufferTest {
     assertEquals(TestUtil.repeat('a', Segment.SIZE * 3), sink.readUtf8(sink.size()));
   }
 
-  @Test public void readByteArray() throws IOException {
-    String string = "abcd" + repeat('e', Segment.SIZE);
-    Buffer buffer = new Buffer().writeUtf8(string);
-    assertByteArraysEquals(string.getBytes(UTF_8), buffer.readByteArray());
-    assertEquals(0, buffer.size());
-  }
-
-  @Test public void readByteArrayPartial() throws IOException {
-    Buffer buffer = new Buffer().writeUtf8("abcd");
-    assertEquals("[97, 98, 99]", Arrays.toString(buffer.readByteArray(3)));
-    assertEquals("d", buffer.readUtf8(1));
-    assertEquals(0, buffer.size());
-  }
-
-  @Test public void readByteString() throws IOException {
-    Buffer buffer = new Buffer().writeUtf8("abcd").writeUtf8(repeat('e', Segment.SIZE));
-    assertEquals("abcd" + repeat('e', Segment.SIZE), buffer.readByteString().utf8());
-    assertEquals(0, buffer.size());
-  }
-
-  @Test public void readByteStringPartial() throws IOException {
-    Buffer buffer = new Buffer().writeUtf8("abcd").writeUtf8(repeat('e', Segment.SIZE));
-    assertEquals("abc", buffer.readByteString(3).utf8());
-    assertEquals("d", buffer.readUtf8(1));
-    assertEquals(Segment.SIZE, buffer.size());
-  }
-
-  @Test public void readFullyTooShortThrows() throws IOException {
-    Buffer source = new Buffer().writeUtf8("Hi");
-    Buffer sink = new Buffer();
-    try {
-      source.readFully(sink, 5);
-      fail();
-    } catch (EOFException ignored) {
-    }
-    assertEquals("Hi", sink.readUtf8());
-  }
-
-  @Test public void readFullyByteArray() throws IOException {
-    Buffer source = new Buffer().writeUtf8("Hello").writeUtf8(repeat('e', Segment.SIZE));
-    byte[] expected = source.clone().readByteArray();
-    byte[] sink = new byte[Segment.SIZE + 5];
-    source.readFully(sink);
-    assertByteArraysEquals(expected, sink);
-  }
-
-  @Test public void readFullyByteArrayTooShortThrows() throws IOException {
-    Buffer source = new Buffer().writeUtf8("Hello");
-    byte[] sink = new byte[6];
-    try {
-      source.readFully(sink);
-      fail();
-    } catch (EOFException ignored) {
-    }
-  }
-
   /**
    * Returns a new buffer containing the data in {@code data}, and a segment
    * layout determined by {@code dice}.
    */
-  private Buffer bufferWithRandomSegmentLayout(Random dice, byte[] data) {
+  private Buffer bufferWithRandomSegmentLayout(Random dice, byte[] data) throws IOException {
     Buffer result = new Buffer();
 
     // Writing to result directly will yield packed segments. Instead, write to

--- a/okio/src/test/java/okio/BufferedSinkTest.java
+++ b/okio/src/test/java/okio/BufferedSinkTest.java
@@ -1,0 +1,170 @@
+package okio;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static java.util.Arrays.asList;
+import static okio.TestUtil.repeat;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class BufferedSinkTest {
+  private interface Factory {
+    BufferedSink create(Buffer data);
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static List<Object[]> parameters() {
+    return Arrays.asList(new Object[] {
+        new Factory() {
+          @Override public BufferedSink create(Buffer data) {
+            return data;
+          }
+
+          @Override public String toString() {
+            return "Buffer";
+          }
+        }
+    }, new Object[] {
+        new Factory() {
+          @Override public BufferedSink create(Buffer data) {
+            return new RealBufferedSink(data);
+          }
+
+          @Override public String toString() {
+            return "RealBufferedSink";
+          }
+        }
+    });
+  }
+
+  @Parameterized.Parameter
+  public Factory factory;
+
+  private Buffer data;
+  private BufferedSink sink;
+
+  @Before public void setUp() {
+    data = new Buffer();
+    sink = factory.create(data);
+  }
+
+  @Test public void writeNothing() throws IOException {
+    sink.writeUtf8("");
+    sink.flush();
+    assertEquals(0, data.size());
+  }
+
+  @Test public void writeBytes() throws Exception {
+    sink.writeByte(0xab);
+    sink.writeByte(0xcd);
+    sink.flush();
+    assertEquals("Buffer[size=2 data=abcd]", data.toString());
+  }
+
+  @Test public void writeLastByteInSegment() throws Exception {
+    sink.writeUtf8(repeat('a', Segment.SIZE - 1));
+    sink.writeByte(0x20);
+    sink.writeByte(0x21);
+    sink.flush();
+    assertEquals(asList(Segment.SIZE, 1), data.segmentSizes());
+    assertEquals(repeat('a', Segment.SIZE - 1), data.readUtf8(Segment.SIZE - 1));
+    assertEquals("Buffer[size=2 data=2021]", data.toString());
+  }
+
+  @Test public void writeShort() throws Exception {
+    sink.writeShort(0xabcd);
+    sink.writeShort(0x4321);
+    sink.flush();
+    assertEquals("Buffer[size=4 data=abcd4321]", data.toString());
+  }
+
+  @Test public void writeShortLe() throws Exception {
+    sink.writeShortLe(0xabcd);
+    sink.writeShortLe(0x4321);
+    sink.flush();
+    assertEquals("Buffer[size=4 data=cdab2143]", data.toString());
+  }
+
+  @Test public void writeInt() throws Exception {
+    sink.writeInt(0xabcdef01);
+    sink.writeInt(0x87654321);
+    sink.flush();
+    assertEquals("Buffer[size=8 data=abcdef0187654321]", data.toString());
+  }
+
+  @Test public void writeLastIntegerInSegment() throws Exception {
+    sink.writeUtf8(repeat('a', Segment.SIZE - 4));
+    sink.writeInt(0xabcdef01);
+    sink.writeInt(0x87654321);
+    sink.flush();
+    assertEquals(asList(Segment.SIZE, 4), data.segmentSizes());
+    assertEquals(repeat('a', Segment.SIZE - 4), data.readUtf8(Segment.SIZE - 4));
+    assertEquals("Buffer[size=8 data=abcdef0187654321]", data.toString());
+  }
+
+  @Test public void writeIntegerDoesNotQuiteFitInSegment() throws Exception {
+    sink.writeUtf8(repeat('a', Segment.SIZE - 3));
+    sink.writeInt(0xabcdef01);
+    sink.writeInt(0x87654321);
+    sink.flush();
+    assertEquals(asList(Segment.SIZE - 3, 8), data.segmentSizes());
+    assertEquals(repeat('a', Segment.SIZE - 3), data.readUtf8(Segment.SIZE - 3));
+    assertEquals("Buffer[size=8 data=abcdef0187654321]", data.toString());
+  }
+
+  @Test public void writeIntLe() throws Exception {
+    sink.writeIntLe(0xabcdef01);
+    sink.writeIntLe(0x87654321);
+    sink.flush();
+    assertEquals("Buffer[size=8 data=01efcdab21436587]", data.toString());
+  }
+
+  @Test public void writeLong() throws Exception {
+    sink.writeLong(0xabcdef0187654321L);
+    sink.writeLong(0xcafebabeb0b15c00L);
+    sink.flush();
+    assertEquals("Buffer[size=16 data=abcdef0187654321cafebabeb0b15c00]", data.toString());
+  }
+
+  @Test public void writeLongLe() throws Exception {
+    sink.writeLongLe(0xabcdef0187654321L);
+    sink.writeLongLe(0xcafebabeb0b15c00L);
+    sink.flush();
+    assertEquals("Buffer[size=16 data=2143658701efcdab005cb1b0bebafeca]", data.toString());
+  }
+
+  @Test public void writeSpecificCharset() throws Exception {
+    sink.writeString("təˈranəˌsôr", Charset.forName("utf-32"));
+    sink.flush();
+    assertEquals(ByteString.decodeHex("0000007400000259000002c800000072000000610000006e00000259"
+        + "000002cc00000073000000f400000072"), data.readByteString());
+  }
+
+  @Test public void writeAll() throws Exception {
+    Buffer source = new Buffer().writeUtf8("abcdef");
+
+    assertEquals(6, sink.writeAll(source));
+    assertEquals(0, source.size());
+    sink.flush();
+    assertEquals("abcdef", data.readUtf8());
+  }
+
+  @Test public void writeAllExhausted() throws Exception {
+    Buffer source = new Buffer();
+    assertEquals(0, sink.writeAll(source));
+    assertEquals(0, source.size());
+  }
+
+  @Test public void closeEmitsBufferedBytes() throws IOException {
+    sink.writeByte('a');
+    sink.close();
+    assertEquals('a', data.readByte());
+  }
+}

--- a/okio/src/test/java/okio/BufferedSourceTest.java
+++ b/okio/src/test/java/okio/BufferedSourceTest.java
@@ -1,0 +1,377 @@
+package okio;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static okio.TestUtil.assertByteArraysEquals;
+import static okio.TestUtil.repeat;
+import static okio.Util.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class BufferedSourceTest {
+  private interface Factory {
+    BufferedSource create(Buffer data);
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static List<Object[]> parameters() {
+    return Arrays.asList(
+        new Object[] { new Factory() {
+          @Override public BufferedSource create(Buffer data) {
+            return data;
+          }
+
+          @Override public String toString() {
+            return "Buffer";
+          }
+        }},
+        new Object[] { new Factory() {
+          @Override public BufferedSource create(Buffer data) {
+            return new RealBufferedSource(data);
+          }
+
+          @Override public String toString() {
+            return "RealBufferedSource";
+          }
+        }}
+    );
+  }
+
+  @Parameterized.Parameter
+  public Factory factory;
+
+  private Buffer data;
+  private BufferedSource source;
+
+  @Before public void setUp() {
+    data = new Buffer();
+    source = factory.create(data);
+  }
+
+  @Test public void readBytes() throws Exception {
+    data.write(new byte[] { (byte) 0xab, (byte) 0xcd });
+    assertEquals(0xab, source.readByte() & 0xff);
+    assertEquals(0xcd, source.readByte() & 0xff);
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readShort() throws Exception {
+    data.write(new byte[] {
+        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x01
+    });
+    assertEquals((short) 0xabcd, source.readShort());
+    assertEquals((short) 0xef01, source.readShort());
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readShortLe() throws Exception {
+    data.write(new byte[] {
+        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x10
+    });
+    assertEquals((short) 0xcdab, source.readShortLe());
+    assertEquals((short) 0x10ef, source.readShortLe());
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readShortSplitAcrossMultipleSegments() throws Exception {
+    data.writeUtf8(repeat('a', Segment.SIZE - 1));
+    data.write(new byte[] { (byte) 0xab, (byte) 0xcd });
+    source.skip(Segment.SIZE - 1);
+    assertEquals((short) 0xabcd, source.readShort());
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readInt() throws Exception {
+    data.write(new byte[] {
+        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x01, (byte) 0x87, (byte) 0x65, (byte) 0x43,
+        (byte) 0x21
+    });
+    assertEquals(0xabcdef01, source.readInt());
+    assertEquals(0x87654321, source.readInt());
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readIntLe() throws Exception {
+    data.write(new byte[] {
+        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x10, (byte) 0x87, (byte) 0x65, (byte) 0x43,
+        (byte) 0x21
+    });
+    assertEquals(0x10efcdab, source.readIntLe());
+    assertEquals(0x21436587, source.readIntLe());
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readIntSplitAcrossMultipleSegments() throws Exception {
+    data.writeUtf8(repeat('a', Segment.SIZE - 3));
+    data.write(new byte[] {
+        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x01
+    });
+    source.skip(Segment.SIZE - 3);
+    assertEquals(0xabcdef01, source.readInt());
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readLong() throws Exception {
+    data.write(new byte[] {
+        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x10, (byte) 0x87, (byte) 0x65, (byte) 0x43,
+        (byte) 0x21, (byte) 0x36, (byte) 0x47, (byte) 0x58, (byte) 0x69, (byte) 0x12, (byte) 0x23,
+        (byte) 0x34, (byte) 0x45
+    });
+    assertEquals(0xabcdef1087654321L, source.readLong());
+    assertEquals(0x3647586912233445L, source.readLong());
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readLongLe() throws Exception {
+    data.write(new byte[] {
+        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x10, (byte) 0x87, (byte) 0x65, (byte) 0x43,
+        (byte) 0x21, (byte) 0x36, (byte) 0x47, (byte) 0x58, (byte) 0x69, (byte) 0x12, (byte) 0x23,
+        (byte) 0x34, (byte) 0x45
+    });
+    assertEquals(0x2143658710efcdabL, source.readLongLe());
+    assertEquals(0x4534231269584736L, source.readLongLe());
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readLongSplitAcrossMultipleSegments() throws Exception {
+    data.writeUtf8(repeat('a', Segment.SIZE - 7));
+    data.write(new byte[] {
+        (byte) 0xab, (byte) 0xcd, (byte) 0xef, (byte) 0x01, (byte) 0x87, (byte) 0x65, (byte) 0x43,
+        (byte) 0x21,
+    });
+    source.skip(Segment.SIZE - 7);
+    assertEquals(0xabcdef0187654321L, source.readLong());
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readAll() throws IOException {
+    source.buffer().writeUtf8("abc");
+    data.writeUtf8("def");
+
+    Buffer sink = new Buffer();
+    assertEquals(6, source.readAll(sink));
+    assertEquals("abcdef", sink.readUtf8());
+    assertTrue(data.exhausted());
+    assertTrue(source.exhausted());
+  }
+
+  @Test public void readAllExhausted() throws IOException {
+    MockSink mockSink = new MockSink();
+    assertEquals(0, source.readAll(mockSink));
+    assertTrue(data.exhausted());
+    assertTrue(source.exhausted());
+    mockSink.assertLog();
+  }
+
+  @Test public void readExhaustedSource() throws Exception {
+    Buffer sink = new Buffer();
+    sink.writeUtf8(repeat('a', 10));
+    assertEquals(-1, source.read(sink, 10));
+    assertEquals(10, sink.size());
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readZeroBytesFromSource() throws Exception {
+    Buffer sink = new Buffer();
+    sink.writeUtf8(repeat('a', 10));
+
+    // Either 0 or -1 is reasonable here. For consistency with Android's
+    // ByteArrayInputStream we return 0.
+    assertEquals(-1, source.read(sink, 0));
+    assertEquals(10, sink.size());
+    assertEquals(0, data.size());
+  }
+
+  @Test public void readFullyTooShortThrows() throws IOException {
+    data.writeUtf8("Hi");
+    Buffer sink = new Buffer();
+    try {
+      source.readFully(sink, 5);
+      fail();
+    } catch (EOFException ignored) {
+    }
+
+    // Verify we read all that we could from the source.
+    assertEquals("Hi", sink.readUtf8());
+  }
+
+  @Test public void readFullyByteArray() throws IOException {
+    data.writeUtf8("Hello").writeUtf8(repeat('e', Segment.SIZE));
+    byte[] expected = data.clone().readByteArray();
+
+    byte[] sink = new byte[Segment.SIZE + 5];
+    source.readFully(sink);
+    assertByteArraysEquals(expected, sink);
+  }
+
+  @Test public void readFullyByteArrayTooShortThrows() throws IOException {
+    data.writeUtf8("Hello");
+
+    byte[] sink = new byte[6];
+    try {
+      source.readFully(sink);
+      fail();
+    } catch (EOFException ignored) {
+    }
+
+    // Verify we read all that we could from the source.
+    assertByteArraysEquals(new byte[] { 'H', 'e', 'l', 'l', 'o', 0 }, sink);
+  }
+
+  @Test public void readIntoByteArray() throws IOException {
+    data.writeUtf8("abcd");
+
+    byte[] sink = new byte[3];
+    int read = source.read(sink);
+    assertEquals(3, read);
+    byte[] expected = { 'a', 'b', 'c' };
+    assertByteArraysEquals(expected, sink);
+  }
+
+  @Test public void readIntoByteArrayNotEnough() throws IOException {
+    data.writeUtf8("abcd");
+
+    byte[] sink = new byte[5];
+    int read = source.read(sink);
+    assertEquals(4, read);
+    byte[] expected = { 'a', 'b', 'c', 'd', 0 };
+    assertByteArraysEquals(expected, sink);
+  }
+
+  @Test public void readIntoByteArrayOffsetAndCount() throws IOException {
+    data.writeUtf8("abcd");
+
+    byte[] sink = new byte[7];
+    int read = source.read(sink, 2, 3);
+    assertEquals(3, read);
+    byte[] expected = { 0, 0, 'a', 'b', 'c', 0, 0 };
+    assertByteArraysEquals(expected, sink);
+  }
+
+  @Test public void readByteArray() throws IOException {
+    String string = "abcd" + repeat('e', Segment.SIZE);
+    data.writeUtf8(string);
+    assertByteArraysEquals(string.getBytes(UTF_8), source.readByteArray());
+  }
+
+  @Test public void readByteArrayPartial() throws IOException {
+    data.writeUtf8("abcd");
+    assertEquals("[97, 98, 99]", Arrays.toString(source.readByteArray(3)));
+    assertEquals("d", source.readUtf8(1));
+  }
+
+  @Test public void readByteString() throws IOException {
+    data.writeUtf8("abcd").writeUtf8(repeat('e', Segment.SIZE));
+    assertEquals("abcd" + repeat('e', Segment.SIZE), source.readByteString().utf8());
+  }
+
+  @Test public void readByteStringPartial() throws IOException {
+    data.writeUtf8("abcd").writeUtf8(repeat('e', Segment.SIZE));
+    assertEquals("abc", source.readByteString(3).utf8());
+    assertEquals("d", source.readUtf8(1));
+  }
+
+  @Test public void readSpecificCharsetPartial() throws Exception {
+    data.write(ByteString.decodeHex("0000007600000259000002c80000006c000000e40000007300000259"
+        + "000002cc000000720000006100000070000000740000025900000072"));
+    assertEquals("vəˈläsə", source.readString(7 * 4, Charset.forName("utf-32")));
+  }
+
+  @Test public void readSpecificCharset() throws Exception {
+    data.write(ByteString.decodeHex("0000007600000259000002c80000006c000000e40000007300000259"
+        + "000002cc000000720000006100000070000000740000025900000072"));
+    assertEquals("vəˈläsəˌraptər", source.readString(Charset.forName("utf-32")));
+  }
+
+  @Test public void readUtf8SpansSegments() throws Exception {
+    data.writeUtf8(repeat('a', Segment.SIZE * 2));
+    source.skip(Segment.SIZE - 1);
+    assertEquals("aa", source.readUtf8(2));
+  }
+
+  @Test public void readUtf8Segment() throws Exception {
+    data.writeUtf8(repeat('a', Segment.SIZE));
+    assertEquals(repeat('a', Segment.SIZE), source.readUtf8(Segment.SIZE));
+  }
+
+  @Test public void readUtf8PartialBuffer() throws Exception {
+    data.writeUtf8(repeat('a', Segment.SIZE + 20));
+    assertEquals(repeat('a', Segment.SIZE + 10), source.readUtf8(Segment.SIZE + 10));
+  }
+
+  @Test public void readUtf8EntireBuffer() throws Exception {
+    data.writeUtf8(repeat('a', Segment.SIZE * 2));
+    assertEquals(repeat('a', Segment.SIZE * 2), source.readUtf8());
+  }
+
+  @Test public void skip() throws Exception {
+    data.writeUtf8("a");
+    data.writeUtf8(repeat('b', Segment.SIZE));
+    data.writeUtf8("c");
+    source.skip(1);
+    assertEquals('b', source.readByte() & 0xff);
+    source.skip(Segment.SIZE - 2);
+    assertEquals('b', source.readByte() & 0xff);
+    source.skip(1);
+    assertTrue(source.exhausted());
+  }
+
+  @Test public void skipInsufficientData() throws Exception {
+    data.writeUtf8("a");
+
+    try {
+      source.skip(2);
+      fail();
+    } catch (EOFException ignored) {
+    }
+  }
+
+  @Test public void indexOf() throws Exception {
+    // The segment is empty.
+    assertEquals(-1, source.indexOf((byte) 'a'));
+
+    // The segment has one value.
+    data.writeUtf8("a"); // a
+    assertEquals(0, source.indexOf((byte) 'a'));
+    assertEquals(-1, source.indexOf((byte) 'b'));
+
+    // The segment has lots of data.
+    data.writeUtf8(repeat('b', Segment.SIZE - 2)); // ab...b
+    assertEquals(0, source.indexOf((byte) 'a'));
+    assertEquals(1, source.indexOf((byte) 'b'));
+    assertEquals(-1, source.indexOf((byte) 'c'));
+
+    // The segment doesn't start at 0, it starts at 2.
+    source.skip(2); // b...b
+    assertEquals(-1, source.indexOf((byte) 'a'));
+    assertEquals(0, source.indexOf((byte) 'b'));
+    assertEquals(-1, source.indexOf((byte) 'c'));
+
+    // The segment is full.
+    data.writeUtf8("c"); // b...bc
+    assertEquals(-1, source.indexOf((byte) 'a'));
+    assertEquals(0, source.indexOf((byte) 'b'));
+    assertEquals(Segment.SIZE - 3, source.indexOf((byte) 'c'));
+
+    // The segment doesn't start at 2, it starts at 4.
+    source.skip(2); // b...bc
+    assertEquals(-1, source.indexOf((byte) 'a'));
+    assertEquals(0, source.indexOf((byte) 'b'));
+    assertEquals(Segment.SIZE - 5, source.indexOf((byte) 'c'));
+
+    // Two segments.
+    data.writeUtf8("d"); // b...bcd, d is in the 2nd segment.
+    assertEquals(Segment.SIZE - 4, source.indexOf((byte) 'd'));
+    assertEquals(-1, source.indexOf((byte) 'e'));
+  }
+}

--- a/okio/src/test/java/okio/RealBufferedSinkTest.java
+++ b/okio/src/test/java/okio/RealBufferedSinkTest.java
@@ -55,13 +55,6 @@ public final class RealBufferedSinkTest {
     assertEquals(0, bufferedSink.buffer().size());
   }
 
-  @Test public void bufferedSinkEmitZero() throws IOException {
-    Buffer sink = new Buffer();
-    BufferedSink bufferedSink = new RealBufferedSink(sink);
-    bufferedSink.writeUtf8("");
-    assertEquals(0, sink.size());
-  }
-
   @Test public void bufferedSinkEmitMultipleSegments() throws IOException {
     Buffer sink = new Buffer();
     BufferedSink bufferedSink = new RealBufferedSink(sink);
@@ -107,14 +100,6 @@ public final class RealBufferedSinkTest {
     BufferedSink bufferedSink = new RealBufferedSink(sink);
     bufferedSink.writeUtf8(repeat('a', Segment.SIZE * 3 - 1));
     assertEquals(Segment.SIZE * 2, sink.size());
-  }
-
-  @Test public void closeEmitsBufferedBytes() throws IOException {
-    Buffer sink = new Buffer();
-    BufferedSink bufferedSink = new RealBufferedSink(sink);
-    bufferedSink.writeByte('a');
-    bufferedSink.close();
-    assertEquals('a', sink.readByte());
   }
 
   @Test public void closeWithExceptionWhenWriting() throws IOException {


### PR DESCRIPTION
This ensures that the behavior (and the semantics of that behavior) of Buffer vs. RealBufferedSource or RealBufferedSink are the same.
