### PR TITLE
Be forgiving in rangeEquals arguments.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -1456,17 +1456,11 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
   }
 
   @Override public boolean rangeEquals(long offset, ByteString bytes, int bytesOffset, int byteCount) {
-    if (offset < 0) throw new ArrayIndexOutOfBoundsException("offset=" + offset);
-    int bytesSize = bytes.size();
-    if ((bytesOffset | byteCount) < 0
-        || bytesOffset > bytesSize
-        || bytesSize - bytesOffset < byteCount) {
-      throw new ArrayIndexOutOfBoundsException(
-          String.format("bytes.size()=%s bytesOffset=%s byteCount=%s", bytesSize, bytesOffset,
-              byteCount));
-    }
-
-    if (this.size - offset < byteCount) {
+    if (offset < 0
+        || bytesOffset < 0
+        || byteCount < 0
+        || size - offset < byteCount
+        || bytes.size() - bytesOffset < byteCount) {
       return false;
     }
     for (int i = 0; i < byteCount; i++) {

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -376,16 +376,12 @@ final class RealBufferedSource implements BufferedSource {
       throws IOException {
     if (closed) throw new IllegalStateException("closed");
 
-    if (offset < 0) throw new ArrayIndexOutOfBoundsException("offset=" + offset);
-    int bytesSize = bytes.size();
-    if ((bytesOffset | byteCount) < 0
-        || bytesOffset > bytesSize
-        || bytesSize - bytesOffset < byteCount) {
-      throw new ArrayIndexOutOfBoundsException(
-          String.format("bytes.size()=%s bytesOffset=%s byteCount=%s", bytesSize, bytesOffset,
-              byteCount));
+    if (offset < 0
+        || bytesOffset < 0
+        || byteCount < 0
+        || bytes.size() - bytesOffset < byteCount) {
+      return false;
     }
-
     for (int i = 0; i < byteCount; i++) {
       long bufferOffset = offset + i;
       if (!request(bufferOffset + 1)) return false;

--- a/okio/src/test/java/okio/BufferedSourceTest.java
+++ b/okio/src/test/java/okio/BufferedSourceTest.java
@@ -942,41 +942,17 @@ public final class BufferedSourceTest {
   }
 
   @Test public void rangeEqualsArgumentValidation() throws IOException {
-    try {
-      source.rangeEquals(-1, ByteString.encodeUtf8("A"));
-      fail();
-    } catch (ArrayIndexOutOfBoundsException expected) {
-      assertEquals("offset=-1", expected.getMessage());
-    }
-    try {
-      source.rangeEquals(0, ByteString.encodeUtf8("A"), -1, 1);
-      fail();
-    } catch (ArrayIndexOutOfBoundsException expected) {
-      assertEquals("bytes.size()=1 bytesOffset=-1 byteCount=1", expected.getMessage());
-    }
-    try {
-      source.rangeEquals(0, ByteString.encodeUtf8("A"), 2, 1);
-      fail();
-    } catch (ArrayIndexOutOfBoundsException expected) {
-      assertEquals("bytes.size()=1 bytesOffset=2 byteCount=1", expected.getMessage());
-    }
-    try {
-      source.rangeEquals(0, ByteString.encodeUtf8("A"), 0, -1);
-      fail();
-    } catch (ArrayIndexOutOfBoundsException expected) {
-      assertEquals("bytes.size()=1 bytesOffset=0 byteCount=-1", expected.getMessage());
-    }
-    try {
-      source.rangeEquals(0, ByteString.encodeUtf8("A"), 0, 2);
-      fail();
-    } catch (ArrayIndexOutOfBoundsException expected) {
-      assertEquals("bytes.size()=1 bytesOffset=0 byteCount=2", expected.getMessage());
-    }
-    try {
-      source.rangeEquals(0, ByteString.encodeUtf8("A"), 1, 1);
-      fail();
-    } catch (ArrayIndexOutOfBoundsException expected) {
-      assertEquals("bytes.size()=1 bytesOffset=1 byteCount=1", expected.getMessage());
-    }
+    // Negative source offset.
+    assertFalse(source.rangeEquals(-1, ByteString.encodeUtf8("A")));
+    // Negative bytes offset.
+    assertFalse(source.rangeEquals(0, ByteString.encodeUtf8("A"), -1, 1));
+    // Bytes offset longer than bytes length.
+    assertFalse(source.rangeEquals(0, ByteString.encodeUtf8("A"), 2, 1));
+    // Negative byte count.
+    assertFalse(source.rangeEquals(0, ByteString.encodeUtf8("A"), 0, -1));
+    // Byte count longer than bytes length.
+    assertFalse(source.rangeEquals(0, ByteString.encodeUtf8("A"), 0, 2));
+    // Bytes offset plus byte count longer than bytes length.
+    assertFalse(source.rangeEquals(0, ByteString.encodeUtf8("A"), 1, 1));
   }
 }


### PR DESCRIPTION
This matches String.regionMatches and ByteString.rangeEquals behavior.