### PR TITLE
Add md5(), sha1(), and sha256() methods to Buffer.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -1400,6 +1400,34 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return result;
   }
 
+  /** Returns the MD5 hash of this buffer. */
+  public ByteString md5() {
+    return digest("MD5");
+  }
+
+  /** Returns the SHA-1 hash of this buffer. */
+  public ByteString sha1() {
+    return digest("SHA-1");
+  }
+
+  /** Returns the SHA-256 hash of this buffer. */
+  public ByteString sha256() {
+    return digest("SHA-256");
+  }
+
+  private ByteString digest(String algorithm) {
+    try {
+      MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
+      messageDigest.update(head.data, head.pos, head.limit - head.pos);
+      for (Segment s = head.next; s != head; s = s.next) {
+        messageDigest.update(s.data, s.pos, s.limit - s.pos);
+      }
+      return ByteString.of(messageDigest.digest());
+    } catch (NoSuchAlgorithmException e) {
+      throw new AssertionError();
+    }
+  }
+
   @Override public boolean equals(Object o) {
     if (this == o) return true;
     if (!(o instanceof Buffer)) return false;
@@ -1456,17 +1484,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
       return String.format("Buffer[size=%s data=%s]", size, data.hex());
     }
 
-    try {
-      MessageDigest md5 = MessageDigest.getInstance("MD5");
-      md5.update(head.data, head.pos, head.limit - head.pos);
-      for (Segment s = head.next; s != head; s = s.next) {
-        md5.update(s.data, s.pos, s.limit - s.pos);
-      }
-      return String.format("Buffer[size=%s md5=%s]",
-          size, ByteString.of(md5.digest()).hex());
-    } catch (NoSuchAlgorithmException e) {
-      throw new AssertionError();
-    }
+    return String.format("Buffer[size=%s md5=%s]", size, md5().hex());
   }
 
   /** Returns a deep copy of this buffer. */

--- a/okio/src/main/java/okio/ByteString.java
+++ b/okio/src/main/java/okio/ByteString.java
@@ -110,14 +110,19 @@ public class ByteString implements Serializable, Comparable<ByteString> {
     return digest("MD5");
   }
 
+  /** Returns the SHA-1 hash of this byte string. */
+  public ByteString sha1() {
+    return digest("SHA-1");
+  }
+
   /** Returns the SHA-256 hash of this byte string. */
   public ByteString sha256() {
     return digest("SHA-256");
   }
 
-  private ByteString digest(String digest) {
+  private ByteString digest(String algorithm) {
     try {
-      return ByteString.of(MessageDigest.getInstance(digest).digest(data));
+      return ByteString.of(MessageDigest.getInstance(algorithm).digest(data));
     } catch (NoSuchAlgorithmException e) {
       throw new AssertionError(e);
     }

--- a/okio/src/main/java/okio/HashingSink.java
+++ b/okio/src/main/java/okio/HashingSink.java
@@ -42,34 +42,26 @@ public final class HashingSink extends ForwardingSink {
 
   /** Returns a sink that uses the obsolete MD5 hash algorithm. */
   public static HashingSink md5(Sink sink) {
-    try {
-      return new HashingSink(sink, MessageDigest.getInstance("MD5"));
-    } catch (NoSuchAlgorithmException e) {
-      throw new AssertionError();
-    }
+    return new HashingSink(sink, "MD5");
   }
 
   /** Returns a sink that uses the obsolete SHA-1 hash algorithm. */
   public static HashingSink sha1(Sink sink) {
-    try {
-      return new HashingSink(sink, MessageDigest.getInstance("SHA-1"));
-    } catch (NoSuchAlgorithmException e) {
-      throw new AssertionError();
-    }
+    return new HashingSink(sink, "SHA-1");
   }
 
   /** Returns a sink that uses the SHA-256 hash algorithm. */
   public static HashingSink sha256(Sink sink) {
+    return new HashingSink(sink, "SHA-256");
+  }
+
+  private HashingSink(Sink sink, String algorithm) {
+    super(sink);
     try {
-      return new HashingSink(sink, MessageDigest.getInstance("SHA-256"));
+      this.messageDigest = MessageDigest.getInstance(algorithm);
     } catch (NoSuchAlgorithmException e) {
       throw new AssertionError();
     }
-  }
-
-  private HashingSink(Sink sink, MessageDigest messageDigest) {
-    super(sink);
-    this.messageDigest = messageDigest;
   }
 
   @Override public void write(Buffer source, long byteCount) throws IOException {

--- a/okio/src/main/java/okio/HashingSource.java
+++ b/okio/src/main/java/okio/HashingSource.java
@@ -40,34 +40,26 @@ public final class HashingSource extends ForwardingSource {
 
   /** Returns a sink that uses the obsolete MD5 hash algorithm. */
   public static HashingSource md5(Source source) {
-    try {
-      return new HashingSource(source, MessageDigest.getInstance("MD5"));
-    } catch (NoSuchAlgorithmException e) {
-      throw new AssertionError();
-    }
+    return new HashingSource(source, "MD5");
   }
 
   /** Returns a sink that uses the obsolete SHA-1 hash algorithm. */
   public static HashingSource sha1(Source source) {
-    try {
-      return new HashingSource(source, MessageDigest.getInstance("SHA-1"));
-    } catch (NoSuchAlgorithmException e) {
-      throw new AssertionError();
-    }
+    return new HashingSource(source, "SHA-1");
   }
 
   /** Returns a sink that uses the SHA-256 hash algorithm. */
   public static HashingSource sha256(Source source) {
+    return new HashingSource(source, "SHA-256");
+  }
+
+  private HashingSource(Source source, String algorithm) {
+    super(source);
     try {
-      return new HashingSource(source, MessageDigest.getInstance("SHA-256"));
+      this.messageDigest = MessageDigest.getInstance(algorithm);
     } catch (NoSuchAlgorithmException e) {
       throw new AssertionError();
     }
-  }
-
-  private HashingSource(Source source, MessageDigest messageDigest) {
-    super(source);
-    this.messageDigest = messageDigest;
   }
 
   @Override public long read(Buffer sink, long byteCount) throws IOException {

--- a/okio/src/test/java/okio/ByteStringTest.java
+++ b/okio/src/test/java/okio/ByteStringTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class ByteStringTest {
+public final class ByteStringTest {
   @Test public void ofCopyRange() {
     byte[] bytes = "Hello, World!".getBytes(Util.UTF_8);
     ByteString byteString = ByteString.of(bytes, 2, 9);
@@ -74,24 +74,6 @@ public class ByteStringTest {
     assertByteArraysEquals(byteString.toByteArray(), bronzeHorseman.getBytes(Util.UTF_8));
     assertTrue(byteString.equals(ByteString.of(bronzeHorseman.getBytes(Util.UTF_8))));
     assertEquals(byteString.utf8(), bronzeHorseman);
-  }
-
-  @Test public void md5() {
-    assertEquals("6cd3556deb0da54bca060b4c39479839",
-        ByteString.encodeUtf8("Hello, world!").md5().hex());
-    assertEquals("c71dc6df4b2e434b8c74fd6dd6ca3f85",
-        ByteString.encodeUtf8("One Two Three").md5().hex());
-    assertEquals("37b69fb926e239e049d7e43987974b99",
-        ByteString.encodeUtf8(bronzeHorseman).md5().hex());
-  }
-
-  @Test public void sha256() {
-    assertEquals("315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3",
-        ByteString.encodeUtf8("Hello, world!").sha256().hex());
-    assertEquals("641e54ba5e49e169408148a25bef8ca8fa4f8aab222fe8ce4b3535a570ddd68e",
-        ByteString.encodeUtf8("One Two Three").sha256().hex());
-    assertEquals("4d869e1c3d94568a5344235d9e4f187b8d5d78d06c5c622854c669f2f582d33e",
-        ByteString.encodeUtf8(bronzeHorseman).sha256().hex());
   }
 
   @Test public void testHashCode() throws Exception {

--- a/okio/src/test/java/okio/HashingSinkTest.java
+++ b/okio/src/test/java/okio/HashingSinkTest.java
@@ -17,21 +17,15 @@ package okio;
 
 import org.junit.Test;
 
+import static okio.HashingTest.MD5_abc;
+import static okio.HashingTest.SHA1_abc;
+import static okio.HashingTest.SHA256_abc;
+import static okio.HashingTest.SHA256_def;
+import static okio.HashingTest.SHA256_x32k;
+import static okio.HashingTest.x32k;
 import static org.junit.Assert.assertEquals;
 
 public final class HashingSinkTest {
-  private static final ByteString MD5_abc = ByteString.decodeHex(
-      "900150983cd24fb0d6963f7d28e17f72");
-  private static final ByteString SHA1_abc = ByteString.decodeHex(
-      "a9993e364706816aba3e25717850c26c9cd0d89d");
-  private static final ByteString SHA256_abc = ByteString.decodeHex(
-      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
-  private static final ByteString SHA256_def = ByteString.decodeHex(
-      "cb8379ac2098aa165029e3938a51da0bcecfc008fd6795f401178647f96c5b34");
-  private static final ByteString SHA256_x32k = ByteString.decodeHex(
-      "427965f49a857174e308658227325dbd23ff4eccbe399d5ad4817dda3ec79f87");
-  private static final String x32k = TestUtil.repeat('x', 32768);
-
   private final Buffer source = new Buffer();
   private final Buffer sink = new Buffer();
 

--- a/okio/src/test/java/okio/HashingSourceTest.java
+++ b/okio/src/test/java/okio/HashingSourceTest.java
@@ -17,21 +17,15 @@ package okio;
 
 import org.junit.Test;
 
+import static okio.HashingTest.MD5_abc;
+import static okio.HashingTest.SHA1_abc;
+import static okio.HashingTest.SHA256_abc;
+import static okio.HashingTest.SHA256_def;
+import static okio.HashingTest.SHA256_x32k;
+import static okio.HashingTest.x32k;
 import static org.junit.Assert.assertEquals;
 
 public final class HashingSourceTest {
-  private static final ByteString MD5_abc = ByteString.decodeHex(
-      "900150983cd24fb0d6963f7d28e17f72");
-  private static final ByteString SHA1_abc = ByteString.decodeHex(
-      "a9993e364706816aba3e25717850c26c9cd0d89d");
-  private static final ByteString SHA256_abc = ByteString.decodeHex(
-      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
-  private static final ByteString SHA256_def = ByteString.decodeHex(
-      "cb8379ac2098aa165029e3938a51da0bcecfc008fd6795f401178647f96c5b34");
-  private static final ByteString SHA256_x32k = ByteString.decodeHex(
-      "427965f49a857174e308658227325dbd23ff4eccbe399d5ad4817dda3ec79f87");
-  private static final String x32k = TestUtil.repeat('x', 32768);
-
   private final Buffer source = new Buffer();
   private final Buffer sink = new Buffer();
 

--- a/okio/src/test/java/okio/HashingTest.java
+++ b/okio/src/test/java/okio/HashingTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public final class HashingTest {
+  public static final ByteString MD5_abc = ByteString.decodeHex(
+      "900150983cd24fb0d6963f7d28e17f72");
+  public static final ByteString SHA1_abc = ByteString.decodeHex(
+      "a9993e364706816aba3e25717850c26c9cd0d89d");
+  public static final ByteString SHA256_abc = ByteString.decodeHex(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  public static final ByteString SHA256_def = ByteString.decodeHex(
+      "cb8379ac2098aa165029e3938a51da0bcecfc008fd6795f401178647f96c5b34");
+  public static final ByteString SHA256_x32k = ByteString.decodeHex(
+      "427965f49a857174e308658227325dbd23ff4eccbe399d5ad4817dda3ec79f87");
+  public static final String x32k = TestUtil.repeat('x', 32768);
+
+  @Test public void byteStringMd5() {
+    assertEquals(MD5_abc, ByteString.encodeUtf8("abc").md5());
+  }
+
+  @Test public void byteStringSha1() {
+    assertEquals(SHA1_abc, ByteString.encodeUtf8("abc").sha1());
+  }
+
+  @Test public void byteStringSha256() {
+    assertEquals(SHA256_abc, ByteString.encodeUtf8("abc").sha256());
+  }
+
+  @Test public void bufferMd5() {
+    assertEquals(MD5_abc, new Buffer().writeUtf8("abc").md5());
+  }
+
+  @Test public void bufferSha1() {
+    assertEquals(SHA1_abc, new Buffer().writeUtf8("abc").sha1());
+  }
+
+  @Test public void bufferSha256() {
+    assertEquals(SHA256_abc, new Buffer().writeUtf8("abc").sha256());
+  }
+
+  @Test public void bufferHashIsNotDestructive() {
+    Buffer buffer = new Buffer();
+
+    buffer.writeUtf8("abc");
+    assertEquals(SHA256_abc, buffer.sha256());
+    assertEquals("abc", buffer.readUtf8());
+
+    buffer.writeUtf8("def");
+    assertEquals(SHA256_def, buffer.sha256());
+    assertEquals("def", buffer.readUtf8());
+
+    buffer.writeUtf8(x32k);
+    assertEquals(SHA256_x32k, buffer.sha256());
+    assertEquals(x32k, buffer.readUtf8());
+  }
+}


### PR DESCRIPTION
Make it a little more extravagant.

Closes https://github.com/square/okio/issues/195