### PR TITLE
Added ByteString.asByteBuffer().

### DIFF
--- a/okio/src/main/java/okio/ByteString.java
+++ b/okio/src/main/java/okio/ByteString.java
@@ -23,6 +23,7 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -288,6 +289,13 @@ public class ByteString implements Serializable, Comparable<ByteString> {
    */
   public byte[] toByteArray() {
     return data.clone();
+  }
+
+  /**
+   * Returns a {@code ByteBuffer} view of the bytes in this {@code ByteString}.
+   */
+  public ByteBuffer asByteBuffer() {
+    return ByteBuffer.wrap(data);
   }
 
   /** Writes the contents of this byte string to {@code out}. */

--- a/okio/src/main/java/okio/ByteString.java
+++ b/okio/src/main/java/okio/ByteString.java
@@ -295,7 +295,7 @@ public class ByteString implements Serializable, Comparable<ByteString> {
    * Returns a {@code ByteBuffer} view of the bytes in this {@code ByteString}.
    */
   public ByteBuffer asByteBuffer() {
-    return ByteBuffer.wrap(data);
+    return ByteBuffer.wrap(data).asReadOnlyBuffer();
   }
 
   /** Writes the contents of this byte string to {@code out}. */

--- a/okio/src/main/java/okio/SegmentedByteString.java
+++ b/okio/src/main/java/okio/SegmentedByteString.java
@@ -17,6 +17,7 @@ package okio;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import static okio.Util.arrayRangeEquals;
@@ -151,6 +152,10 @@ final class SegmentedByteString extends ByteString {
       segmentOffset = nextSegmentOffset;
     }
     return result;
+  }
+
+  @Override public ByteBuffer asByteBuffer() {
+    return ByteBuffer.wrap(toByteArray()).asReadOnlyBuffer();
   }
 
   @Override public void write(OutputStream out) throws IOException {

--- a/okio/src/test/java/okio/ByteStringTest.java
+++ b/okio/src/test/java/okio/ByteStringTest.java
@@ -327,4 +327,8 @@ public class ByteStringTest {
 
     assertEquals(originalByteStrings, sortedByteStrings);
   }
+
+  @Test public void asByteBuffer() {
+    assertEquals(0x42, ByteString.of((byte) 0x41, (byte) 0x42, (byte) 0x43).asByteBuffer().get(1));
+  }
 }


### PR DESCRIPTION
This avoids an unnecessary copy.