### PR TITLE
Change Timeout.throwIfReached() to throw InterruptedIOException

### DIFF
--- a/okio/src/main/java/okio/ForwardingTimeout.java
+++ b/okio/src/main/java/okio/ForwardingTimeout.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/** A {@link Timeout} which forwards calls to another. Useful for subclassing. */
+public class ForwardingTimeout extends Timeout {
+  private Timeout delegate;
+
+  public ForwardingTimeout(Timeout delegate) {
+    if (delegate == null) throw new IllegalArgumentException("delegate == null");
+    this.delegate = delegate;
+  }
+
+  /** {@link Timeout} instance to which this instance is currently delegating. */
+  public final Timeout delegate() {
+    return delegate;
+  }
+
+  public final ForwardingTimeout setDelegate(Timeout delegate) {
+    if (delegate == null) throw new IllegalArgumentException("delegate == null");
+    this.delegate = delegate;
+    return this;
+  }
+
+  @Override public Timeout timeout(long timeout, TimeUnit unit) {
+    return delegate.timeout(timeout, unit);
+  }
+
+  @Override public long timeoutNanos() {
+    return delegate.timeoutNanos();
+  }
+
+  @Override public boolean hasDeadline() {
+    return delegate.hasDeadline();
+  }
+
+  @Override public long deadlineNanoTime() {
+    return delegate.deadlineNanoTime();
+  }
+
+  @Override public Timeout deadlineNanoTime(long deadlineNanoTime) {
+    return delegate.deadlineNanoTime(deadlineNanoTime);
+  }
+
+  @Override public Timeout clearTimeout() {
+    return delegate.clearTimeout();
+  }
+
+  @Override public Timeout clearDeadline() {
+    return delegate.clearDeadline();
+  }
+
+  @Override public void throwIfReached() throws IOException {
+    delegate.throwIfReached();
+  }
+}

--- a/okio/src/main/java/okio/Timeout.java
+++ b/okio/src/main/java/okio/Timeout.java
@@ -136,18 +136,17 @@ public class Timeout {
   }
 
   /**
-   * Throws an {@link IOException} if the deadline has been reached or if the
-   * current thread has been interrupted. This method doesn't detect timeouts;
-   * that should be implemented to asynchronously abort an in-progress
-   * operation.
+   * Throws an {@link InterruptedIOException} if the deadline has been reached or if the current
+   * thread has been interrupted. This method doesn't detect timeouts; that should be implemented to
+   * asynchronously abort an in-progress operation.
    */
   public void throwIfReached() throws IOException {
     if (Thread.interrupted()) {
-      throw new InterruptedIOException();
+      throw new InterruptedIOException("thread interrupted");
     }
 
-    if (hasDeadline && System.nanoTime() > deadlineNanoTime) {
-      throw new IOException("deadline reached");
+    if (hasDeadline && deadlineNanoTime - System.nanoTime() <= 0) {
+      throw new InterruptedIOException("deadline reached");
     }
   }
 }


### PR DESCRIPTION
Previously this was throwing IOException, but nothing was anticipated
that. This is slightly semantically incorrect; the thread wasn't
interrupted. But it's much more convenient to use a single exception
type for both timeouts.

Also add a new type, ForwardingTimeout.