### PR TITLE
Make Okio Socket-related methods throw SocketTimeoutException

### DIFF
--- a/okio/src/main/java/okio/AsyncTimeout.java
+++ b/okio/src/main/java/okio/AsyncTimeout.java
@@ -241,22 +241,36 @@ public class AsyncTimeout extends Timeout {
   }
 
   /**
-   * Throws an InterruptedIOException if {@code throwOnTimeout} is true and a
-   * timeout occurred.
+   * Throws an IOException if {@code throwOnTimeout} is {@code true} and a
+   * timeout occurred. See {@link #newTimeoutException(java.io.IOException)}
+   * for the type of exception thrown.
    */
   final void exit(boolean throwOnTimeout) throws IOException {
     boolean timedOut = exit();
-    if (timedOut && throwOnTimeout) throw new InterruptedIOException("timeout");
+    if (timedOut && throwOnTimeout) throw newTimeoutException(null);
   }
 
   /**
-   * Returns either {@code cause} or an InterruptedIOException that's caused by
-   * {@code cause} if a timeout occurred.
+   * Returns either {@code cause} or an IOException that's caused by
+   * {@code cause} if a timeout occurred. See
+   * {@link #newTimeoutException(java.io.IOException)} for the type of
+   * exception returned.
    */
   final IOException exit(IOException cause) throws IOException {
     if (!exit()) return cause;
+    return newTimeoutException(cause);
+  }
+
+  /**
+   * Returns an {@link IOException} to represent a timeout. By default this method returns
+   * {@link java.io.InterruptedIOException}. If {@code cause} is non-null it is set as the cause of
+   * the returned exception.
+   */
+  protected IOException newTimeoutException(IOException cause) {
     InterruptedIOException e = new InterruptedIOException("timeout");
-    e.initCause(cause);
+    if (cause != null) {
+      e.initCause(cause);
+    }
     return e;
   }
 

--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -21,8 +21,10 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.nio.file.Files;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -201,6 +203,14 @@ public final class Okio {
 
   private static AsyncTimeout timeout(final Socket socket) {
     return new AsyncTimeout() {
+      @Override protected IOException newTimeoutException(IOException cause) {
+        InterruptedIOException ioe = new SocketTimeoutException("timeout");
+        if (cause != null) {
+          ioe.initCause(cause);
+        }
+        return ioe;
+      }
+
       @Override protected void timedOut() {
         try {
           socket.close();

--- a/okio/src/test/java/okio/SocketTimeoutTest.java
+++ b/okio/src/test/java/okio/SocketTimeoutTest.java
@@ -18,10 +18,10 @@ package okio;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
@@ -50,7 +50,7 @@ public class SocketTimeoutTest {
     try {
       source.require(ONE_MB);
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (SocketTimeoutException expected) {
     }
     socket.close();
   }
@@ -75,7 +75,7 @@ public class SocketTimeoutTest {
       sink.write(new Buffer().write(data), data.length);
       sink.flush();
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (SocketTimeoutException expected) {
     }
     long elapsed = System.nanoTime() - start;
     socket.close();


### PR DESCRIPTION
...instead of InterruptedIOException. This is a backwards compatible
change because SocketTimeoutException extends
InterruptedIOException.

This change is to address:
https://github.com/square/okhttp/issues/1676