### PR TITLE
Add blackhole Sink.

### DIFF
--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -192,6 +192,23 @@ public final class Okio {
     return sink(Files.newOutputStream(path, options));
   }
 
+  /** Returns a sink that writes nowhere. */
+  public static Sink blackhole() {
+    return new Sink() {
+      @Override public void write(Buffer source, long byteCount) throws IOException {
+        source.skip(byteCount);
+      }
+
+      @Override public void flush() throws IOException {}
+
+      @Override public Timeout timeout() {
+        return Timeout.NONE;
+      }
+
+      @Override public void close() throws IOException {}
+    };
+  }
+
   /**
    * Returns a source that reads from {@code socket}. Prefer this over {@link
    * #source(InputStream)} because this method honors timeouts. When the socket

--- a/okio/src/test/java/okio/OkioTest.java
+++ b/okio/src/test/java/okio/OkioTest.java
@@ -145,4 +145,14 @@ public final class OkioTest {
       assertEquals("source == null", expected.getMessage());
     }
   }
+
+  @Test public void blackhole() throws Exception {
+    Buffer data = new Buffer();
+    data.writeUtf8("blackhole");
+
+    Sink blackhole = Okio.blackhole();
+    blackhole.write(data, 5);
+
+    assertEquals("hole", data.readUtf8());
+  }
 }


### PR DESCRIPTION
This adds `Okio.blackhole()` which returns a Sink that writes to the void.

Fixes #229 