### PR TITLE
Simplifies the Watchdog thread impl by using a DelayQueue.

### DIFF
--- a/okio/src/main/java/okio/AsyncTimeout.java
+++ b/okio/src/main/java/okio/AsyncTimeout.java
@@ -137,15 +137,10 @@ public class AsyncTimeout extends Timeout implements Delayed {
 
   @Override
   public final int compareTo(Delayed that) {
-    long thisDelay = getDelay(TimeUnit.NANOSECONDS);
-    long thatDelay = that.getDelay(TimeUnit.NANOSECONDS);
-    if (thisDelay == thatDelay) {
-      return 0;
-    } else if (thisDelay < thatDelay) {
-      return -1;
-    } else {
-      return 1;
+    if (that instanceof AsyncTimeout) {
+      return (int) (timeoutAt - ((AsyncTimeout) that).timeoutAt);
     }
+    return (int) (getDelay(TimeUnit.NANOSECONDS) - that.getDelay(TimeUnit.NANOSECONDS));
   }
 
   /**


### PR DESCRIPTION
Also lowers thread priority and adds an explicit yield between processed items.
I'm hoping this can ameliorate or at least help narrow down CPU issues related to #185 . I wasn't able to repro as severely as some of the original reporters, but this does seem to hit the watchdog less. Any thoughts on better ways to verify this would be awesome.