### PR TITLE
Add Reader convenience factory.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -18,7 +18,9 @@ package okio;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.Reader;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -26,6 +28,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static okio.ByteOrderMark.BOM_UTF_16_BE;
+import static okio.ByteOrderMark.BOM_UTF_16_LE;
+import static okio.ByteOrderMark.BOM_UTF_32_BE;
+import static okio.ByteOrderMark.BOM_UTF_32_LE;
+import static okio.ByteOrderMark.BOM_UTF_8;
+import static okio.ByteOrderMark.getByteOrderMark;
+import static okio.Util.UTF_8;
 import static okio.Util.checkOffsetAndCount;
 import static okio.Util.reverseBytesLong;
 
@@ -128,6 +137,26 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
         return Buffer.this + ".inputStream()";
       }
     };
+  }
+
+  @Override public Reader reader() {
+    return new BomAwareReader(
+        null, BOM_UTF_8, BOM_UTF_32_LE, BOM_UTF_32_BE, BOM_UTF_16_LE, BOM_UTF_16_BE);
+  }
+
+  @Override public Reader reader(Charset charset) {
+    if (charset == null) throw new IllegalArgumentException("charset == null");
+
+    String charsetName = charset.name();
+    if (charsetName.equals("UTF-8")) {
+      return new BomAwareReader(charset, BOM_UTF_8);
+    } else if (charsetName.startsWith("UTF-16")) {
+      return new BomAwareReader(charset, BOM_UTF_16_BE, BOM_UTF_16_LE);
+    } else if (charsetName.startsWith("UTF-32")) {
+      return new BomAwareReader(charset, BOM_UTF_32_BE, BOM_UTF_32_LE);
+    } else {
+      return new InputStreamReader(inputStream(), charset);
+    }
   }
 
   /** Copy the contents of this to {@code out}. */
@@ -1630,5 +1659,46 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
   public ByteString snapshot(int byteCount) {
     if (byteCount == 0) return ByteString.EMPTY;
     return new SegmentedByteString(this, byteCount);
+  }
+
+  final class BomAwareReader extends Reader {
+    final Charset suppliedCharset;
+    final ByteOrderMark[] byteOrderMarks;
+    private Reader delegate;
+
+    BomAwareReader(Charset charset, ByteOrderMark... byteOrderMarks) {
+      this.suppliedCharset = charset;
+      this.byteOrderMarks = byteOrderMarks;
+    }
+
+    @Override public int read(char[] data, int offset, int charCount) throws IOException {
+      if (delegate == null) {
+        ByteOrderMark byteOrderMark = getByteOrderMark(Buffer.this, byteOrderMarks);
+
+        Charset charset;
+        if (byteOrderMark != null) {
+          byteOrderMark.skip(Buffer.this);
+          charset = byteOrderMark.charset;
+        } else {
+          charset = suppliedCharset == null ? UTF_8 : suppliedCharset;
+        }
+
+        delegate = new InputStreamReader(inputStream(), charset);
+      }
+
+      return delegate.read(data, offset, charCount);
+    }
+
+    @Override public void close() throws IOException {
+      if (delegate != null) {
+        delegate.close();
+      }
+    }
+
+    @Override public String toString() {
+      return suppliedCharset == null
+          ? Buffer.this + ".reader()"
+          : Buffer.this + ".reader(" + suppliedCharset + ")";
+    }
   }
 }

--- a/okio/src/main/java/okio/BufferedSource.java
+++ b/okio/src/main/java/okio/BufferedSource.java
@@ -17,6 +17,7 @@ package okio;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.nio.charset.Charset;
 
 /**
@@ -499,4 +500,10 @@ public interface BufferedSource extends Source {
 
   /** Returns an input stream that reads from this source. */
   InputStream inputStream();
+
+  /** Returns a Reader that reads from this source. */
+  Reader reader();
+
+  /** Returns a Reader that reads from this source. */
+  Reader reader(Charset charset);
 }

--- a/okio/src/main/java/okio/ByteOrderMark.java
+++ b/okio/src/main/java/okio/ByteOrderMark.java
@@ -1,0 +1,36 @@
+package okio;
+
+import java.io.EOFException;
+import java.nio.charset.Charset;
+
+enum ByteOrderMark {
+  BOM_UTF_8(Util.UTF_8, ByteString.decodeHex("EFBBBF")),
+  BOM_UTF_16_BE(Charset.forName("UTF-16BE"), ByteString.decodeHex("FEFF")),
+  BOM_UTF_16_LE(Charset.forName("UTF-16LE"), ByteString.decodeHex("FFFE")),
+  BOM_UTF_32_BE(Charset.forName("UTF-32BE"), ByteString.decodeHex("0000FEFF")),
+  BOM_UTF_32_LE(Charset.forName("UTF-32LE"), ByteString.decodeHex("FFFE0000"));
+
+  static final int MAX_BOM_LENGTH = 4;
+
+  final Charset charset;
+  final ByteString bom;
+
+  ByteOrderMark(Charset charset, ByteString bom) {
+    this.charset = charset;
+    this.bom = bom;
+  }
+
+  void skip(Buffer buffer) throws EOFException {
+    buffer.skip(bom.size());
+  }
+
+  static ByteOrderMark getByteOrderMark(Buffer buffer, ByteOrderMark... byteOrderMarks) {
+    for (ByteOrderMark byteOrderMark : byteOrderMarks) {
+      if (buffer.rangeEquals(0, byteOrderMark.bom)) {
+        return byteOrderMark;
+      }
+    }
+
+    return null;
+  }
+}

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -18,8 +18,17 @@ package okio;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.Charset;
 
+import static okio.ByteOrderMark.BOM_UTF_16_BE;
+import static okio.ByteOrderMark.BOM_UTF_16_LE;
+import static okio.ByteOrderMark.BOM_UTF_32_BE;
+import static okio.ByteOrderMark.BOM_UTF_32_LE;
+import static okio.ByteOrderMark.BOM_UTF_8;
+import static okio.ByteOrderMark.getByteOrderMark;
+import static okio.Util.UTF_8;
 import static okio.Util.checkOffsetAndCount;
 
 final class RealBufferedSource implements BufferedSource {
@@ -428,6 +437,26 @@ final class RealBufferedSource implements BufferedSource {
     };
   }
 
+  @Override public Reader reader() {
+    return new BomAwareReader(
+        null, BOM_UTF_8, BOM_UTF_32_LE, BOM_UTF_32_BE, BOM_UTF_16_LE, BOM_UTF_16_BE);
+  }
+
+  @Override public Reader reader(Charset charset) {
+    if (charset == null) throw new IllegalArgumentException("charset == null");
+
+    String charsetName = charset.name();
+    if (charsetName.equals("UTF-8")) {
+      return new BomAwareReader(charset, BOM_UTF_8);
+    } else if (charsetName.startsWith("UTF-16")) {
+      return new BomAwareReader(charset, BOM_UTF_16_BE, BOM_UTF_16_LE);
+    } else if (charsetName.startsWith("UTF-32")) {
+      return new BomAwareReader(charset, BOM_UTF_32_BE, BOM_UTF_32_LE);
+    } else {
+      return new InputStreamReader(inputStream(), charset);
+    }
+  }
+
   @Override public void close() throws IOException {
     if (closed) return;
     closed = true;
@@ -441,5 +470,55 @@ final class RealBufferedSource implements BufferedSource {
 
   @Override public String toString() {
     return "buffer(" + source + ")";
+  }
+
+  final class BomAwareReader extends Reader {
+    final Charset suppliedCharset;
+    final ByteOrderMark[] byteOrderMarks;
+    private Reader delegate;
+
+    BomAwareReader(Charset charset, ByteOrderMark... byteOrderMarks) {
+      this.suppliedCharset = charset;
+      this.byteOrderMarks = byteOrderMarks;
+    }
+
+    @Override public int read(char[] data, int offset, int charCount) throws IOException {
+      if (delegate == null) {
+        if (closed) throw new IOException("closed");
+
+        // Make sure buffer holds all bytes of the BOM.
+        if (buffer.size() < ByteOrderMark.MAX_BOM_LENGTH) {
+          source.read(buffer, Segment.SIZE);
+        }
+
+        ByteOrderMark byteOrderMark = getByteOrderMark(buffer, byteOrderMarks);
+
+        Charset charset;
+        if (byteOrderMark != null) {
+          byteOrderMark.skip(buffer);
+          charset = byteOrderMark.charset;
+        } else {
+          charset = suppliedCharset == null ? UTF_8 : suppliedCharset;
+        }
+
+        delegate = new InputStreamReader(inputStream(), charset);
+      }
+
+      return delegate.read(data, offset, charCount);
+    }
+
+    @Override public void close() throws IOException {
+      if (delegate == null) {
+        RealBufferedSource.this.close();
+      } else {
+        delegate.close();
+      }
+    }
+
+    @Override public String toString() {
+      return suppliedCharset == null
+          ? RealBufferedSource.this + ".reader()"
+          : RealBufferedSource.this + ".reader(" + suppliedCharset + ")";
+    }
   }
 }

--- a/okio/src/test/java/okio/RealBufferedSourceTest.java
+++ b/okio/src/test/java/okio/RealBufferedSourceTest.java
@@ -18,8 +18,11 @@ package okio;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.Charset;
 import org.junit.Test;
 
+import static okio.TestUtil.readerToString;
 import static okio.TestUtil.repeat;
 import static okio.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
@@ -191,6 +194,20 @@ public final class RealBufferedSourceTest {
       fail();
     } catch (IOException expected) {
     }
+
+    Reader reader = bufferedSource.reader();
+    try {
+      reader.read();
+      fail();
+    } catch (IOException expected) {
+    }
+
+    Reader readerWithCharset = bufferedSource.reader(UTF_8);
+    try {
+      readerWithCharset.read();
+      fail();
+    } catch (IOException expected) {
+    }
   }
 
   /**
@@ -214,5 +231,182 @@ public final class RealBufferedSourceTest {
         "write(" + write1 + ", " + write1.size() + ")",
         "write(" + write2 + ", " + write2.size() + ")",
         "write(" + write3 + ", " + write3.size() + ")");
+  }
+
+  @Test public void readerWithoutBom() throws Exception {
+    Buffer source = new Buffer();
+    source.writeUtf8("ab");
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader();
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("ab", stringFromReader);
+  }
+
+  @Test public void readerWithUtf8Bom() throws Exception {
+    Buffer source = new Buffer();
+    source.write(ByteString.decodeHex("efbbbf"));
+    source.writeUtf8("utf8");
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader();
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf8", stringFromReader);
+  }
+
+  @Test public void readerWithUtf16BigEndianBom() throws Exception {
+    Buffer source = new Buffer();
+    source.write(ByteString.decodeHex("feff"));
+    source.writeString("utf16", Charset.forName("UTF-16BE"));
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader();
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf16", stringFromReader);
+  }
+
+  @Test public void readerWithUtf16LittleEndianBom() throws Exception {
+    Buffer source = new Buffer();
+    source.write(ByteString.decodeHex("fffe"));
+    source.writeString("utf16", Charset.forName("UTF-16LE"));
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader();
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf16", stringFromReader);
+  }
+
+  @Test public void readerWithUtf32BigEndianBom() throws Exception {
+    Buffer source = new Buffer();
+    source.write(ByteString.decodeHex("0000feff"));
+    source.writeString("utf32", Charset.forName("UTF-32BE"));
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader();
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf32", stringFromReader);
+  }
+
+  @Test public void readerWithUtf32LittleEndianBom() throws Exception {
+    Buffer source = new Buffer();
+    source.write(ByteString.decodeHex("fffe0000"));
+    source.writeString("utf32", Charset.forName("UTF-32LE"));
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader();
+    String string = readerToString(reader);
+
+    assertEquals("utf32", string);
+  }
+
+  @Test public void readerWithBomCrossingSegmentBoundary() throws Exception {
+    Buffer source = new Buffer();
+    source.writeUtf8(TestUtil.repeat('a', Segment.SIZE - 1));
+    source.write(ByteString.decodeHex("efbbbf"));
+    source.writeUtf8("utf8");
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    bufferedSource.readByteString(Segment.SIZE - 1);
+    Reader reader = bufferedSource.reader();
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf8", stringFromReader);
+  }
+
+  @Test public void readerUtf8() throws Exception {
+    Buffer source = new Buffer();
+    source.writeUtf8("utf8");
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader(UTF_8);
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf8", stringFromReader);
+  }
+
+  @Test public void readerUtf8WithBom() throws Exception {
+    Buffer source = new Buffer();
+    source.write(ByteString.decodeHex("efbbbf"));
+    source.writeUtf8("utf8");
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader(UTF_8);
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf8", stringFromReader);
+  }
+
+  @Test public void readerUtf16() throws Exception {
+    Buffer source = new Buffer();
+    source.writeString("utf16", Charset.forName("UTF-16BE"));
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader(Charset.forName("UTF-16BE"));
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf16", stringFromReader);
+  }
+
+  @Test public void readerUtf16WithBom() throws Exception {
+    Buffer source = new Buffer();
+    source.write(ByteString.decodeHex("feff"));
+    source.writeString("utf16", Charset.forName("UTF-16BE"));
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader(Charset.forName("UTF-16"));
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf16", stringFromReader);
+  }
+
+  @Test public void readerUtf32() throws Exception {
+    Buffer source = new Buffer();
+    source.writeString("utf32", Charset.forName("UTF-32LE"));
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader(Charset.forName("UTF-32LE"));
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf32", stringFromReader);
+  }
+
+  @Test public void readerUtf32WithBom() throws Exception {
+    Buffer source = new Buffer();
+    source.write(ByteString.decodeHex("fffe0000"));
+    source.writeString("utf32", Charset.forName("UTF-32LE"));
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader(Charset.forName("UTF-32"));
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf32", stringFromReader);
+  }
+
+  @Test public void readerLatinOne() throws Exception {
+    Buffer source = new Buffer();
+    source.writeString("Übergrößenträger", Charset.forName("ISO-8859-1"));
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+
+    Reader reader = bufferedSource.reader(Charset.forName("ISO-8859-1"));
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("Übergrößenträger", stringFromReader);
+  }
+
+  @Test public void readerCloses() throws Exception {
+    RealBufferedSource source = new RealBufferedSource(new Buffer());
+    Reader reader = source.reader();
+    reader.close();
+    try {
+      source.require(1);
+      fail();
+    } catch (IllegalStateException e) {
+      assertEquals("closed", e.getMessage());
+    }
   }
 }

--- a/okio/src/test/java/okio/TestUtil.java
+++ b/okio/src/test/java/okio/TestUtil.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Reader;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Random;
@@ -157,5 +158,14 @@ final class TestUtil {
     }
 
     return result;
+  }
+
+  static String readerToString(Reader reader) throws IOException {
+    StringBuilder stringBuilder = new StringBuilder();
+    int read;
+    while ((read = reader.read()) != -1) {
+      stringBuilder.append((char) read);
+    }
+    return stringBuilder.toString();
   }
 }


### PR DESCRIPTION
The `Reader` supports the Unicode byte order mark (BOM) and based on it will select the right `Charset` for decoding.

See #239.