### PR TITLE
fix wrong changelog date for Version 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Change Log
 
 ## Version 1.7.0
 
-_2015-04-10_
+_2016-04-10_
 
  * New: Change the segment size to 8 KiB. This has been reported to dramatically
    improver performance in some applications.


### PR DESCRIPTION
@swankjesse forgot in his commit 0b3635a34b2e2f02572f62bb989ec8ac053dcf99 that this year marks the **2016** anniversary of jesus christ death.

This PR changes the changelog date for version `1.7.0` from _2015-04-10_ to _2016-04-10_