### PR TITLE
Change write timeouts to have a maximum write size.

### DIFF
--- a/okio/src/test/java/okio/AsyncTimeoutTest.java
+++ b/okio/src/test/java/okio/AsyncTimeoutTest.java
@@ -19,11 +19,13 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 
+import static okio.TestUtil.bufferWithRandomSegmentLayout;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -192,8 +194,9 @@ public class AsyncTimeoutTest {
     AsyncTimeout timeout = new AsyncTimeout();
     timeout.timeout(250, TimeUnit.MILLISECONDS);
     Sink timeoutSink = timeout.sink(sink);
+    Buffer data = new Buffer().writeUtf8("a");
     try {
-      timeoutSink.write(null, 0);
+      timeoutSink.write(data, 1);
       fail();
     } catch (InterruptedIOException expected) {
     }
@@ -234,8 +237,9 @@ public class AsyncTimeoutTest {
     AsyncTimeout timeout = new AsyncTimeout();
     timeout.timeout(250, TimeUnit.MILLISECONDS);
     Sink timeoutSink = timeout.sink(sink);
+    Buffer data = new Buffer().writeUtf8("a");
     try {
-      timeoutSink.write(null, 0);
+      timeoutSink.write(data, 1);
       fail();
     } catch (InterruptedIOException expected) {
       assertEquals("timeout", expected.getMessage());
@@ -252,12 +256,48 @@ public class AsyncTimeoutTest {
     AsyncTimeout timeout = new AsyncTimeout();
     timeout.timeout(250, TimeUnit.MILLISECONDS);
     Sink timeoutSink = timeout.sink(sink);
+    Buffer data = new Buffer().writeUtf8("a");
     try {
-      timeoutSink.write(null, 0);
+      timeoutSink.write(data, 1);
       fail();
     } catch (IOException expected) {
       assertEquals("no timeout occurred", expected.getMessage());
     }
+  }
+
+  /**
+   * We had a bug where writing a very large buffer would fail with an
+   * unexpected timeout because although the sink was making steady forward
+   * progress, doing it all as a single write caused a timeout.
+   */
+  @Test public void sinkSplitsLargeWrites() throws Exception {
+    byte[] data = new byte[512 * 1024];
+    Random dice = new Random(0);
+    dice.nextBytes(data);
+    final Buffer source = bufferWithRandomSegmentLayout(dice, data);
+    final Buffer target = new Buffer();
+
+    Sink sink = new ForwardingSink(new Buffer()) {
+      @Override public void write(Buffer source, long byteCount) throws IOException {
+        try {
+          Thread.sleep(byteCount / 500); // ~500 KiB/s.
+          target.write(source, byteCount);
+        } catch (InterruptedException e) {
+          throw new AssertionError();
+        }
+      }
+    };
+
+    // Timeout after 250 ms of inactivity.
+    AsyncTimeout timeout = new AsyncTimeout();
+    timeout.timeout(250, TimeUnit.MILLISECONDS);
+    Sink timeoutSink = timeout.sink(sink);
+
+    // Transmit 500 KiB of data, which should take ~1 second. But expect no timeout!
+    timeoutSink.write(source, source.size());
+
+    // The data should all have arrived.
+    assertEquals(ByteString.of(data), target.readByteString());
   }
 
   /** Asserts which timeouts fired, and in which order. */

--- a/okio/src/test/java/okio/BufferTest.java
+++ b/okio/src/test/java/okio/BufferTest.java
@@ -25,6 +25,7 @@ import java.util.Random;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
+import static okio.TestUtil.bufferWithRandomSegmentLayout;
 import static okio.TestUtil.repeat;
 import static okio.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
@@ -588,30 +589,5 @@ public final class BufferTest {
   @Test public void snapshotReportsAccurateSize() throws Exception {
     Buffer buf = new Buffer().write(new byte[] { 0, 1, 2, 3 });
     assertEquals(1, buf.snapshot(1).size());
-  }
-
-  /**
-   * Returns a new buffer containing the data in {@code data}, and a segment
-   * layout determined by {@code dice}.
-   */
-  private Buffer bufferWithRandomSegmentLayout(Random dice, byte[] data) throws IOException {
-    Buffer result = new Buffer();
-
-    // Writing to result directly will yield packed segments. Instead, write to
-    // other buffers, then write those buffers to result.
-    for (int pos = 0, byteCount; pos < data.length; pos += byteCount) {
-      byteCount = (Segment.SIZE / 2) + dice.nextInt(Segment.SIZE / 2);
-      if (byteCount > data.length - pos) byteCount = data.length - pos;
-      int offset = dice.nextInt(Segment.SIZE - byteCount);
-
-      Buffer segment = new Buffer();
-      segment.write(new byte[offset]);
-      segment.write(data, pos, byteCount);
-      segment.skip(offset);
-
-      result.write(segment, byteCount);
-    }
-
-    return result;
   }
 }


### PR DESCRIPTION
Previously large writes could easly suffer timeouts because the entire
write was subject to a single timeout.

With this change we split the write up into 64 KiB chunks and each
chunk gets its own timeout window. This way the timeout is more granular:
it triggers if the write fails to make forward progress, not if the
entire write fails to complete within its window.

See https://github.com/square/okhttp/issues/2122