### PR TITLE
Limit snapshot byte strings to requested size.

### DIFF
--- a/okio/src/main/java/okio/SegmentedByteString.java
+++ b/okio/src/main/java/okio/SegmentedByteString.java
@@ -75,6 +75,9 @@ final class SegmentedByteString extends ByteString {
     for (Segment s = buffer.head; offset < byteCount; s = s.next) {
       segments[segmentCount] = s.data;
       offset += s.limit - s.pos;
+      if (offset > byteCount) {
+        offset = byteCount; // Despite sharing more bytes, only report having up to byteCount.
+      }
       directory[segmentCount] = offset;
       directory[segmentCount + segments.length] = s.pos;
       s.shared = true;

--- a/okio/src/test/java/okio/BufferTest.java
+++ b/okio/src/test/java/okio/BufferTest.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
@@ -583,6 +584,12 @@ public final class BufferTest {
     source.copyTo(target, 0L, 3L);
     assertEquals("aaa", source.readUtf8());
     assertEquals("aaa", target.readUtf8());
+  }
+
+  @Ignore
+  @Test public void snapshotReportsAccurateSize() throws Exception {
+    Buffer buf = new Buffer().write(new byte[] { 0, 1, 2, 3 });
+    assertEquals(1, buf.snapshot(1).size());
   }
 
   /**

--- a/okio/src/test/java/okio/BufferTest.java
+++ b/okio/src/test/java/okio/BufferTest.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
@@ -586,7 +585,6 @@ public final class BufferTest {
     assertEquals("aaa", target.readUtf8());
   }
 
-  @Ignore
   @Test public void snapshotReportsAccurateSize() throws Exception {
     Buffer buf = new Buffer().write(new byte[] { 0, 1, 2, 3 });
     assertEquals(1, buf.snapshot(1).size());


### PR DESCRIPTION
Closes #192. #Closes #193. 