### PR TITLE
Make tests pass on Android and other platforms

### DIFF
--- a/okio/src/test/java/okio/SocketTimeoutTest.java
+++ b/okio/src/test/java/okio/SocketTimeoutTest.java
@@ -29,6 +29,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class SocketTimeoutTest {
+
+  // The size of the socket buffers to use. Less than half the data transferred during tests to
+  // ensure send and receive buffers are flooded and any necessary blocking behavior takes place.
+  private static final int SOCKET_BUFFER_SIZE = 256 * 1024;
   private static final int ONE_MB = 1024 * 1024;
 
   @Test public void readWithoutTimeout() throws Exception {
@@ -88,12 +92,14 @@ public class SocketTimeoutTest {
   static Socket socket(final int readableByteCount, final int writableByteCount) throws IOException {
     final ServerSocket serverSocket = new ServerSocket(0);
     serverSocket.setReuseAddress(true);
+    serverSocket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
 
     Thread peer = new Thread("peer") {
       @Override public void run() {
         Socket socket = null;
         try {
           socket = serverSocket.accept();
+          socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
           writeFully(socket.getOutputStream(), readableByteCount);
           readFully(socket.getInputStream(), writableByteCount);
           Thread.sleep(5000); // Sleep 5 seconds so the peer can close the connection.
@@ -108,7 +114,10 @@ public class SocketTimeoutTest {
     };
     peer.start();
 
-    return new Socket(serverSocket.getInetAddress(), serverSocket.getLocalPort());
+    Socket socket = new Socket(serverSocket.getInetAddress(), serverSocket.getLocalPort());
+    socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
+    socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
+    return socket;
   }
 
   private static void writeFully(OutputStream out, int byteCount) throws IOException {


### PR DESCRIPTION
Previously failing with:
  okio.SocketTimeoutTest#writeWithTimeout
    junit.framework.AssertionFailedError
        at junit.framework.Assert.fail(Assert.java:56)
        at okio.SocketTimeoutTest.writeWithTimeout(SocketTimeoutTest.java:75)

The problem: the 1MB of data can be written to the
client socket even though the server socket is not reading.
This is because sockets on Android are buffered by default
by more that the amount of data in the test. This prevents
the write timeout occurring.

Socket defaults measured on a Nexus 4 running AOSP:
send: 524288 bytes, receive: 1048576 bytes.
IIRC, it varies by device.

Only some of the buffers need to be set to fix this, but
setting all of them seems reasonable to make it explicit.
The buffers are set to 1/4 of the data being
transferred to ensure that the data will
flood the send and receive buffers with some to spare.
Too small and the "withoutTimeout" tests will timeout
due to inefficiency.

The tests were also failing on a Linux desktop, probably
for similar reasons.
