### PR TITLE
Implement BufferedSource.select(List<ByteString>).

### DIFF
--- a/okio/src/main/java/okio/BufferedSource.java
+++ b/okio/src/main/java/okio/BufferedSource.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.List;
 
 /**
  * A source that keeps a buffer internally so that callers can do small reads without a performance
@@ -245,6 +246,33 @@ public interface BufferedSource extends Source {
 
   /** Removes {@code byteCount} bytes from this and returns them as a byte string. */
   ByteString readByteString(long byteCount) throws IOException;
+
+  /**
+   * Finds the first string in {@code byteStrings} that is a prefix of this buffer, consumes it from
+   * this buffer, and returns its index. If no byte string in {@code byteStrings} is a prefix of
+   * this buffer this returns -1 and no bytes are consumed.
+   *
+   * <p>This can be used as an alternative to {@link #readByteString} or even {@link #readUtf8} if
+   * the set of expected values is known in advance. <pre>{@code
+   *
+   *   List<ByteString> FIELDS = Arrays.asList(
+   *       ByteString.encodeUtf8("depth="),
+   *       ByteString.encodeUtf8("height="),
+   *       ByteString.encodeUtf8("width="));
+   *
+   *   Buffer buffer = new Buffer()
+   *       .writeUtf8("width=640\n")
+   *       .writeUtf8("height=480\n");
+   *
+   *   assertEquals(2, buffer.select(FIELDS));
+   *   assertEquals(640, buffer.readDecimalLong());
+   *   assertEquals('\n', buffer.readByte());
+   *   assertEquals(1, buffer.select(FIELDS));
+   *   assertEquals(480, buffer.readDecimalLong());
+   *   assertEquals('\n', buffer.readByte());
+   * }</pre>
+   */
+  int select(List<ByteString> byteStrings) throws IOException;
 
   /** Removes all bytes from this and returns them as a byte array. */
   byte[] readByteArray() throws IOException;

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -19,6 +19,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.List;
 
 import static okio.Util.checkOffsetAndCount;
 
@@ -81,6 +82,25 @@ final class RealBufferedSource implements BufferedSource {
   @Override public ByteString readByteString(long byteCount) throws IOException {
     require(byteCount);
     return buffer.readByteString(byteCount);
+  }
+
+  @Override public int select(List<ByteString> byteStrings) throws IOException {
+    if (closed) throw new IllegalStateException("closed");
+
+    while (true) {
+      int index = buffer.selectPrefix(byteStrings);
+      if (index == -1) return -1;
+
+      // If the prefix match actually matched a full byte string, consume it and return it.
+      int selectedSize = byteStrings.get(index).size();
+      if (selectedSize <= buffer.size) {
+        buffer.skip(selectedSize);
+        return index;
+      }
+
+      // We need to grow the buffer. Do that, then try it all again.
+      if (source.read(buffer, Segment.SIZE) == -1) return -1;
+    }
   }
 
   @Override public byte[] readByteArray() throws IOException {

--- a/okio/src/test/java/okio/BufferedSourceTest.java
+++ b/okio/src/test/java/okio/BufferedSourceTest.java
@@ -810,4 +810,109 @@ public class BufferedSourceTest {
     assertLongDecimalString("-00000000000000009223372036854775808", -9223372036854775808L);
     assertLongDecimalString(TestUtil.repeat('0', Segment.SIZE + 1) + "1", 1);
   }
+
+  @Test public void select() throws IOException {
+    List<ByteString> selection = Arrays.asList(
+        ByteString.encodeUtf8("ROCK"),
+        ByteString.encodeUtf8("SCISSORS"),
+        ByteString.encodeUtf8("PAPER"));
+
+    sink.writeUtf8("PAPER,SCISSORS,ROCK");
+    assertEquals(2, source.select(selection));
+    assertEquals(',', source.readByte());
+    assertEquals(1, source.select(selection));
+    assertEquals(',', source.readByte());
+    assertEquals(0, source.select(selection));
+    assertTrue(source.exhausted());
+  }
+
+  @Test public void selectSpanningMultipleSegments() throws IOException {
+    ByteString commonPrefix = TestUtil.randomBytes(Segment.SIZE + 10);
+    ByteString a = new Buffer().write(commonPrefix).writeUtf8("a").readByteString();
+    ByteString bc = new Buffer().write(commonPrefix).writeUtf8("bc").readByteString();
+    ByteString bd = new Buffer().write(commonPrefix).writeUtf8("bd").readByteString();
+    List<ByteString> selection = Arrays.asList(a, bc, bd);
+
+    sink.write(bd);
+    sink.write(a);
+    sink.write(bc);
+
+    assertEquals(2, source.select(selection));
+    assertEquals(0, source.select(selection));
+    assertEquals(1, source.select(selection));
+    assertTrue(source.exhausted());
+  }
+
+  @Test public void selectNotFound() throws IOException {
+    List<ByteString> selection = Arrays.asList(
+        ByteString.encodeUtf8("ROCK"),
+        ByteString.encodeUtf8("SCISSORS"),
+        ByteString.encodeUtf8("PAPER"));
+
+    sink.writeUtf8("SPOCK");
+    assertEquals(-1, source.select(selection));
+    assertEquals("SPOCK", source.readUtf8());
+  }
+
+  @Test public void selectValuesHaveCommonPrefix() throws IOException {
+    List<ByteString> selection = Arrays.asList(
+        ByteString.encodeUtf8("abcd"),
+        ByteString.encodeUtf8("abce"),
+        ByteString.encodeUtf8("abcc"));
+
+    sink.writeUtf8("abcc").writeUtf8("abcd").writeUtf8("abce");
+    assertEquals(2, source.select(selection));
+    assertEquals(0, source.select(selection));
+    assertEquals(1, source.select(selection));
+  }
+
+  @Test public void selectLongerThanSource() throws IOException {
+    List<ByteString> selection = Arrays.asList(
+        ByteString.encodeUtf8("abcd"),
+        ByteString.encodeUtf8("abce"),
+        ByteString.encodeUtf8("abcc"));
+    sink.writeUtf8("abc");
+    assertEquals(-1, source.select(selection));
+    assertEquals("abc", source.readUtf8());
+  }
+
+  @Test public void selectReturnsFirstByteStringThatMatches() throws IOException {
+    List<ByteString> selection = Arrays.asList(
+        ByteString.encodeUtf8("abcd"),
+        ByteString.encodeUtf8("abc"),
+        ByteString.encodeUtf8("abcde"));
+    sink.writeUtf8("abcdef");
+    assertEquals(0, source.select(selection));
+    assertEquals("ef", source.readUtf8());
+  }
+
+  @Test public void selectNoByteStrings() throws IOException {
+    List<ByteString> selection = Arrays.asList();
+    sink.writeUtf8("abc");
+    assertEquals(-1, source.select(selection));
+  }
+
+  @Test public void selectFromEmptySource() throws IOException {
+    List<ByteString> selection = Arrays.asList(
+        ByteString.encodeUtf8("abc"),
+        ByteString.encodeUtf8("def"));
+    assertEquals(-1, source.select(selection));
+  }
+
+  @Test public void selectNoByteStringsFromEmptySource() throws IOException {
+    List<ByteString> selection = Arrays.asList();
+    assertEquals(-1, source.select(selection));
+  }
+
+  @Test public void selectEmptyByteString() throws IOException {
+    List<ByteString> selection = Arrays.asList(ByteString.of());
+    sink.writeUtf8("abc");
+    assertEquals(0, source.select(selection));
+    assertEquals("abc", source.readUtf8());
+  }
+
+  @Test public void selectEmptyByteStringFromEmptySource() throws IOException {
+    List<ByteString> selection = Arrays.asList(ByteString.of());
+    assertEquals(0, source.select(selection));
+  }
 }


### PR DESCRIPTION
I spent a lot of time working on an alternate version that took a
Selection object. It modeled a 'compiled' variant of the List<String>
that had certain optimizations applied. Unfortunately the benefits
of these optimizations weren't worth the complexity: they improved
performance only when the choices were very long strings.

This API is not particularly extensible. If we ever found optimizations
that require the bytestrings to be sorted, or converted into a trie,
or something else, this API prevents that. From my investigation this
is a reasonable tradeoff; those approaches have been explored and aren't
that compelling!