### PR TITLE
Add length write overload for a Source.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -601,6 +601,11 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return totalBytesRead;
   }
 
+  @Override public BufferedSink write(Source source, long byteCount) throws IOException {
+    source.read(this, byteCount);
+    return this;
+  }
+
   @Override public Buffer writeByte(int b) {
     Segment tail = writableSegment(1);
     tail.data[tail.limit++] = (byte) b;

--- a/okio/src/main/java/okio/BufferedSink.java
+++ b/okio/src/main/java/okio/BufferedSink.java
@@ -42,10 +42,13 @@ public interface BufferedSink extends Sink {
   BufferedSink write(byte[] source, int offset, int byteCount) throws IOException;
 
   /**
-   * Removes all bytes from {@code source} and appends them to this. Returns the
+   * Removes all bytes from {@code source} and appends them to this sink. Returns the
    * number of bytes read which will be 0 if {@code source} is exhausted.
    */
   long writeAll(Source source) throws IOException;
+
+  /** Removes {@code byteCount} bytes from {@code source} and appends them to this sink. */
+  BufferedSink write(Source source, long byteCount) throws IOException;
 
   /** Encodes {@code string} in UTF-8 and writes it to this sink. */
   BufferedSink writeUtf8(String string) throws IOException;

--- a/okio/src/main/java/okio/RealBufferedSink.java
+++ b/okio/src/main/java/okio/RealBufferedSink.java
@@ -85,6 +85,11 @@ final class RealBufferedSink implements BufferedSink {
     return totalBytesRead;
   }
 
+  @Override public BufferedSink write(Source source, long byteCount) throws IOException {
+    source.read(buffer, byteCount);
+    return this;
+  }
+
   @Override public BufferedSink writeByte(int b) throws IOException {
     if (closed) throw new IllegalStateException("closed");
     buffer.writeByte(b);

--- a/okio/src/test/java/okio/BufferedSinkTest.java
+++ b/okio/src/test/java/okio/BufferedSinkTest.java
@@ -156,6 +156,16 @@ public class BufferedSinkTest {
     assertEquals("abcdef", data.readUtf8());
   }
 
+  @Test public void writeSource() throws Exception {
+    Buffer source = new Buffer().writeUtf8("abcdef");
+
+    // Force resolution of the Source method overload.
+    sink.write((Source) source, 4);
+    sink.flush();
+    assertEquals("abcd", data.readUtf8());
+    assertEquals("ef", source.readUtf8());
+  }
+
   @Test public void writeAllExhausted() throws Exception {
     Buffer source = new Buffer();
     assertEquals(0, sink.writeAll(source));


### PR DESCRIPTION
This is merely a convenience method for semantic clarity and/or to prevent callers from needed to use the underlying buffer directly.
