### PR TITLE
Stabilize test so it passes on Android too

### DIFF
--- a/okio/src/test/java/okio/BufferedSinkTest.java
+++ b/okio/src/test/java/okio/BufferedSinkTest.java
@@ -141,7 +141,7 @@ public class BufferedSinkTest {
   }
 
   @Test public void writeSpecificCharset() throws Exception {
-    sink.writeString("təˈranəˌsôr", Charset.forName("utf-32"));
+    sink.writeString("təˈranəˌsôr", Charset.forName("utf-32be"));
     sink.flush();
     assertEquals(ByteString.decodeHex("0000007400000259000002c800000072000000610000006e00000259"
         + "000002cc00000073000000f400000072"), data.readByteString());


### PR DESCRIPTION
Android treats "utf-32" as ambiguous with respect to
ordering and so outputs a BOM. utf-32be / utf-32le do
not. Specifying the byte-ordering stabilizes the test
and makes it pass on Android.

Context:

The RI I looked at does not output the BOM for "utf-32".

As comparison: For both, "utf-16" outputs a BOM, and does
not for "utf-16le" / "utf-16be". This is documented. This
inconsistency between "utf-32" and "utf-16" on the RI
suggests the lack of a BOM with is a "feature" of the RI.

When le/be is not specified it is worth noting that Android
and the RI I tried used different ordering, though I did
not check whether the ordering was stable on different
platforms.
