### PR TITLE
Make sure every writableSegment() call writes or recycles.

### DIFF
--- a/okio/src/main/java/okio/DeflaterSink.java
+++ b/okio/src/main/java/okio/DeflaterSink.java
@@ -99,7 +99,12 @@ public final class DeflaterSink implements Sink {
         buffer.size += deflated;
         sink.emitCompleteSegments();
       } else if (deflater.needsInput()) {
-        return; // TODO(jwilson): do we have a dangling empty tail segment here?
+        if (s.pos == s.limit) {
+          // We allocated a tail segment, but didn't end up needing it. Recycle!
+          buffer.head = s.pop();
+          SegmentPool.recycle(s);
+        }
+        return;
       }
     }
   }

--- a/okio/src/main/java/okio/InflaterSource.java
+++ b/okio/src/main/java/okio/InflaterSource.java
@@ -70,9 +70,13 @@ public final class InflaterSource implements Source {
           sink.size += bytesInflated;
           return bytesInflated;
         }
-        // TODO(jwilson): do we have an empty tail?
         if (inflater.finished() || inflater.needsDictionary()) {
           releaseInflatedBytes();
+          if (tail.pos == tail.limit) {
+            // We allocated a tail segment, but didn't end up needing it. Recycle!
+            sink.head = tail.pop();
+            SegmentPool.recycle(tail);
+          }
           return -1;
         }
         if (sourceExhausted) throw new EOFException("source exhausted prematurely");

--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -130,6 +130,7 @@ public final class Okio {
     return new Source() {
       @Override public long read(Buffer sink, long byteCount) throws IOException {
         if (byteCount < 0) throw new IllegalArgumentException("byteCount < 0: " + byteCount);
+        if (byteCount == 0) return 0;
         timeout.throwIfReached();
         Segment tail = sink.writableSegment(1);
         int maxToCopy = (int) Math.min(byteCount, Segment.SIZE - tail.limit);

--- a/okio/src/test/java/okio/InflaterSourceTest.java
+++ b/okio/src/test/java/okio/InflaterSourceTest.java
@@ -17,6 +17,7 @@ package okio;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
 import org.junit.Test;
@@ -72,6 +73,19 @@ public final class InflaterSourceTest {
     Buffer deflated = deflate(original);
     Buffer inflated = inflate(deflated);
     assertEquals(original, inflated.readByteString());
+  }
+
+  @Test public void inflateIntoNonemptySink() throws Exception {
+    for (int i = 0; i < Segment.SIZE; i++) {
+      Buffer inflated = new Buffer().writeUtf8(repeat('a', i));
+      Buffer deflated = decodeBase64(
+          "eJxzz09RyEjNKVAoLdZRKE9VL0pVyMxTKMlIVchIzEspVshPU0jNS8/MS00tKtYDAF6CD5s=");
+      InflaterSource source = new InflaterSource(deflated, new Inflater());
+      while (source.read(inflated, Integer.MAX_VALUE) != -1) {
+      }
+      inflated.skip(i);
+      assertEquals("God help us, we're in the hands of engineers.", inflated.readUtf8());
+    }
   }
 
   private Buffer decodeBase64(String s) {


### PR DESCRIPTION
With segment sharing it's important that we never have empty segments
around inside a buffer. These were some edge cases where that was
possible.

Closes https://github.com/square/okio/issues/129