### PR TITLE
Add Reader convenience factory (second attempt)

### DIFF
--- a/okio/src/main/java/okio/BomAwareReader.java
+++ b/okio/src/main/java/okio/BomAwareReader.java
@@ -1,0 +1,66 @@
+package okio;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+
+import static okio.Util.UTF_8;
+
+final class BomAwareReader extends Reader {
+  private static final char BOM_CHARACTER = '\uFEFF';
+
+  final Charset charset;
+  final Object toStringPrefix;
+  final InputStreamReader delegate;
+  boolean skipBom;
+
+  BomAwareReader(InputStream inputStream, Charset charset, Object toStringPrefix) {
+    this.charset = charset;
+    this.toStringPrefix = toStringPrefix;
+
+    Charset charsetForReader = charset != null ? charset : UTF_8;
+    delegate = new InputStreamReader(inputStream, charsetForReader);
+    skipBom = charsetForReader.equals(UTF_8);
+  }
+
+  @Override public int read(char[] data, int offset, int charSize) throws IOException {
+    if (skipBom) {
+      skipBom = false;
+      return readAndSkipBom(data, offset, charSize);
+    }
+
+    return delegate.read(data, offset, charSize);
+  }
+
+  private int readAndSkipBom(char[] data, int offset, int charSize) throws IOException {
+    if (charSize == 0) {
+      return 0;
+    }
+
+    int read = delegate.read();
+    if (read == -1) {
+      return -1;
+    }
+
+    char firstChar = (char) read;
+    if (firstChar == BOM_CHARACTER) {
+      return delegate.read(data, offset, charSize);
+    }
+
+    data[offset] = firstChar;
+    read = delegate.read(data, offset + 1, charSize - 1);
+    return read == -1 ? 1 : 1 + read;
+  }
+
+  @Override public void close() throws IOException {
+    delegate.close();
+  }
+
+  @Override public String toString() {
+    return toStringPrefix + (charset == null
+        ? ".readerUtf8()"
+        : ".reader(" + charset + ")");
+  }
+}

--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -19,6 +19,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -128,6 +129,15 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
         return Buffer.this + ".inputStream()";
       }
     };
+  }
+
+  @Override public Reader readerUtf8() {
+    return new BomAwareReader(inputStream(), null, this);
+  }
+
+  @Override public Reader reader(Charset charset) {
+    if (charset == null) throw new IllegalArgumentException("charset == null");
+    return new BomAwareReader(inputStream(), charset, this);
   }
 
   /** Copy the contents of this to {@code out}. */

--- a/okio/src/main/java/okio/BufferedSource.java
+++ b/okio/src/main/java/okio/BufferedSource.java
@@ -17,6 +17,7 @@ package okio;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.nio.charset.Charset;
 
 /**
@@ -499,4 +500,10 @@ public interface BufferedSource extends Source {
 
   /** Returns an input stream that reads from this source. */
   InputStream inputStream();
+
+  /** Returns a Reader that decodes this source using the UTF-8 charset. */
+  Reader readerUtf8();
+
+  /** Returns a Reader that decodes this source using the supplied charset. */
+  Reader reader(Charset charset);
 }

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.nio.charset.Charset;
 
 import static okio.Util.checkOffsetAndCount;
@@ -426,6 +427,15 @@ final class RealBufferedSource implements BufferedSource {
         return RealBufferedSource.this + ".inputStream()";
       }
     };
+  }
+
+  @Override public Reader readerUtf8() {
+    return new BomAwareReader(inputStream(), null, this);
+  }
+
+  @Override public Reader reader(Charset charset) {
+    if (charset == null) throw new IllegalArgumentException("charset == null");
+    return new BomAwareReader(inputStream(), charset, this);
   }
 
   @Override public void close() throws IOException {

--- a/okio/src/test/java/okio/BomAwareReaderTest.java
+++ b/okio/src/test/java/okio/BomAwareReaderTest.java
@@ -1,0 +1,178 @@
+package okio;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import org.junit.Test;
+
+import static okio.TestUtil.readerToString;
+import static okio.Util.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BomAwareReaderTest {
+  static final ByteString UTF_8_BOM = ByteString.decodeHex("EFBBBF");
+
+  @Test public void readZeroCharacters() throws Exception {
+    Buffer buffer = new Buffer();
+    buffer.writeUtf8("1");
+    Reader reader = newReader(buffer.inputStream(), UTF_8);
+
+    int read = reader.read(new char[0], 0, 0);
+
+    assertEquals(0, read);
+  }
+
+  @Test public void readOneCharacter() throws Exception {
+    Buffer buffer = new Buffer();
+    buffer.writeUtf8("1");
+    Reader reader = newReader(buffer.inputStream(), UTF_8);
+
+    char[] chars = new char[1];
+    int read = reader.read(chars, 0, chars.length);
+
+    assertEquals(1, read);
+    assertEquals('1', chars[0]);
+  }
+
+  @Test public void readAtEndOfStream() throws Exception {
+    Reader reader = newReader(emptyInputStream(), UTF_8);
+
+    char[] chars = new char[6];
+    int read = reader.read(chars, 0, chars.length);
+
+    assertEquals(-1, read);
+  }
+
+  @Test public void readBomRightBeforeEndOfStream() throws Exception {
+    Buffer buffer = new Buffer();
+    buffer.write(UTF_8_BOM);
+    Reader reader = newReader(buffer.inputStream(), UTF_8);
+
+    char[] chars = new char[6];
+    int read = reader.read(chars, 0, chars.length);
+
+    assertEquals(-1, read);
+    // Make sure the BOM wasn't written to the array.
+    assertEquals(0, chars[0]);
+  }
+
+  @Test public void readSingleCharacterRightBeforeEndOfStream() throws Exception {
+    Buffer buffer = new Buffer();
+    buffer.writeUtf8("x");
+    Reader reader = newReader(buffer.inputStream(), UTF_8);
+
+    char[] chars = new char[6];
+    int read = reader.read(chars, 0, chars.length);
+
+    assertEquals(1, read);
+    assertEquals('x', chars[0]);
+  }
+
+  @Test public void readBomAndSingleCharacterRightBeforeEndOfStream() throws Exception {
+    Buffer buffer = new Buffer();
+    buffer.write(UTF_8_BOM);
+    buffer.writeUtf8("x");
+    Reader reader = newReader(buffer.inputStream(), UTF_8);
+
+    char[] chars = new char[6];
+    int read = reader.read(chars, 0, 1);
+
+    assertEquals(1, read);
+    assertEquals('x', chars[0]);
+  }
+
+  @Test public void readMoreCharactersThanAvailable() throws Exception {
+    Buffer buffer = new Buffer();
+    buffer.writeUtf8("hello");
+    Reader reader = newReader(buffer.inputStream(), UTF_8);
+
+    char[] chars = new char[6];
+    int read = reader.read(chars, 0, chars.length);
+
+    assertEquals(5, read);
+    assertEquals("hello", new String(chars, 0, read));
+  }
+
+  @Test public void readTwice() throws Exception {
+    Buffer buffer = new Buffer();
+    buffer.writeUtf8("onetwo");
+    Reader reader = newReader(buffer.inputStream(), UTF_8);
+
+    char[] chars = new char[6];
+    int read = reader.read(chars, 0, 3);
+
+    assertEquals(3, read);
+    assertEquals("one", new String(chars, 0, read));
+
+    read = reader.read(chars, 3, 3);
+
+    assertEquals(3, read);
+    assertEquals("two", new String(chars, 3, read));
+
+    assertEquals("onetwo", new String(chars, 0, 6));
+  }
+
+  @Test public void readLatin1() throws Exception {
+    Charset latin1Charset = Charset.forName("ISO-8859-1");
+    Buffer buffer = new Buffer();
+    buffer.writeString("Überwachung", latin1Charset);
+    Reader reader = newReader(buffer.inputStream(), latin1Charset);
+
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("Überwachung", stringFromReader);
+  }
+
+  @Test public void closeClosesInputStream() throws Exception {
+    MockInputStream inputStream = new MockInputStream();
+    Reader reader = newReader(inputStream, null);
+
+    reader.close();
+
+    inputStream.assertClosed();
+  }
+
+  @Test public void toStringWithNullCharset() throws Exception {
+    BomAwareReader reader = new BomAwareReader(emptyInputStream(), null, "$prefix");
+
+    String result = reader.toString();
+
+    assertEquals("$prefix.readerUtf8()", result);
+  }
+
+  @Test public void toStringWithUtf16Charset() throws Exception {
+    Charset charset = Charset.forName("UTF-16");
+    BomAwareReader reader = new BomAwareReader(emptyInputStream(), charset, "$prefix");
+
+    String result = reader.toString();
+
+    assertEquals("$prefix.reader(" + charset + ")", result);
+  }
+
+  private BomAwareReader newReader(InputStream inputStream, Charset charset) {
+    return new BomAwareReader(inputStream, charset, "boring");
+  }
+
+  private InputStream emptyInputStream() {
+    return new ByteArrayInputStream(new byte[0]);
+  }
+
+  static class MockInputStream extends InputStream {
+    private boolean closed = false;
+
+    @Override public int read() throws IOException {
+      return 0;
+    }
+
+    @Override public void close() throws IOException {
+      closed = true;
+    }
+
+    public void assertClosed() {
+      assertTrue(closed);
+    }
+  }
+}

--- a/okio/src/test/java/okio/BufferedSourceTest.java
+++ b/okio/src/test/java/okio/BufferedSourceTest.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
@@ -30,6 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static okio.TestUtil.assertByteArrayEquals;
 import static okio.TestUtil.assertByteArraysEquals;
+import static okio.TestUtil.readerToString;
 import static okio.TestUtil.repeat;
 import static okio.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
@@ -958,5 +960,63 @@ public final class BufferedSourceTest {
     assertFalse(source.rangeEquals(0, ByteString.encodeUtf8("A"), 0, 2));
     // Bytes offset plus byte count longer than bytes length.
     assertFalse(source.rangeEquals(0, ByteString.encodeUtf8("A"), 1, 1));
+  }
+
+  @Test public void readerUtf8WithBom() throws Exception {
+    sink.write(ByteString.decodeHex("EFBBBF"));
+    sink.writeUtf8("utf8");
+
+    Reader reader = source.readerUtf8();
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf8", stringFromReader);
+  }
+
+  @Test public void readerUtf8() throws Exception {
+    sink.writeUtf8("no BOM present");
+
+    Reader reader = source.readerUtf8();
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("no BOM present", stringFromReader);
+  }
+
+  @Test public void readerWithUtf8CharsetAndBom() throws Exception {
+    sink.write(ByteString.decodeHex("EFBBBF"));
+    sink.writeUtf8("utf8");
+
+    Reader reader = source.reader(UTF_8);
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("utf8", stringFromReader);
+  }
+
+  @Test public void readerWithUtf8Charset() throws Exception {
+    sink.writeUtf8("no BOM present");
+
+    Reader reader = source.reader(UTF_8);
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("no BOM present", stringFromReader);
+  }
+
+  @Test public void readerUtf16() throws Exception {
+    sink.write(ByteString.decodeHex("FEFF"));
+    sink.writeString("UTF-16 🍩", Charset.forName("UTF-16BE"));
+
+    Reader reader = source.reader(Charset.forName("UTF-16"));
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("UTF-16 \uD83C\uDF69", stringFromReader);
+  }
+
+  @Test public void readerLatin1() throws Exception {
+    Charset latin1Charset = Charset.forName("ISO-8859-1");
+    sink.writeString("Übergrößenträger", latin1Charset);
+
+    Reader reader = source.reader(latin1Charset);
+    String stringFromReader = readerToString(reader);
+
+    assertEquals("Übergrößenträger", stringFromReader);
   }
 }

--- a/okio/src/test/java/okio/TestUtil.java
+++ b/okio/src/test/java/okio/TestUtil.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Reader;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Random;
@@ -157,5 +158,14 @@ final class TestUtil {
     }
 
     return result;
+  }
+
+  static String readerToString(Reader reader) throws IOException {
+    StringBuilder stringBuilder = new StringBuilder();
+    int read;
+    while ((read = reader.read()) != -1) {
+      stringBuilder.append((char) read);
+    }
+    return stringBuilder.toString();
   }
 }


### PR DESCRIPTION
Because `InputStreamReader` doesn't do it, `BomAwareReader` will strip a UTF-8 BOM if present (see http://bugs.java.com/view_bug.do?bug_id=4508058).

See #239.