### PR TITLE
Do not call through to Source on zero byte count write.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -669,7 +669,9 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
   }
 
   @Override public BufferedSink write(Source source, long byteCount) throws IOException {
-    source.read(this, byteCount);
+    if (byteCount > 0) {
+      source.read(this, byteCount);
+    }
     return this;
   }
 

--- a/okio/src/main/java/okio/RealBufferedSink.java
+++ b/okio/src/main/java/okio/RealBufferedSink.java
@@ -86,7 +86,9 @@ final class RealBufferedSink implements BufferedSink {
   }
 
   @Override public BufferedSink write(Source source, long byteCount) throws IOException {
-    source.read(buffer, byteCount);
+    if (byteCount > 0) {
+      source.read(buffer, byteCount);
+    }
     return this;
   }
 

--- a/okio/src/test/java/okio/BufferedSinkTest.java
+++ b/okio/src/test/java/okio/BufferedSinkTest.java
@@ -166,6 +166,19 @@ public class BufferedSinkTest {
     assertEquals("ef", source.readUtf8());
   }
 
+  @Test public void writeSourceWithZeroIsNoOp() throws IOException {
+    // This test ensures that a zero byte count never calls through to read the source. It may be
+    // tied to something like a socket which will potentially block trying to read a segment when
+    // ultimately we don't want any data.
+    Source source = new ForwardingSource(new Buffer()) {
+      @Override public long read(Buffer sink, long byteCount) throws IOException {
+        throw new AssertionError();
+      }
+    };
+    sink.write(source, 0);
+    assertEquals(0, data.size());
+  }
+
   @Test public void writeAllExhausted() throws Exception {
     Buffer source = new Buffer();
     assertEquals(0, sink.writeAll(source));


### PR DESCRIPTION
This ensures that a zero byte count never calls through to read the source. It may be tied to something like a socket which will potentially block trying to read a segment when ultimately we don't want any data.

Multiple instances of this bug occurring @ https://github.com/square/okhttp/pull/1241/files#r22281975
