### PR TITLE
Segment sharing.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -86,7 +86,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return this; // Nowhere to emit to!
   }
 
-  @Override public BufferedSink emit() throws IOException {
+  @Override public BufferedSink emit() {
     return this; // Nowhere to emit to!
   }
 
@@ -98,7 +98,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     if (size < byteCount) throw new EOFException();
   }
 
-  @Override public boolean request(long byteCount) throws IOException {
+  @Override public boolean request(long byteCount) {
     return size >= byteCount;
   }
 
@@ -164,30 +164,26 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     checkOffsetAndCount(size, offset, byteCount);
     if (byteCount == 0) return this;
 
-    Segment source = head;
-    Segment target = out.writableSegment(1);
     out.size += byteCount;
 
-    while (byteCount > 0) {
-      // If necessary, advance to a readable source segment. This won't repeat after the first copy.
-      while (offset >= source.limit - source.pos) {
-        offset -= (source.limit - source.pos);
-        source = source.next;
-      }
+    // Skip segments that we aren't copying from.
+    Segment s = head;
+    for (; offset >= (s.limit - s.pos); s = s.next) {
+      offset -= (s.limit - s.pos);
+    }
 
-      // If necessary, append another target segment.
-      if (target.limit == Segment.SIZE) {
-        target = target.push(SegmentPool.INSTANCE.take());
+    // Copy one segment at a time.
+    for (; byteCount > 0; s = s.next) {
+      Segment copy = new Segment(s);
+      copy.pos += offset;
+      copy.limit = Math.min(copy.pos + (int) byteCount, copy.limit);
+      if (out.head == null) {
+        out.head = copy.next = copy.prev = copy;
+      } else {
+        out.head.prev.push(copy);
       }
-
-      // Copy bytes from the source segment to the target segment.
-      long sourceReadable = Math.min(source.limit - (source.pos + offset), byteCount);
-      long targetWritable = Segment.SIZE - target.limit;
-      int toCopy = (int) Math.min(sourceReadable, targetWritable);
-      System.arraycopy(source.data, source.pos + (int) offset, target.data, target.limit, toCopy);
-      offset += toCopy;
-      target.limit += toCopy;
-      byteCount -= toCopy;
+      byteCount -= copy.limit - copy.pos;
+      offset = 0;
     }
 
     return this;
@@ -215,7 +211,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
       if (s.pos == s.limit) {
         Segment toRecycle = s;
         head = s = toRecycle.pop();
-        SegmentPool.INSTANCE.recycle(toRecycle);
+        SegmentPool.recycle(toRecycle);
       }
     }
 
@@ -262,7 +258,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
 
     // Omit the tail if it's still writable.
     Segment tail = head.prev;
-    if (tail.limit < Segment.SIZE) {
+    if (tail.limit < Segment.SIZE && tail.owner) {
       result -= tail.limit - tail.pos;
     }
 
@@ -282,7 +278,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
 
     if (pos == limit) {
       head = segment.pop();
-      SegmentPool.INSTANCE.recycle(segment);
+      SegmentPool.recycle(segment);
     } else {
       segment.pos = pos;
     }
@@ -321,7 +317,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
 
     if (pos == limit) {
       head = segment.pop();
-      SegmentPool.INSTANCE.recycle(segment);
+      SegmentPool.recycle(segment);
     } else {
       segment.pos = pos;
     }
@@ -353,7 +349,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
 
     if (pos == limit) {
       head = segment.pop();
-      SegmentPool.INSTANCE.recycle(segment);
+      SegmentPool.recycle(segment);
     } else {
       segment.pos = pos;
     }
@@ -387,7 +383,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
 
     if (pos == limit) {
       head = segment.pop();
-      SegmentPool.INSTANCE.recycle(segment);
+      SegmentPool.recycle(segment);
     } else {
       segment.pos = pos;
     }
@@ -471,7 +467,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
 
     if (s.pos == s.limit) {
       head = s.pop();
-      SegmentPool.INSTANCE.recycle(s);
+      SegmentPool.recycle(s);
     }
 
     return result;
@@ -558,7 +554,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
 
     if (s.pos == s.limit) {
       head = s.pop();
-      SegmentPool.INSTANCE.recycle(s);
+      SegmentPool.recycle(s);
     }
 
     return toCopy;
@@ -589,14 +585,15 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
       if (head.pos == head.limit) {
         Segment toRecycle = head;
         head = toRecycle.pop();
-        SegmentPool.INSTANCE.recycle(toRecycle);
+        SegmentPool.recycle(toRecycle);
       }
     }
   }
 
   @Override public Buffer write(ByteString byteString) {
     if (byteString == null) throw new IllegalArgumentException("byteString == null");
-    return write(byteString.data, 0, byteString.data.length);
+    byteString.write(this);
+    return this;
   }
 
   @Override public Buffer writeUtf8(String string) {
@@ -783,13 +780,13 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     if (minimumCapacity < 1 || minimumCapacity > Segment.SIZE) throw new IllegalArgumentException();
 
     if (head == null) {
-      head = SegmentPool.INSTANCE.take(); // Acquire a first segment.
+      head = SegmentPool.take(); // Acquire a first segment.
       return head.next = head.prev = head;
     }
 
     Segment tail = head.prev;
-    if (tail.limit + minimumCapacity > Segment.SIZE) {
-      tail = tail.push(SegmentPool.INSTANCE.take()); // Append a new empty segment to fill up.
+    if (tail.limit + minimumCapacity > Segment.SIZE || !tail.owner) {
+      tail = tail.push(SegmentPool.take()); // Append a new empty segment to fill up.
     }
     return tail;
   }
@@ -853,16 +850,17 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
       // Is a prefix of the source's head segment all that we need to move?
       if (byteCount < (source.head.limit - source.head.pos)) {
         Segment tail = head != null ? head.prev : null;
-        if (tail == null || byteCount + (tail.limit - tail.pos) > Segment.SIZE) {
-          // We're going to need another segment. Split the source's head
-          // segment in two, then move the first of those two to this buffer.
-          source.head = source.head.split((int) byteCount);
-        } else {
+        if (tail != null && tail.owner
+            && (byteCount + tail.limit - (tail.shared ? 0 : tail.pos) <= Segment.SIZE)) {
           // Our existing segments are sufficient. Move bytes from source's head to our tail.
           source.head.writeTo(tail, (int) byteCount);
           source.size -= byteCount;
           size += byteCount;
           return;
+        } else {
+          // We're going to need another segment. Split the source's head
+          // segment in two, then move the first of those two to this buffer.
+          source.head = source.head.split((int) byteCount);
         }
       }
 
@@ -934,7 +932,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     Segment s = head;
     if (s == null) return -1L;
     long offset = 0L;
-    byte[] toFind = targetBytes.data;
+    byte[] toFind = targetBytes.toByteArray();
     do {
       int segmentByteCount = s.limit - s.pos;
       if (fromIndex >= segmentByteCount) {
@@ -1050,11 +1048,28 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     Buffer result = new Buffer();
     if (size == 0) return result;
 
-    result.write(head.data, head.pos, head.limit - head.pos);
+    result.head = new Segment(head);
+    result.head.next = result.head.prev = result.head;
     for (Segment s = head.next; s != head; s = s.next) {
-      result.write(s.data, s.pos, s.limit - s.pos);
+      result.head.prev.push(new Segment(s));
     }
-
+    result.size = size;
     return result;
+  }
+
+  /** Returns an immutable copy of this buffer as a byte string. */
+  public ByteString snapshot() {
+    if (size > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("size > Integer.MAX_VALUE: " + size);
+    }
+    return snapshot((int) size);
+  }
+
+  /**
+   * Returns an immutable copy of the first {@code byteCount} bytes of this buffer as a byte string.
+   */
+  public ByteString snapshot(int byteCount) {
+    if (byteCount == 0) return ByteString.EMPTY;
+    return new SegmentedByteString(this, byteCount);
   }
 }

--- a/okio/src/main/java/okio/DeflaterSink.java
+++ b/okio/src/main/java/okio/DeflaterSink.java
@@ -73,7 +73,7 @@ public final class DeflaterSink implements Sink {
       head.pos += toDeflate;
       if (head.pos == head.limit) {
         source.head = head.pop();
-        SegmentPool.INSTANCE.recycle(head);
+        SegmentPool.recycle(head);
       }
 
       byteCount -= toDeflate;
@@ -99,7 +99,7 @@ public final class DeflaterSink implements Sink {
         buffer.size += deflated;
         sink.emitCompleteSegments();
       } else if (deflater.needsInput()) {
-        return;
+        return; // TODO(jwilson): do we have a dangling empty tail segment here?
       }
     }
   }

--- a/okio/src/main/java/okio/GzipSink.java
+++ b/okio/src/main/java/okio/GzipSink.java
@@ -83,8 +83,8 @@ public final class GzipSink implements Sink {
 
     // This method delegates to the DeflaterSink for finishing the deflate process
     // but keeps responsibility for releasing the deflater's resources. This is
-    // necessary because writeFooter needs to query the proccessed byte count which
-    // only works when the defalter is still open.
+    // necessary because writeFooter needs to query the processed byte count which
+    // only works when the deflater is still open.
 
     Throwable thrown = null;
     try {

--- a/okio/src/main/java/okio/InflaterSource.java
+++ b/okio/src/main/java/okio/InflaterSource.java
@@ -70,6 +70,7 @@ public final class InflaterSource implements Source {
           sink.size += bytesInflated;
           return bytesInflated;
         }
+        // TODO(jwilson): do we have an empty tail?
         if (inflater.finished() || inflater.needsDictionary()) {
           releaseInflatedBytes();
           return -1;

--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -83,7 +83,7 @@ public final class Okio {
 
           if (head.pos == head.limit) {
             source.head = head.pop();
-            SegmentPool.INSTANCE.recycle(head);
+            SegmentPool.recycle(head);
           }
         }
       }

--- a/okio/src/main/java/okio/Segment.java
+++ b/okio/src/main/java/okio/Segment.java
@@ -18,20 +18,23 @@ package okio;
 /**
  * A segment of a buffer.
  *
- * <p>Each segment in a buffer is a circularly-linked list node referencing
- * the following and preceding segments in the buffer.
+ * <p>Each segment in a buffer is a circularly-linked list node referencing the following and
+ * preceding segments in the buffer.
  *
- * <p>Each segment in the pool is a singly-linked list node referencing the rest
- * of segments in the pool.
+ * <p>Each segment in the pool is a singly-linked list node referencing the rest of segments in the
+ * pool.
+ *
+ * <p>The underlying byte arrays of segments may be shared between buffers and byte strings. When a
+ * segment's byte array is shared the segment may not be recycled, nor may its byte data be changed.
+ * The lone exception is that the owner segment is allowed to append to the segment, writing data at
+ * {@code limit} and beyond. There is a single owning segment for each byte array. Positions,
+ * limits, prev, and next references are not shared.
  */
 final class Segment {
   /** The size of all segments in bytes. */
-  // TODO: Using fixed-size segments makes pooling easier. But it harms memory
-  //       efficiency and encourages copying. Try variable sized segments?
-  // TODO: Is 2 KiB a good default segment size?
   static final int SIZE = 2048;
 
-  final byte[] data = new byte[SIZE];
+  final byte[] data;
 
   /** The next byte of application data byte to read in this segment. */
   int pos;
@@ -39,11 +42,36 @@ final class Segment {
   /** The first byte of available data ready to be written to. */
   int limit;
 
+  /** True if other segments or byte strings use the same byte array. */
+  boolean shared;
+
+  /** True if this segment owns the byte array and can append to it, extending {@code limit}. */
+  boolean owner;
+
   /** Next segment in a linked or circularly-linked list. */
   Segment next;
 
   /** Previous segment in a circularly-linked list. */
   Segment prev;
+
+  Segment() {
+    this.data = new byte[SIZE];
+    this.owner = true;
+    this.shared = false;
+  }
+
+  Segment(Segment shareFrom) {
+    this(shareFrom.data, shareFrom.pos, shareFrom.limit);
+    shareFrom.shared = true;
+  }
+
+  Segment(byte[] data, int pos, int limit) {
+    this.data = data;
+    this.pos = pos;
+    this.limit = limit;
+    this.owner = false;
+    this.shared = true;
+  }
 
   /**
    * Removes this segment of a circularly-linked list and returns its successor.
@@ -79,28 +107,12 @@ final class Segment {
    * <p>Returns the new head of the circularly-linked list.
    */
   public Segment split(int byteCount) {
-    int aSize = byteCount;
-    int bSize = (limit - pos) - byteCount;
-    if (aSize <= 0 || bSize <= 0) throw new IllegalArgumentException();
-
-    // Which side of the split is larger? We want to copy as few bytes as possible.
-    if (aSize < bSize) {
-      // Create a segment of size 'aSize' before this segment.
-      Segment before = SegmentPool.INSTANCE.take();
-      System.arraycopy(data, pos, before.data, before.pos, aSize);
-      pos += aSize;
-      before.limit += aSize;
-      prev.push(before);
-      return before;
-    } else {
-      // Create a new segment of size 'bSize' after this segment.
-      Segment after = SegmentPool.INSTANCE.take();
-      System.arraycopy(data, pos + aSize, after.data, after.pos, bSize);
-      limit -= bSize;
-      after.limit += bSize;
-      push(after);
-      return this;
-    }
+    if (byteCount <= 0 || byteCount > limit - pos) throw new IllegalArgumentException();
+    Segment prefix = new Segment(this);
+    prefix.limit = prefix.pos + byteCount;
+    pos += byteCount;
+    prev.push(prefix);
+    return prefix;
   }
 
   /**
@@ -109,20 +121,22 @@ final class Segment {
    */
   public void compact() {
     if (prev == this) throw new IllegalStateException();
-    if ((prev.limit - prev.pos) + (limit - pos) > SIZE) return; // Cannot compact.
-    writeTo(prev, limit - pos);
+    if (!prev.owner) return; // Cannot compact: prev isn't writable.
+    int byteCount = limit - pos;
+    int availableByteCount = SIZE - prev.limit + (prev.shared ? 0 : prev.pos);
+    if (byteCount > availableByteCount) return; // Cannot compact: not enough writable space.
+    writeTo(prev, byteCount);
     pop();
-    SegmentPool.INSTANCE.recycle(this);
+    SegmentPool.recycle(this);
   }
 
   /** Moves {@code byteCount} bytes from this segment to {@code sink}. */
-  // TODO: if sink has fewer bytes than this, it may be cheaper to reverse the
-  //       direction of the copy and swap the segments!
   public void writeTo(Segment sink, int byteCount) {
-    if (byteCount + (sink.limit - sink.pos) > SIZE) throw new IllegalArgumentException();
-
+    if (!sink.owner) throw new IllegalArgumentException();
     if (sink.limit + byteCount > SIZE) {
-      // We can't fit byteCount bytes at the sink's current position. Compact sink first.
+      // We can't fit byteCount bytes at the sink's current position. Shift sink first.
+      if (sink.shared) throw new IllegalArgumentException();
+      if (sink.limit + byteCount - sink.pos > SIZE) throw new IllegalArgumentException();
       System.arraycopy(sink.data, sink.pos, sink.data, 0, sink.limit - sink.pos);
       sink.limit -= sink.pos;
       sink.pos = 0;

--- a/okio/src/main/java/okio/SegmentedByteString.java
+++ b/okio/src/main/java/okio/SegmentedByteString.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+
+import static okio.Util.arrayRangeEquals;
+import static okio.Util.checkOffsetAndCount;
+
+/**
+ * An immutable byte string composed of segments of byte arrays. This class exists to implement
+ * efficient snapshots of buffers. It is implemented as an array of segments, plus a directory in
+ * two halves that describes how the segments compose this byte string.
+ *
+ * <p>The first half of the directory is the cumulative byte count covered by each segment. The
+ * element at {@code directory[0]} contains the number of bytes held in {@code segments[0]}; the
+ * element at {@code directory[1]} contains the number of bytes held in {@code segments[0] +
+ * segments[1]}, and so on. The element at {@code directory[segments.length - 1]} contains the total
+ * size of this byte string. The first half of the directory is always monotonically increasing.
+ *
+ * <p>The second half of the directory is the offset in {@code segments} of the first content byte.
+ * Bytes preceding this offset are unused, as are bytes beyond the segment's effective size.
+ *
+ * <p>Suppose we have a byte string, {@code [A, B, C, D, E, F, G, H, I, J, K, L, M]} that is stored
+ * across three byte arrays: {@code [x, x, x, x, A, B, C, D, E, x, x, x]}, {@code [x, F, G]}, and
+ * {@code [H, I, J, K, L, M, x, x, x, x, x, x]}. The three byte arrays would be stored in {@code
+ * segments} in order. Since the arrays contribute 5, 2, and 6 elements respectively, the directory
+ * starts with {@code [5, 7, 13} to hold the cumulative total at each position. Since the offsets
+ * into the arrays are 4, 1, and 0 respectively, the directory ends with {@code 4, 1, 0]}.
+ * Concatenating these two halves, the complete directory is {@code [5, 7, 13, 4, 1, 0]}.
+ *
+ * <p>This structure is chosen so that the segment holding a particular offset can be found by
+ * binary search. We use one array rather than two for the directory as a micro-optimization.
+ */
+final class SegmentedByteString extends ByteString {
+  transient final byte[][] segments;
+  transient final int[] directory;
+
+  SegmentedByteString(Buffer buffer, int byteCount) {
+    super(null);
+    checkOffsetAndCount(buffer.size, 0, byteCount);
+
+    // Walk through the buffer to count how many segments we'll need.
+    int offset = 0;
+    int segmentCount = 0;
+    for (Segment s = buffer.head; offset < byteCount; s = s.next) {
+      if (s.limit == s.pos) {
+        throw new AssertionError("s.limit == s.pos"); // Empty segment. This should not happen!
+      }
+      offset += s.limit - s.pos;
+      segmentCount++;
+    }
+
+    // Walk through the buffer again to assign segments and build the directory.
+    this.segments = new byte[segmentCount][];
+    this.directory = new int[segmentCount * 2];
+    offset = 0;
+    segmentCount = 0;
+    for (Segment s = buffer.head; offset < byteCount; s = s.next) {
+      segments[segmentCount] = s.data;
+      offset += s.limit - s.pos;
+      directory[segmentCount] = offset;
+      directory[segmentCount + segments.length] = s.pos;
+      s.shared = true;
+      segmentCount++;
+    }
+  }
+
+  @Override public String utf8() {
+    return toByteString().utf8();
+  }
+
+  @Override public String base64() {
+    return toByteString().base64();
+  }
+
+  @Override public String hex() {
+    return toByteString().hex();
+  }
+
+  @Override public ByteString toAsciiLowercase() {
+    return toByteString().toAsciiLowercase();
+  }
+
+  @Override public ByteString toAsciiUppercase() {
+    return toByteString().toAsciiUppercase();
+  }
+
+  @Override public byte getByte(int pos) {
+    checkOffsetAndCount(directory[segments.length - 1], pos, 1);
+    int segment = segment(pos);
+    int segmentOffset = segment == 0 ? 0 : directory[segment - 1];
+    int segmentPos = directory[segment + segments.length];
+    return segments[segment][pos - segmentOffset + segmentPos];
+  }
+
+  /** Returns the index of the segment that contains the byte at {@code pos}. */
+  private int segment(int pos) {
+    // Search for (pos + 1) instead of (pos) because the directory holds sizes, not indexes.
+    int i = Arrays.binarySearch(directory, 0, segments.length, pos + 1);
+    return i >= 0 ? i : ~i; // If i is negative, bitflip to get the insert position.
+  }
+
+  @Override public int size() {
+    return directory[segments.length - 1];
+  }
+
+  @Override public byte[] toByteArray() {
+    byte[] result = new byte[directory[segments.length - 1]];
+    int segmentOffset = 0;
+    for (int s = 0, segmentCount = segments.length; s < segmentCount; s++) {
+      int segmentPos = directory[segmentCount + s];
+      int nextSegmentOffset = directory[s];
+      System.arraycopy(segments[s], segmentPos, result, segmentOffset,
+          nextSegmentOffset - segmentOffset);
+      segmentOffset = nextSegmentOffset;
+    }
+    return result;
+  }
+
+  @Override public void write(OutputStream out) throws IOException {
+    if (out == null) throw new IllegalArgumentException("out == null");
+    int segmentOffset = 0;
+    for (int s = 0, segmentCount = segments.length; s < segmentCount; s++) {
+      int segmentPos = directory[segmentCount + s];
+      int nextSegmentOffset = directory[s];
+      out.write(segments[s], segmentPos, nextSegmentOffset - segmentOffset);
+      segmentOffset = nextSegmentOffset;
+    }
+  }
+
+  @Override void write(Buffer buffer) {
+    int segmentOffset = 0;
+    for (int s = 0, segmentCount = segments.length; s < segmentCount; s++) {
+      int segmentPos = directory[segmentCount + s];
+      int nextSegmentOffset = directory[s];
+      Segment segment = new Segment(segments[s], segmentPos,
+          segmentPos + nextSegmentOffset - segmentOffset);
+      if (buffer.head == null) {
+        buffer.head = segment.next = segment.prev = segment;
+      } else {
+        buffer.head.prev.push(segment);
+      }
+      segmentOffset = nextSegmentOffset;
+    }
+    buffer.size += segmentOffset;
+  }
+
+  @Override public boolean rangeEquals(
+      int offset, ByteString other, int otherOffset, int byteCount) {
+    if (offset > size() - byteCount) return false;
+    // Go segment-by-segment through this, passing arrays to other's rangeEquals().
+    for (int s = segment(offset); byteCount > 0; s++) {
+      int segmentOffset = s == 0 ? 0 : directory[s - 1];
+      int segmentSize = directory[s] - segmentOffset;
+      int stepSize = Math.min(byteCount, segmentOffset + segmentSize - offset);
+      int segmentPos = directory[segments.length + s];
+      int arrayOffset = offset - segmentOffset + segmentPos;
+      if (!other.rangeEquals(otherOffset, segments[s], arrayOffset, stepSize)) return false;
+      offset += stepSize;
+      otherOffset += stepSize;
+      byteCount -= stepSize;
+    }
+    return true;
+  }
+
+  @Override public boolean rangeEquals(int offset, byte[] other, int otherOffset, int byteCount) {
+    if (offset > size() - byteCount || otherOffset > other.length - byteCount) return false;
+    // Go segment-by-segment through this, comparing ranges of arrays.
+    for (int s = segment(offset); byteCount > 0; s++) {
+      int segmentOffset = s == 0 ? 0 : directory[s - 1];
+      int segmentSize = directory[s] - segmentOffset;
+      int stepSize = Math.min(byteCount, segmentOffset + segmentSize - offset);
+      int segmentPos = directory[segments.length + s];
+      int arrayOffset = offset - segmentOffset + segmentPos;
+      if (!arrayRangeEquals(segments[s], arrayOffset, other, otherOffset, stepSize)) return false;
+      offset += stepSize;
+      otherOffset += stepSize;
+      byteCount -= stepSize;
+    }
+    return true;
+  }
+
+  /** Returns a copy as a non-segmented byte string. */
+  private ByteString toByteString() {
+    return new ByteString(toByteArray());
+  }
+
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    return o instanceof ByteString
+        && ((ByteString) o).size() == size()
+        && rangeEquals(0, ((ByteString) o), 0, size());
+  }
+
+  @Override public int hashCode() {
+    int result = hashCode;
+    if (result != 0) return result;
+
+    // Equivalent to Arrays.hashCode(toByteArray()).
+    result = 1;
+    int segmentOffset = 0;
+    for (int s = 0, segmentCount = segments.length; s < segmentCount; s++) {
+      byte[] segment = segments[s];
+      int segmentPos = directory[segmentCount + s];
+      int nextSegmentOffset = directory[s];
+      int segmentSize = nextSegmentOffset - segmentOffset;
+      for (int i = segmentPos, limit = segmentPos + segmentSize; i < limit; i++) {
+        result = (31 * result) + segment[i];
+      }
+      segmentOffset = nextSegmentOffset;
+    }
+    return (hashCode = result);
+  }
+
+  @Override public String toString() {
+    return toByteString().toString();
+  }
+
+  private Object writeReplace() {
+    return toByteString();
+  }
+}

--- a/okio/src/main/java/okio/Util.java
+++ b/okio/src/main/java/okio/Util.java
@@ -69,4 +69,12 @@ final class Util {
   private static <T extends Throwable> void sneakyThrow2(Throwable t) throws T {
     throw (T) t;
   }
+
+  public static boolean arrayRangeEquals(
+      byte[] a, int aOffset, byte[] b, int bOffset, int byteCount) {
+    for (int i = 0; i < byteCount; i++) {
+      if (a[i + aOffset] != b[i + bOffset]) return false;
+    }
+    return true;
+  }
 }

--- a/okio/src/test/java/okio/BufferTest.java
+++ b/okio/src/test/java/okio/BufferTest.java
@@ -118,23 +118,23 @@ public final class BufferTest {
     // Take 2 * MAX_SIZE segments. This will drain the pool, even if other tests filled it.
     buffer.write(new byte[(int) SegmentPool.MAX_SIZE]);
     buffer.write(new byte[(int) SegmentPool.MAX_SIZE]);
-    assertEquals(0, SegmentPool.INSTANCE.byteCount);
+    assertEquals(0, SegmentPool.byteCount);
 
     // Recycle MAX_SIZE segments. They're all in the pool.
     buffer.readByteString(SegmentPool.MAX_SIZE);
-    assertEquals(SegmentPool.MAX_SIZE, SegmentPool.INSTANCE.byteCount);
+    assertEquals(SegmentPool.MAX_SIZE, SegmentPool.byteCount);
 
     // Recycle MAX_SIZE more segments. The pool is full so they get garbage collected.
     buffer.readByteString(SegmentPool.MAX_SIZE);
-    assertEquals(SegmentPool.MAX_SIZE, SegmentPool.INSTANCE.byteCount);
+    assertEquals(SegmentPool.MAX_SIZE, SegmentPool.byteCount);
 
     // Take MAX_SIZE segments to drain the pool.
     buffer.write(new byte[(int) SegmentPool.MAX_SIZE]);
-    assertEquals(0, SegmentPool.INSTANCE.byteCount);
+    assertEquals(0, SegmentPool.byteCount);
 
     // Take MAX_SIZE more segments. The pool is drained so these will need to be allocated.
     buffer.write(new byte[(int) SegmentPool.MAX_SIZE]);
-    assertEquals(0, SegmentPool.INSTANCE.byteCount);
+    assertEquals(0, SegmentPool.byteCount);
   }
 
   @Test public void moveBytesBetweenBuffersShareSegment() throws Exception {
@@ -567,6 +567,22 @@ public final class BufferTest {
 
     source.copyTo(source, 0, source.size());
     assertEquals(as + bs + as + bs, source.readUtf8());
+  }
+
+  @Test public void copyToEmptySource() throws Exception {
+    Buffer source = new Buffer();
+    Buffer target = new Buffer().writeUtf8("aaa");
+    source.copyTo(target, 0L, 0L);
+    assertEquals("", source.readUtf8());
+    assertEquals("aaa", target.readUtf8());
+  }
+
+  @Test public void copyToEmptyTarget() throws Exception {
+    Buffer source = new Buffer().writeUtf8("aaa");
+    Buffer target = new Buffer();
+    source.copyTo(target, 0L, 3L);
+    assertEquals("aaa", source.readUtf8());
+    assertEquals("aaa", target.readUtf8());
   }
 
   /**

--- a/okio/src/test/java/okio/BufferedSinkTest.java
+++ b/okio/src/test/java/okio/BufferedSinkTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okio;
 
 import java.io.IOException;

--- a/okio/src/test/java/okio/BufferedSourceTest.java
+++ b/okio/src/test/java/okio/BufferedSourceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okio;
 
 import java.io.EOFException;

--- a/okio/src/test/java/okio/ByteStringTest.java
+++ b/okio/src/test/java/okio/ByteStringTest.java
@@ -18,14 +18,12 @@ package okio;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import org.junit.Test;
 
 import static okio.TestUtil.assertByteArraysEquals;
+import static okio.TestUtil.assertEquivalent;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -230,40 +228,12 @@ public class ByteStringTest {
   }
 
   @Test public void javaSerializationTestNonEmpty() throws Exception {
-    ByteString original = ByteString.encodeUtf8(bronzeHorseman);
-    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-    ObjectOutputStream out = new ObjectOutputStream(bytes);
-    out.writeObject("before");
-    out.writeObject(original);
-    out.writeObject("after");
-    ObjectInputStream in = new ObjectInputStream(
-        new ByteArrayInputStream(bytes.toByteArray()));
-    assertEquals("before", in.readObject());
-    Object roundTrippedObject = in.readObject();
-    assertNotNull(roundTrippedObject);
-    assertTrue("Round tripped object wasn't a ByteString but a " +
-        roundTrippedObject.getClass(), roundTrippedObject instanceof ByteString);
-    assertEquals(original, roundTrippedObject);
-    assertEquals("hashCodes", original.hashCode(), roundTrippedObject.hashCode());
-    assertEquals("after", in.readObject());
+    ByteString byteString = ByteString.encodeUtf8(bronzeHorseman);
+    assertEquivalent(byteString, TestUtil.reserialize(byteString));
   }
 
   @Test public void javaSerializationTestEmpty() throws Exception {
-    ByteString original = ByteString.of();
-    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-    ObjectOutputStream out = new ObjectOutputStream(bytes);
-    out.writeObject("before");
-    out.writeObject(original);
-    out.writeObject("after");
-    ObjectInputStream in = new ObjectInputStream(
-        new ByteArrayInputStream(bytes.toByteArray()));
-    assertEquals("before", in.readObject());
-    Object roundTrippedObject = in.readObject();
-    assertNotNull(roundTrippedObject);
-    assertTrue("Round tripped object wasn't a ByteString but a " +
-        roundTrippedObject.getClass(), roundTrippedObject instanceof ByteString);
-    assertEquals(original, roundTrippedObject);
-    assertEquals("hashCodes", original.hashCode(), roundTrippedObject.hashCode());
-    assertEquals("after", in.readObject());
+    ByteString byteString = ByteString.of();
+    assertEquivalent(byteString, TestUtil.reserialize(byteString));
   }
 }

--- a/okio/src/test/java/okio/GzipSinkTest.java
+++ b/okio/src/test/java/okio/GzipSinkTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okio;
 
 import java.io.IOException;

--- a/okio/src/test/java/okio/SegmentSharingTest.java
+++ b/okio/src/test/java/okio/SegmentSharingTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio;
+
+import org.junit.Test;
+
+import static okio.TestUtil.assertEquivalent;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/** Tests behavior optimized by sharing segments between buffers and byte strings. */
+public final class SegmentSharingTest {
+  private static final String us = TestUtil.repeat('u', Segment.SIZE / 2 - 2);
+  private static final String vs = TestUtil.repeat('v', Segment.SIZE / 2 - 1);
+  private static final String ws = TestUtil.repeat('w', Segment.SIZE / 2);
+  private static final String xs = TestUtil.repeat('x', Segment.SIZE / 2 + 1);
+  private static final String ys = TestUtil.repeat('y', Segment.SIZE / 2 + 2);
+  private static final String zs = TestUtil.repeat('z', Segment.SIZE / 2 + 3);
+
+  @Test public void snapshotOfEmptyBuffer() throws Exception {
+    ByteString snapshot = new Buffer().snapshot();
+    assertEquivalent(snapshot, ByteString.EMPTY);
+  }
+
+  @Test public void snapshotsAreEquivalent() throws Exception {
+    ByteString byteString = concatenateBuffers(xs, ys, zs).snapshot();
+    assertEquivalent(byteString, concatenateBuffers(xs, ys + zs).snapshot());
+    assertEquivalent(byteString, concatenateBuffers(xs + ys + zs).snapshot());
+    assertEquivalent(byteString, ByteString.encodeUtf8(xs + ys + zs));
+  }
+
+  @Test public void snapshotGetByte() throws Exception {
+    ByteString byteString = concatenateBuffers(xs, ys, zs).snapshot();
+    assertEquals('x', byteString.getByte(0));
+    assertEquals('x', byteString.getByte(xs.length() - 1));
+    assertEquals('y', byteString.getByte(xs.length()));
+    assertEquals('y', byteString.getByte(xs.length() + ys.length() - 1));
+    assertEquals('z', byteString.getByte(xs.length() + ys.length()));
+    assertEquals('z', byteString.getByte(xs.length() + ys.length() + zs.length() - 1));
+    try {
+      byteString.getByte(-1);
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+    }
+    try {
+      byteString.getByte(xs.length() + ys.length() + zs.length());
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+    }
+  }
+
+  @Test public void snapshotWriteToOutputStream() throws Exception {
+    ByteString byteString = concatenateBuffers(xs, ys, zs).snapshot();
+    Buffer out = new Buffer();
+    byteString.write(out.outputStream());
+    assertEquals(xs + ys + zs, out.readUtf8());
+  }
+
+  /**
+   * Snapshots share their backing byte arrays with the source buffers. Those byte arrays must not
+   * be recycled, otherwise the new writer could corrupt the segment.
+   */
+  @Test public void snapshotSegmentsAreNotRecycled() throws Exception {
+    Buffer buffer = concatenateBuffers(xs, ys, zs);
+    ByteString snapshot = buffer.snapshot();
+    assertEquals(xs + ys + zs, snapshot.utf8());
+
+    // While locking the pool, confirm that clearing the buffer doesn't release its segments.
+    synchronized (SegmentPool.class) {
+      SegmentPool.next = null;
+      SegmentPool.byteCount = 0L;
+      buffer.clear();
+      assertEquals(null, SegmentPool.next);
+    }
+  }
+
+  /**
+   * Clones share their backing byte arrays with the source buffers. Those byte arrays must not
+   * be recycled, otherwise the new writer could corrupt the segment.
+   */
+  @Test public void cloneSegmentsAreNotRecycled() throws Exception {
+    Buffer buffer = concatenateBuffers(xs, ys, zs);
+    Buffer clone = buffer.clone();
+
+    // While locking the pool, confirm that clearing the buffer doesn't release its segments.
+    synchronized (SegmentPool.class) {
+      SegmentPool.next = null;
+      SegmentPool.byteCount = 0L;
+      buffer.clear();
+      assertEquals(null, SegmentPool.next);
+      clone.clear();
+      assertEquals(null, SegmentPool.next);
+    }
+  }
+
+  @Test public void snapshotJavaSerialization() throws Exception {
+    ByteString byteString = concatenateBuffers(xs, ys, zs).snapshot();
+    assertEquivalent(byteString, TestUtil.reserialize(byteString));
+  }
+
+  @Test public void clonesAreEquivalent() throws Exception {
+    Buffer bufferA = concatenateBuffers(xs, ys, zs);
+    Buffer bufferB = bufferA.clone();
+    assertEquivalent(bufferA, bufferB);
+    assertEquivalent(bufferA, concatenateBuffers(xs + ys, zs));
+  }
+
+  /** Even though some segments are shared, clones can be mutated independently. */
+  @Test public void mutateAfterClone() throws Exception {
+    Buffer bufferA = new Buffer();
+    bufferA.writeUtf8("abc");
+    Buffer bufferB = bufferA.clone();
+    bufferA.writeUtf8("def");
+    bufferB.writeUtf8("DEF");
+    assertEquals("abcdef", bufferA.readUtf8());
+    assertEquals("abcDEF", bufferB.readUtf8());
+  }
+
+  @Test public void concatenateSegmentsCanCombine() throws Exception {
+    Buffer bufferA = new Buffer().writeUtf8(ys).writeUtf8(us);
+    assertEquals(ys, bufferA.readUtf8(ys.length()));
+    Buffer bufferB = new Buffer().writeUtf8(vs).writeUtf8(ws);
+    Buffer bufferC = bufferA.clone();
+    bufferA.write(bufferB, vs.length());
+    bufferC.writeUtf8(xs);
+
+    assertEquals(us + vs, bufferA.readUtf8());
+    assertEquals(ws, bufferB.readUtf8());
+    assertEquals(us + xs, bufferC.readUtf8());
+  }
+
+  @Test public void shareAndSplit() throws Exception {
+    Buffer bufferA = new Buffer().writeUtf8("xxxx");
+    ByteString snapshot = bufferA.snapshot(); // Share the segment.
+    Buffer bufferB = new Buffer();
+    bufferB.write(bufferA, 2); // Split the shared segment in two.
+    bufferB.writeUtf8("yy"); // Append to the first half of the shared segment.
+    assertEquals("xxxx", snapshot.utf8());
+  }
+
+  @Test public void appendSnapshotToEmptyBuffer() throws Exception {
+    Buffer bufferA = concatenateBuffers(xs, ys);
+    ByteString snapshot = bufferA.snapshot();
+    Buffer bufferB = new Buffer();
+    bufferB.write(snapshot);
+    assertEquivalent(bufferB, bufferA);
+  }
+
+  @Test public void appendSnapshotToNonEmptyBuffer() throws Exception {
+    Buffer bufferA = concatenateBuffers(xs, ys);
+    ByteString snapshot = bufferA.snapshot();
+    Buffer bufferB = new Buffer().writeUtf8(us);
+    bufferB.write(snapshot);
+    assertEquivalent(bufferB, new Buffer().writeUtf8(us + xs + ys));
+  }
+
+  @Test public void copyToSegmentSharing() throws Exception {
+    Buffer bufferA = concatenateBuffers(ws, xs + "aaaa", ys, "bbbb" + zs);
+    Buffer bufferB = concatenateBuffers(us);
+    bufferA.copyTo(bufferB, ws.length() + xs.length(), 4 + ys.length() + 4);
+    assertEquivalent(bufferB, new Buffer().writeUtf8(us + "aaaa" + ys + "bbbb"));
+  }
+
+  /**
+   * Returns a new buffer containing the contents of {@code segments}, attempting to isolate each
+   * string to its own segment in the returned buffer.
+   */
+  public Buffer concatenateBuffers(String... segments) throws Exception {
+    Buffer result = new Buffer();
+    for (String s : segments) {
+      int offsetInSegment = s.length() < Segment.SIZE ? (Segment.SIZE - s.length()) / 2 : 0;
+      Buffer buffer = new Buffer();
+      buffer.writeUtf8(TestUtil.repeat('_', offsetInSegment));
+      buffer.writeUtf8(s);
+      buffer.skip(offsetInSegment);
+      result.write(buffer, buffer.size);
+    }
+    return result;
+  }
+}

--- a/okio/src/test/java/okio/TestUtil.java
+++ b/okio/src/test/java/okio/TestUtil.java
@@ -15,10 +15,15 @@
  */
 package okio;
 
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 final class TestUtil {
   private TestUtil() {
@@ -43,5 +48,88 @@ final class TestUtil {
     char[] array = new char[count];
     Arrays.fill(array, c);
     return new String(array);
+  }
+
+  public static void assertEquivalent(ByteString b1, ByteString b2) {
+    // Equals.
+    assertTrue(b1.equals(b2));
+    assertTrue(b1.equals(b1));
+    assertTrue(b2.equals(b1));
+
+    // Hash code.
+    assertEquals(b1.hashCode(), b2.hashCode());
+    assertEquals(b1.hashCode(), b1.hashCode());
+    assertEquals(b1.toString(), b2.toString());
+
+    // Content.
+    assertEquals(b1.size(), b2.size());
+    byte[] b2Bytes = b2.toByteArray();
+    for (int i = 0; i < b2Bytes.length; i++) {
+      byte b = b2Bytes[i];
+      assertEquals(b, b1.getByte(i));
+    }
+    assertByteArraysEquals(b1.toByteArray(), b2Bytes);
+
+    // Doesn't equal a different byte string.
+    assertFalse(b1.equals(null));
+    assertFalse(b1.equals(new Object()));
+    if (b2Bytes.length > 0) {
+      byte[] b3Bytes = b2Bytes.clone();
+      b3Bytes[b3Bytes.length - 1]++;
+      ByteString b3 = new ByteString(b3Bytes);
+      assertFalse(b1.equals(b3));
+      assertFalse(b1.hashCode() == b3.hashCode());
+    } else {
+      ByteString b3 = ByteString.encodeUtf8("a");
+      assertFalse(b1.equals(b3));
+      assertFalse(b1.hashCode() == b3.hashCode());
+    }
+  }
+
+  public static void assertEquivalent(Buffer b1, Buffer b2) {
+    // Equals.
+    assertTrue(b1.equals(b2));
+    assertTrue(b1.equals(b1));
+    assertTrue(b2.equals(b1));
+
+    // Hash code.
+    assertEquals(b1.hashCode(), b2.hashCode());
+    assertEquals(b1.hashCode(), b1.hashCode());
+    assertEquals(b1.toString(), b2.toString());
+
+    // Content.
+    assertEquals(b1.size(), b2.size());
+    Buffer buffer = new Buffer();
+    b2.copyTo(buffer, 0, b2.size);
+    byte[] b2Bytes = b2.readByteArray();
+    for (int i = 0; i < b2Bytes.length; i++) {
+      byte b = b2Bytes[i];
+      assertEquals(b, b1.getByte(i));
+    }
+
+    // Doesn't equal a different buffer.
+    assertFalse(b1.equals(null));
+    assertFalse(b1.equals(new Object()));
+    if (b2Bytes.length > 0) {
+      byte[] b3Bytes = b2Bytes.clone();
+      b3Bytes[b3Bytes.length - 1]++;
+      Buffer b3 = new Buffer().write(b3Bytes);
+      assertFalse(b1.equals(b3));
+      assertFalse(b1.hashCode() == b3.hashCode());
+    } else {
+      Buffer b3 = new Buffer().writeUtf8("a");
+      assertFalse(b1.equals(b3));
+      assertFalse(b1.hashCode() == b3.hashCode());
+    }
+  }
+
+  /** Serializes original to bytes, then deserializes those bytes and returns the result. */
+  @SuppressWarnings("unchecked") // Assume serialization doesn't change types.
+  public static <T extends Serializable> T reserialize(T original) throws Exception {
+    Buffer buffer = new Buffer();
+    ObjectOutputStream out = new ObjectOutputStream(buffer.outputStream());
+    out.writeObject(original);
+    ObjectInputStream in = new ObjectInputStream(buffer.inputStream());
+    return (T) in.readObject();
   }
 }


### PR DESCRIPTION
We now have three different types of segments:
 * Private. This was the only type of segment previously offered.
   This is shared=false, owner=true.
 * Appendable. Segments of this type can be written, but only
   beyond segment.limit. Bytes preceding segment.limit are shared
   and must not be written. This is shared=true, owner=true.
 * Unwritable. Segments of this type cannot be written at all.
   They are owned by another buffer. This is shared=true, owner=false.

Note that there are no segments of type 'shared=false, owner=false',
since the only way a buffer doesn't own its segment is if that segment
is shared.

This introduces a new subclass of ByteString, SegmentedByteString.
These byte strings share backing arrays with buffers. SegmentedByteString
instances are immutable and support fast random access. Reading a random
byte from a SegmentedByteString is O(log N); reading a random byte from a
Buffer is O(N).

Segment sharing isn't necessarily more efficient in all cases. For example,
shared segments are not pooled; this harms efficiency of segment allocation.
Shared segments may also be wasteful of memory: previously segments were
consistently > 50% full. With this change, we have no such minimum.

This change should have significant benefits for Buffer.copyTo(), which
is an important operation of OkHttp. Right now whenever a single buffer
needs to be written to multiple destinations, we manually copy the buffer
so that each destination gets its own private copy of the buffer's segments.
By sharing segments, the work required by copyTo() is cut down to the
segment bookkeeping. No byte arrays are copied.