### PR TITLE
Ensure empty sources work with gzip and inflater wrappers.

### DIFF
--- a/okio/src/main/java/okio/GzipSource.java
+++ b/okio/src/main/java/okio/GzipSource.java
@@ -68,6 +68,10 @@ public final class GzipSource implements Source {
     if (byteCount < 0) throw new IllegalArgumentException("byteCount < 0: " + byteCount);
     if (byteCount == 0) return 0;
 
+    if (source.exhausted()) {
+      return -1;
+    }
+
     // If we haven't consumed the header, we must consume it before anything else.
     if (section == SECTION_HEADER) {
       consumeHeader();

--- a/okio/src/main/java/okio/InflaterSource.java
+++ b/okio/src/main/java/okio/InflaterSource.java
@@ -58,6 +58,10 @@ public final class InflaterSource implements Source {
     if (closed) throw new IllegalStateException("closed");
     if (byteCount == 0) return 0;
 
+    if (source.exhausted()) {
+      return -1;
+    }
+
     while (true) {
       boolean sourceExhausted = refill();
 

--- a/okio/src/test/java/okio/GzipSourceTest.java
+++ b/okio/src/test/java/okio/GzipSourceTest.java
@@ -35,6 +35,11 @@ public class GzipSourceTest {
     assertGzipped(gzipped);
   }
 
+  @Test public void gunzipEmpty() throws IOException {
+    Source gzip = new GzipSource(new Buffer());
+    assertEquals(-1, gzip.read(new Buffer(), 1));
+  }
+
   @Test public void gunzip_withHCRC() throws Exception {
     CRC32 hcrc = new CRC32();
     ByteString gzipHeader = gzipHeaderWithFlags((byte) 0x02);

--- a/okio/src/test/java/okio/InflaterSourceTest.java
+++ b/okio/src/test/java/okio/InflaterSourceTest.java
@@ -17,7 +17,6 @@ package okio;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
 import org.junit.Test;
@@ -33,6 +32,11 @@ public final class InflaterSourceTest {
         + "tYDAF6CD5s=");
     Buffer inflated = inflate(deflated);
     assertEquals("God help us, we're in the hands of engineers.", inflated.readUtf8());
+  }
+
+  @Test public void inflateEmpty() throws IOException {
+    Source source = new InflaterSource(new Buffer(), new Inflater());
+    assertEquals(-1, source.read(new Buffer(), 1));
   }
 
   @Test public void inflateTruncated() throws Exception {


### PR DESCRIPTION
Closes https://github.com/square/retrofit/issues/804.