### PR TITLE
Fix a major bug where HashingSource is incorrect for large writes.

### DIFF
--- a/okio/src/main/java/okio/HashingSource.java
+++ b/okio/src/main/java/okio/HashingSource.java
@@ -71,7 +71,7 @@ public final class HashingSource extends ForwardingSource {
       // Find the first segment that has new bytes.
       long offset = sink.size;
       Segment s = sink.head;
-      while (offset > sink.size - result) {
+      while (offset > start) {
         s = s.prev;
         offset -= (s.limit - s.pos);
       }
@@ -82,6 +82,7 @@ public final class HashingSource extends ForwardingSource {
         messageDigest.update(s.data, pos, s.limit - pos);
         offset += (s.limit - s.pos);
         start = offset;
+        s = s.next;
       }
     }
 

--- a/okio/src/test/java/okio/HashingSinkTest.java
+++ b/okio/src/test/java/okio/HashingSinkTest.java
@@ -21,8 +21,8 @@ import static okio.HashingTest.MD5_abc;
 import static okio.HashingTest.SHA1_abc;
 import static okio.HashingTest.SHA256_abc;
 import static okio.HashingTest.SHA256_def;
-import static okio.HashingTest.SHA256_x32k;
-import static okio.HashingTest.x32k;
+import static okio.HashingTest.SHA256_r32k;
+import static okio.HashingTest.r32k;
 import static org.junit.Assert.assertEquals;
 
 public final class HashingSinkTest {
@@ -73,18 +73,18 @@ public final class HashingSinkTest {
 
   @Test public void multipleSegments() throws Exception {
     HashingSink hashingSink = HashingSink.sha256(sink);
-    source.writeUtf8(x32k);
-    hashingSink.write(source, x32k.length());
-    assertEquals(SHA256_x32k, hashingSink.hash());
+    source.write(r32k);
+    hashingSink.write(source, r32k.size());
+    assertEquals(SHA256_r32k, hashingSink.hash());
   }
 
   @Test public void readFromPrefixOfBuffer() throws Exception {
     source.writeUtf8("z");
-    source.writeUtf8(x32k);
+    source.write(r32k);
     source.skip(1);
     source.writeUtf8(TestUtil.repeat('z', Segment.SIZE * 2 - 1));
     HashingSink hashingSink = HashingSink.sha256(sink);
-    hashingSink.write(source, x32k.length());
-    assertEquals(SHA256_x32k, hashingSink.hash());
+    hashingSink.write(source, r32k.size());
+    assertEquals(SHA256_r32k, hashingSink.hash());
   }
 }

--- a/okio/src/test/java/okio/HashingSourceTest.java
+++ b/okio/src/test/java/okio/HashingSourceTest.java
@@ -21,8 +21,8 @@ import static okio.HashingTest.MD5_abc;
 import static okio.HashingTest.SHA1_abc;
 import static okio.HashingTest.SHA256_abc;
 import static okio.HashingTest.SHA256_def;
-import static okio.HashingTest.SHA256_x32k;
-import static okio.HashingTest.x32k;
+import static okio.HashingTest.SHA256_r32k;
+import static okio.HashingTest.r32k;
 import static org.junit.Assert.assertEquals;
 
 public final class HashingSourceTest {
@@ -75,16 +75,16 @@ public final class HashingSourceTest {
   @Test public void multipleSegments() throws Exception {
     HashingSource hashingSource = HashingSource.sha256(source);
     BufferedSource bufferedSource = Okio.buffer(hashingSource);
-    source.writeUtf8(x32k);
-    assertEquals(x32k, bufferedSource.readUtf8());
-    assertEquals(SHA256_x32k, hashingSource.hash());
+    source.write(r32k);
+    assertEquals(r32k, bufferedSource.readByteString());
+    assertEquals(SHA256_r32k, hashingSource.hash());
   }
 
   @Test public void readIntoSuffixOfBuffer() throws Exception {
     HashingSource hashingSource = HashingSource.sha256(source);
-    source.writeUtf8(x32k);
+    source.write(r32k);
     sink.writeUtf8(TestUtil.repeat('z', Segment.SIZE * 2 - 1));
-    assertEquals(x32k.length(), hashingSource.read(sink, Long.MAX_VALUE));
-    assertEquals(SHA256_x32k, hashingSource.hash());
+    assertEquals(r32k.size(), hashingSource.read(sink, Long.MAX_VALUE));
+    assertEquals(SHA256_r32k, hashingSource.hash());
   }
 }

--- a/okio/src/test/java/okio/HashingTest.java
+++ b/okio/src/test/java/okio/HashingTest.java
@@ -28,9 +28,9 @@ public final class HashingTest {
       "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
   public static final ByteString SHA256_def = ByteString.decodeHex(
       "cb8379ac2098aa165029e3938a51da0bcecfc008fd6795f401178647f96c5b34");
-  public static final ByteString SHA256_x32k = ByteString.decodeHex(
-      "427965f49a857174e308658227325dbd23ff4eccbe399d5ad4817dda3ec79f87");
-  public static final String x32k = TestUtil.repeat('x', 32768);
+  public static final ByteString SHA256_r32k = ByteString.decodeHex(
+      "3a640aa4d129671cb36a4bfbed652d732bce6b7ea83ccdd080c485b8c9ef479d");
+  public static final ByteString r32k = TestUtil.randomBytes(32768);
 
   @Test public void byteStringMd5() {
     assertEquals(MD5_abc, ByteString.encodeUtf8("abc").md5());
@@ -67,8 +67,8 @@ public final class HashingTest {
     assertEquals(SHA256_def, buffer.sha256());
     assertEquals("def", buffer.readUtf8());
 
-    buffer.writeUtf8(x32k);
-    assertEquals(SHA256_x32k, buffer.sha256());
-    assertEquals(x32k, buffer.readUtf8());
+    buffer.write(r32k);
+    assertEquals(SHA256_r32k, buffer.sha256());
+    assertEquals(r32k, buffer.readByteString());
   }
 }


### PR DESCRIPTION
There was a bug where it wasn't traversing through the segments of
the buffer being hashed. This means that HashingSource was returning
incorrect answers for any writes that spanned multiple segment
boundaries.

The problem wasn't detected by our test cases because although
we have tests for non-uniform segments, and for buffers that
span multiple segments, we don't have tests for non-uniform
buffers that span multiple segments. This has been fixed too.