### PR TITLE
Do not re-buffer sources and sinks.

### DIFF
--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -43,20 +43,28 @@ public final class Okio {
    * Returns a new source that buffers reads from {@code source}. The returned
    * source will perform bulk reads into its in-memory buffer. Use this wherever
    * you read a source to get an ergonomic and efficient access to data.
+   * <p>
+   * Note: This method will not re-buffer a {@link BufferedSource} instance.
    */
   public static BufferedSource buffer(Source source) {
     if (source == null) throw new IllegalArgumentException("source == null");
-    return new RealBufferedSource(source);
+    return source instanceof BufferedSource
+        ? (BufferedSource) source
+        : new RealBufferedSource(source);
   }
 
   /**
    * Returns a new sink that buffers writes to {@code sink}. The returned sink
    * will batch writes to {@code sink}. Use this wherever you write to a sink to
    * get an ergonomic and efficient access to data.
+   * <p>
+   * Note: This method will not re-buffer a {@link BufferedSink} instance.
    */
   public static BufferedSink buffer(Sink sink) {
     if (sink == null) throw new IllegalArgumentException("sink == null");
-    return new RealBufferedSink(sink);
+    return sink instanceof BufferedSink
+        ? (BufferedSink) sink
+        : new RealBufferedSink(sink);
   }
 
   /** Returns a sink that writes to {@code out}. */

--- a/okio/src/test/java/okio/OkioTest.java
+++ b/okio/src/test/java/okio/OkioTest.java
@@ -28,11 +28,24 @@ import org.junit.rules.TemporaryFolder;
 import static okio.TestUtil.repeat;
 import static okio.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class OkioTest {
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test public void doNotBufferBufferedSource() {
+    Source in = new Buffer();
+    BufferedSource out = Okio.buffer(in);
+    assertSame(in, out);
+  }
+
+  @Test public void doNotBufferBufferedSink() {
+    Sink in = new Buffer();
+    BufferedSink out = Okio.buffer(in);
+    assertSame(in, out);
+  }
 
   @Test public void readWriteFile() throws Exception {
     File file = temporaryFolder.newFile();

--- a/okio/src/test/java/okio/RealBufferedSourceTest.java
+++ b/okio/src/test/java/okio/RealBufferedSourceTest.java
@@ -197,13 +197,14 @@ public final class RealBufferedSourceTest {
     Buffer write2 = new Buffer().writeUtf8(TestUtil.repeat('b', Segment.SIZE));
     Buffer write3 = new Buffer().writeUtf8(TestUtil.repeat('c', Segment.SIZE));
 
-    Buffer source = new Buffer().writeUtf8(""
+    Buffer sourceBuffer = new Buffer().writeUtf8(""
         + TestUtil.repeat('a', Segment.SIZE)
         + TestUtil.repeat('b', Segment.SIZE)
         + TestUtil.repeat('c', Segment.SIZE));
+    Source source = new ForwardingSource(sourceBuffer) {};
+    BufferedSource bufferedSource = Okio.buffer(source);
 
     MockSink mockSink = new MockSink();
-    BufferedSource bufferedSource = Okio.buffer((Source) source);
     assertEquals(Segment.SIZE * 3, bufferedSource.readAll(mockSink));
     mockSink.assertLog(
         "write(" + write1 + ", " + write1.size() + ")",


### PR DESCRIPTION
We talked about this a few weeks ago. This should probably come as a v1.1 since while not technically an API change or improvement, it's a semantic change that would be surprising for a dot release.
