### PR TITLE
allow base64-decoding byte arrays, not just strings

### DIFF
--- a/okio/src/main/java/okio/Base64.java
+++ b/okio/src/main/java/okio/Base64.java
@@ -22,15 +22,24 @@ package okio;
 
 import java.io.UnsupportedEncodingException;
 
+import java.nio.charset.Charset;
+
+
 final class Base64 {
+  static private Charset utf8 = Charset.forName("utf8");
+
   private Base64() {
   }
 
-  public static byte[] decode(String in) {
+  public static byte[] decode(final String in) {
+      return decode(in.getBytes(utf8));
+  }
+
+  public static byte[] decode(final byte[] in) {
     // Ignore trailing '=' padding and whitespace from the input.
-    int limit = in.length();
+    int limit = in.length;
     for (; limit > 0; limit--) {
-      char c = in.charAt(limit - 1);
+      byte c = in[limit - 1];
       if (c != '=' && c != '\n' && c != '\r' && c != ' ' && c != '\t') {
         break;
       }
@@ -43,7 +52,7 @@ final class Base64 {
 
     int word = 0;
     for (int pos = 0; pos < limit; pos++) {
-      char c = in.charAt(pos);
+      byte c = in[pos];
 
       int bits;
       if (c >= 'A' && c <= 'Z') {

--- a/okio/src/main/java/okio/ByteString.java
+++ b/okio/src/main/java/okio/ByteString.java
@@ -105,7 +105,17 @@ public final class ByteString implements Serializable {
    * Decodes the Base64-encoded bytes and returns their value as a byte string.
    * Returns null if {@code base64} is not a Base64-encoded sequence of bytes.
    */
-  public static ByteString decodeBase64(String base64) {
+  public static ByteString decodeBase64(final String base64) {
+    if (base64 == null) throw new IllegalArgumentException("base64 == null");
+    byte[] decoded = Base64.decode(base64);
+    return decoded != null ? new ByteString(decoded) : null;
+  }
+
+  /**
+   * Decodes the Base64-encoded bytes and returns their value as a byte string.
+   * Returns null if {@code base64} is not a Base64-encoded sequence of bytes.
+   */
+  public static ByteString decodeBase64(final byte[] base64) {
     if (base64 == null) throw new IllegalArgumentException("base64 == null");
     byte[] decoded = Base64.decode(base64);
     return decoded != null ? new ByteString(decoded) : null;

--- a/okio/src/test/java/okio/ByteStringTest.java
+++ b/okio/src/test/java/okio/ByteStringTest.java
@@ -117,16 +117,16 @@ public class ByteStringTest {
   @Test public void toAsciiStartsUppercaseEndsLowercase() throws Exception {
     assertEquals(ByteString.encodeUtf8("ABCD"), ByteString.encodeUtf8("ABcd").toAsciiUppercase());
   }
-  
+
   @Test public void substring() throws Exception {
     ByteString byteString = ByteString.encodeUtf8("Hello, World!");
-    
+
     assertEquals(byteString.substring(0), byteString);
     assertEquals(byteString.substring(0, 5), ByteString.encodeUtf8("Hello"));
     assertEquals(byteString.substring(7), ByteString.encodeUtf8("World!"));
     assertEquals(byteString.substring(6, 6), ByteString.encodeUtf8(""));
   }
-  
+
   @Test public void substringWithInvalidBounds() throws Exception {
     ByteString byteString = ByteString.encodeUtf8("Hello, World!");
 
@@ -179,6 +179,11 @@ public class ByteStringTest {
     assertEquals("What's to be scared about? It's just a little hiccup in the power...",
         ByteString.decodeBase64("V2hhdCdzIHRvIGJlIHNjYXJlZCBhYm91dD8gSXQncyBqdXN0IGEgbGl0dGxlIGhpY2"
             + "N1cCBpbiB0aGUgcG93ZXIuLi4=").utf8());
+  }
+
+  @Test public void decodeBase64FromBytes() {
+    assertEquals(ByteString.of(), ByteString.decodeBase64("".getBytes()));
+    assertEquals("chic", ByteString.decodeBase64("Y2hpYw==".getBytes()).utf8());
   }
 
   @Test public void decodeBase64WithWhitespace() {


### PR DESCRIPTION
This is just a convenience function; it helps to avoid having to convert data from the network from bytes to String before decodeBase64() converts it back and decodes it. If you accept this sort of overload I'll provide some more, e.g. decodeBase64(final ByteString in) and an RFC-compliant encoding variant.

I see the diff removes some spurious whitespace at EOL. Oh well.
