### PR TITLE
Remove synthetic accessors for private members in different scopes.

### DIFF
--- a/okio/src/main/java/okio/AsyncTimeout.java
+++ b/okio/src/main/java/okio/AsyncTimeout.java
@@ -302,7 +302,7 @@ public class AsyncTimeout extends Timeout {
    * either a newer node is inserted at the head, or the node being waited on
    * has been removed.
    */
-  private static synchronized AsyncTimeout awaitTimeout() throws InterruptedException {
+  static synchronized AsyncTimeout awaitTimeout() throws InterruptedException {
     // Get the next eligible node.
     AsyncTimeout node = head.next;
 

--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -36,7 +36,7 @@ import static okio.Util.checkOffsetAndCount;
 
 /** Essential APIs for working with Okio. */
 public final class Okio {
-  private static final Logger logger = Logger.getLogger(Okio.class.getName());
+  static final Logger logger = Logger.getLogger(Okio.class.getName());
 
   private Okio() {
   }
@@ -238,7 +238,7 @@ public final class Okio {
    * Returns true if {@code e} is due to a firmware bug fixed after Android 4.2.2.
    * https://code.google.com/p/android/issues/detail?id=54072
    */
-  private static boolean isAndroidGetsocknameError(AssertionError e) {
+  static boolean isAndroidGetsocknameError(AssertionError e) {
     return e.getCause() != null && e.getMessage() != null
         && e.getMessage().contains("getsockname failed");
   }

--- a/okio/src/main/java/okio/RealBufferedSink.java
+++ b/okio/src/main/java/okio/RealBufferedSink.java
@@ -23,7 +23,7 @@ import java.nio.charset.Charset;
 final class RealBufferedSink implements BufferedSink {
   public final Buffer buffer;
   public final Sink sink;
-  private boolean closed;
+  boolean closed;
 
   public RealBufferedSink(Sink sink, Buffer buffer) {
     if (sink == null) throw new IllegalArgumentException("sink == null");

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -25,7 +25,7 @@ import static okio.Util.checkOffsetAndCount;
 final class RealBufferedSource implements BufferedSource {
   public final Buffer buffer;
   public final Source source;
-  private boolean closed;
+  boolean closed;
 
   public RealBufferedSource(Source source, Buffer buffer) {
     if (source == null) throw new IllegalArgumentException("source == null");


### PR DESCRIPTION
This removes 5 methods taking the count to 607 from 612.