### PR TITLE
catch exception

### DIFF
--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -216,6 +216,9 @@ public final class Okio {
           socket.close();
         } catch (Exception e) {
           logger.log(Level.WARNING, "Failed to close timed out socket " + socket, e);
+        } catch (AssertionError are) {
+          //Catch this exception due to a Firmware issue up to android 4.2.2
+          logger.log(Level.WARNING, "Failed to close timed out socket " + socket, are);
         }
       }
     };

--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -217,8 +217,13 @@ public final class Okio {
         } catch (Exception e) {
           logger.log(Level.WARNING, "Failed to close timed out socket " + socket, e);
         } catch (AssertionError are) {
-          //Catch this exception due to a Firmware issue up to android 4.2.2
-          logger.log(Level.WARNING, "Failed to close timed out socket " + socket, are);
+            if(are.getCause() != null && are.getMessage() != null && are.getMessage().contains("getsockname failed")){
+                // Catch this exception due to a Firmware issue up to android 4.2.2
+                // https://code.google.com/p/android/issues/detail?id=54072
+                logger.log(Level.WARNING, "Failed to close timed out socket " + socket, are);
+            }
+            else
+                throw are;
         }
       }
     };


### PR DESCRIPTION
An issue that impact android version up to 4.2.2 cause an exception to be thrown:
java.lang.AssertionError: libcore.io.ErrnoException: getsockname failed: EBADF (Bad file number)
caused by libcore.io.IoBridge.getSocketLocalPort(IoBridge.java:649)
 https://code.google.com/p/android/issues/detail?id=54072

I use okHttp on my application and I get some crashes regarding this issue. 
I cannot catch this exception on my code because this exception is thrown at a deeper level. 
But this exception can be catched by the okio code.
Most of my crashes can be fixed by this pull request.

This fix is related to this discussion : https://github.com/square/okhttp/issues/1684#issuecomment-117123290