### PR TITLE
Friendlier toString for ByteStrings and Buffers.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -644,7 +644,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
       Buffer data = new Buffer();
       copyTo(data, 0, Math.min(32, size));
       throw new EOFException("\\n not found: size=" + size()
-          + " content=" + data.readByteString().hex() + "...");
+          + " content=" + data.readByteString().hex() + "…");
     }
     return readUtf8Line(newline);
   }
@@ -1587,17 +1587,12 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return result;
   }
 
+  /**
+   * Returns a human-readable string that describes the contents of this buffer. Typically this
+   * is a string like {@code [text=Hello]} or {@code [hex=0000ffff]}.
+   */
   @Override public String toString() {
-    if (size == 0) {
-      return "Buffer[size=0]";
-    }
-
-    if (size <= 16) {
-      ByteString data = clone().readByteString();
-      return String.format("Buffer[size=%s data=%s]", size, data.hex());
-    }
-
-    return String.format("Buffer[size=%s md5=%s]", size, md5().hex());
+    return snapshot().toString();
   }
 
   /** Returns a deep copy of this buffer. */

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -212,7 +212,7 @@ final class RealBufferedSource implements BufferedSource {
       Buffer data = new Buffer();
       buffer.copyTo(data, 0, Math.min(32, buffer.size()));
       throw new EOFException("\\n not found: size=" + buffer.size()
-          + " content=" + data.readByteString().hex() + "...");
+          + " content=" + data.readByteString().hex() + "…");
     }
     return buffer.readUtf8Line(newline);
   }

--- a/okio/src/test/java/okio/BufferTest.java
+++ b/okio/src/test/java/okio/BufferTest.java
@@ -72,27 +72,19 @@ public final class BufferTest {
     assertEquals(Segment.SIZE * 3, buffer.completeSegmentByteCount());
   }
 
-  @Test public void toStringOnEmptyBuffer() throws Exception {
-    Buffer buffer = new Buffer();
-    assertEquals("Buffer[size=0]", buffer.toString());
-  }
-
-  @Test public void toStringOnSmallBufferIncludesContents() throws Exception {
-    Buffer buffer = new Buffer();
-    buffer.write(ByteString.decodeHex("a1b2c3d4e5f61a2b3c4d5e6f10203040"));
-    assertEquals("Buffer[size=16 data=a1b2c3d4e5f61a2b3c4d5e6f10203040]", buffer.toString());
-  }
-
-  @Test public void toStringOnLargeBufferIncludesMd5() throws Exception {
-    Buffer buffer = new Buffer();
-    buffer.write(ByteString.encodeUtf8("12345678901234567"));
-    assertEquals("Buffer[size=17 md5=2c9728a2138b2f25e9f89f99bdccf8db]", buffer.toString());
-  }
-
-  @Test public void toStringOnMultipleSegmentBuffer() throws Exception {
-    Buffer buffer = new Buffer();
-    buffer.writeUtf8(repeat('a', 6144));
-    assertEquals("Buffer[size=6144 md5=d890021f28522533c1cc1b9b1f83ce73]", buffer.toString());
+  /** Buffer's toString is the same as ByteString's. */
+  @Test public void bufferToString() throws Exception {
+    assertEquals("[size=0]", new Buffer().toString());
+    assertEquals("[text=a\\r\\nb\\nc\\rd\\\\e]",
+        new Buffer().writeUtf8("a\r\nb\nc\rd\\e").toString());
+    assertEquals("[text=Tyrannosaur]",
+        new Buffer().writeUtf8("Tyrannosaur").toString());
+    assertEquals("[text=təˈranəˌsôr]", new Buffer()
+        .write(ByteString.decodeHex("74c999cb8872616ec999cb8c73c3b472"))
+        .toString());
+    assertEquals("[hex=0000000000000000000000000000000000000000000000000000000000000000000000000000"
+        + "0000000000000000000000000000000000000000000000000000]",
+        new Buffer().write(new byte[64]).toString());
   }
 
   @Test public void multipleSegmentBuffers() throws Exception {

--- a/okio/src/test/java/okio/BufferedSinkTest.java
+++ b/okio/src/test/java/okio/BufferedSinkTest.java
@@ -87,7 +87,7 @@ public final class BufferedSinkTest {
     sink.writeByte(0xab);
     sink.writeByte(0xcd);
     sink.flush();
-    assertEquals("Buffer[size=2 data=abcd]", data.toString());
+    assertEquals("[hex=abcd]", data.toString());
   }
 
   @Test public void writeLastByteInSegment() throws Exception {
@@ -97,28 +97,28 @@ public final class BufferedSinkTest {
     sink.flush();
     assertEquals(asList(Segment.SIZE, 1), data.segmentSizes());
     assertEquals(repeat('a', Segment.SIZE - 1), data.readUtf8(Segment.SIZE - 1));
-    assertEquals("Buffer[size=2 data=2021]", data.toString());
+    assertEquals("[text= !]", data.toString());
   }
 
   @Test public void writeShort() throws Exception {
     sink.writeShort(0xabcd);
     sink.writeShort(0x4321);
     sink.flush();
-    assertEquals("Buffer[size=4 data=abcd4321]", data.toString());
+    assertEquals("[hex=abcd4321]", data.toString());
   }
 
   @Test public void writeShortLe() throws Exception {
-    sink.writeShortLe(0xabcd);
-    sink.writeShortLe(0x4321);
+    sink.writeShortLe(0xcdab);
+    sink.writeShortLe(0x2143);
     sink.flush();
-    assertEquals("Buffer[size=4 data=cdab2143]", data.toString());
+    assertEquals("[hex=abcd4321]", data.toString());
   }
 
   @Test public void writeInt() throws Exception {
     sink.writeInt(0xabcdef01);
     sink.writeInt(0x87654321);
     sink.flush();
-    assertEquals("Buffer[size=8 data=abcdef0187654321]", data.toString());
+    assertEquals("[hex=abcdef0187654321]", data.toString());
   }
 
   @Test public void writeLastIntegerInSegment() throws Exception {
@@ -128,7 +128,7 @@ public final class BufferedSinkTest {
     sink.flush();
     assertEquals(asList(Segment.SIZE, 4), data.segmentSizes());
     assertEquals(repeat('a', Segment.SIZE - 4), data.readUtf8(Segment.SIZE - 4));
-    assertEquals("Buffer[size=8 data=abcdef0187654321]", data.toString());
+    assertEquals("[hex=abcdef0187654321]", data.toString());
   }
 
   @Test public void writeIntegerDoesNotQuiteFitInSegment() throws Exception {
@@ -138,28 +138,28 @@ public final class BufferedSinkTest {
     sink.flush();
     assertEquals(asList(Segment.SIZE - 3, 8), data.segmentSizes());
     assertEquals(repeat('a', Segment.SIZE - 3), data.readUtf8(Segment.SIZE - 3));
-    assertEquals("Buffer[size=8 data=abcdef0187654321]", data.toString());
+    assertEquals("[hex=abcdef0187654321]", data.toString());
   }
 
   @Test public void writeIntLe() throws Exception {
     sink.writeIntLe(0xabcdef01);
     sink.writeIntLe(0x87654321);
     sink.flush();
-    assertEquals("Buffer[size=8 data=01efcdab21436587]", data.toString());
+    assertEquals("[hex=01efcdab21436587]", data.toString());
   }
 
   @Test public void writeLong() throws Exception {
     sink.writeLong(0xabcdef0187654321L);
     sink.writeLong(0xcafebabeb0b15c00L);
     sink.flush();
-    assertEquals("Buffer[size=16 data=abcdef0187654321cafebabeb0b15c00]", data.toString());
+    assertEquals("[hex=abcdef0187654321cafebabeb0b15c00]", data.toString());
   }
 
   @Test public void writeLongLe() throws Exception {
     sink.writeLongLe(0xabcdef0187654321L);
     sink.writeLongLe(0xcafebabeb0b15c00L);
     sink.flush();
-    assertEquals("Buffer[size=16 data=2143658701efcdab005cb1b0bebafeca]", data.toString());
+    assertEquals("[hex=2143658701efcdab005cb1b0bebafeca]", data.toString());
   }
 
   @Test public void writeStringUtf8() throws IOException {

--- a/okio/src/test/java/okio/ByteStringTest.java
+++ b/okio/src/test/java/okio/ByteStringTest.java
@@ -406,18 +406,51 @@ public final class ByteStringTest {
     }
   }
 
-  @Test public void toStringOnEmptyByteString() {
-    assertEquals("ByteString[size=0]", ByteString.of().toString());
+  @Test public void toStringOnEmpty() {
+    assertEquals("[size=0]", factory.decodeHex("").toString());
   }
 
-  @Test public void toStringOnSmallByteStringIncludesContents() {
-    assertEquals("ByteString[size=16 data=a1b2c3d4e5f61a2b3c4d5e6f10203040]",
-        factory.decodeHex("a1b2c3d4e5f61a2b3c4d5e6f10203040").toString());
+  @Test public void toStringOnShortText() {
+    assertEquals("[text=Tyrannosaur]",
+        factory.encodeUtf8("Tyrannosaur").toString());
+    assertEquals("[text=təˈranəˌsôr]",
+        factory.decodeHex("74c999cb8872616ec999cb8c73c3b472").toString());
   }
 
-  @Test public void toStringOnLargeByteStringIncludesMd5() {
-    assertEquals("ByteString[size=17 md5=2c9728a2138b2f25e9f89f99bdccf8db]",
-        factory.encodeUtf8("12345678901234567").toString());
+  @Test public void toStringOnLongTextIsTruncated() {
+    String raw = "Um, I'll tell you the problem with the scientific power that you're using here, "
+        + "it didn't require any discipline to attain it. You read what others had done and you "
+        + "took the next step. You didn't earn the knowledge for yourselves, so you don't take any "
+        + "responsibility for it. You stood on the shoulders of geniuses to accomplish something "
+        + "as fast as you could, and before you even knew what you had, you patented it, and "
+        + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
+        + "sell it.";
+    assertEquals("[size=517 text=Um, I'll tell you the problem with the scientific power that "
+        + "you…]", factory.encodeUtf8(raw).toString());
+  }
+
+  @Test public void toStringOnTextWithNewlines() {
+    // Instead of emitting a literal newline in the toString(), these are escaped as "\n".
+    assertEquals("[text=a\\r\\nb\\nc\\rd\\\\e]",
+        factory.encodeUtf8("a\r\nb\nc\rd\\e").toString());
+  }
+
+  @Test public void toStringOnData() {
+    ByteString byteString = factory.decodeHex(""
+        + "60b420bb3851d9d47acb933dbe70399bf6c92da33af01d4fb770e98c0325f41d3ebaf8986da712c82bcd4d55"
+        + "4bf0b54023c29b624de9ef9c2f931efc580f9afb");
+    assertEquals("[hex="
+        + "60b420bb3851d9d47acb933dbe70399bf6c92da33af01d4fb770e98c0325f41d3ebaf8986da712c82bcd4d55"
+        + "4bf0b54023c29b624de9ef9c2f931efc580f9afb]", byteString.toString());
+  }
+
+  @Test public void toStringOnLongDataIsTruncated() {
+    ByteString byteString = factory.decodeHex(""
+        + "60b420bb3851d9d47acb933dbe70399bf6c92da33af01d4fb770e98c0325f41d3ebaf8986da712c82bcd4d55"
+        + "4bf0b54023c29b624de9ef9c2f931efc580f9afba1");
+    assertEquals("[size=65 hex="
+        + "60b420bb3851d9d47acb933dbe70399bf6c92da33af01d4fb770e98c0325f41d3ebaf8986da712c82bcd4d55"
+        + "4bf0b54023c29b624de9ef9c2f931efc580f9afb…]", byteString.toString());
   }
 
   @Test public void javaSerializationTestNonEmpty() throws Exception {

--- a/okio/src/test/java/okio/ReadUtf8LineTest.java
+++ b/okio/src/test/java/okio/ReadUtf8LineTest.java
@@ -90,7 +90,7 @@ public final class ReadUtf8LineTest {
       source.readUtf8LineStrict();
       fail();
     } catch (EOFException expected) {
-      assertEquals("\\n not found: size=0 content=...", expected.getMessage());
+      assertEquals("\\n not found: size=0 content=…", expected.getMessage());
     }
   }
 
@@ -101,7 +101,7 @@ public final class ReadUtf8LineTest {
       fail();
     } catch (EOFException expected) {
       assertEquals("\\n not found: size=33 content=616161616161616162626262626262626363636363636363"
-          + "6464646464646464...", expected.getMessage());
+          + "6464646464646464…", expected.getMessage());
     }
   }
 

--- a/okio/src/test/java/okio/RealBufferedSinkTest.java
+++ b/okio/src/test/java/okio/RealBufferedSinkTest.java
@@ -115,7 +115,7 @@ public final class RealBufferedSinkTest {
       fail();
     } catch (IOException expected) {
     }
-    mockSink.assertLog("write(Buffer[size=1 data=61], 1)", "close()");
+    mockSink.assertLog("write([text=a], 1)", "close()");
   }
 
   @Test public void closeWithExceptionWhenClosing() throws IOException {
@@ -128,7 +128,7 @@ public final class RealBufferedSinkTest {
       fail();
     } catch (IOException expected) {
     }
-    mockSink.assertLog("write(Buffer[size=1 data=61], 1)", "close()");
+    mockSink.assertLog("write([text=a], 1)", "close()");
   }
 
   @Test public void closeWithExceptionWhenWritingAndClosing() throws IOException {
@@ -143,7 +143,7 @@ public final class RealBufferedSinkTest {
     } catch (IOException expected) {
       assertEquals("first", expected.getMessage());
     }
-    mockSink.assertLog("write(Buffer[size=1 data=61], 1)", "close()");
+    mockSink.assertLog("write([text=a], 1)", "close()");
   }
 
   @Test public void operationsAfterClose() throws IOException {


### PR DESCRIPTION
If the data looks like text, this returns text. Otherwise it returns hex.
MD5 checksums are no longer used.