### PR TITLE
Move a cast in Buffer.indexOf().

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -1242,8 +1242,8 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
         fromIndex -= segmentByteCount;
       } else {
         byte[] data = s.data;
-        for (long pos = s.pos + fromIndex, limit = s.limit; pos < limit; pos++) {
-          if (data[(int) pos] == b) return offset + pos - s.pos;
+        for (int pos = (int) (s.pos + fromIndex), limit = s.limit; pos < limit; pos++) {
+          if (data[pos] == b) return offset + pos - s.pos;
         }
         fromIndex = 0;
       }


### PR DESCRIPTION
This has the happy side-effect of preventing the Lenovo S939 from
behaving incorrectly when executing this method.

The following test exercises the previous code; it fails after
a few iterations on that device:
https://gist.github.com/swankjesse/4396e276e43dbb0e71cc

Unfortunately there's no good way to regression test that we
haven't hit a bug in a specific lousy device.