### PR TITLE
Allowing graceful shutdown (if JVM lives longer than application)

### DIFF
--- a/okio/src/main/java/okio/AsyncTimeout.java
+++ b/okio/src/main/java/okio/AsyncTimeout.java
@@ -140,7 +140,7 @@ public class AsyncTimeout extends Timeout {
     return true;
   }
 
-  public void shutdown() {
+  public static void shutdown() {
       shutdown = true;
       if (watchdog != null) {
         watchdog.interrupt();

--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -257,4 +257,14 @@ public final class Okio {
     return e.getCause() != null && e.getMessage() != null
         && e.getMessage().contains("getsockname failed");
   }
+
+  /**
+   * In order produce synthetic write timeouts we need a background (deamon) thread
+   * When running inside an application server, the lifespan of the JVM is longer than the application.
+   * This method can be used to stop the background thread.
+   */
+  public static void shutdownTimeoutThread() {
+      AsyncTimeout.shutdown();
+  }
+
 }


### PR DESCRIPTION
Allow for gracefull shutdown of the Watchdog thread. This is important if the code runs inside an application server JBoss, Tomcat etc, where you deploy new versions of the application without restarting the application server (JVM).

If you don't shutdown the thread gracefully you will get an error from Tomcat.
WARNING: The web application [ROOT##000860] appears to have started a thread named [Okio Watchdog] but has failed to stop it. This is very likely to create a memory leak. Stack trace of thread: java.lang.Object.wait(Native Method) java.lang.Object.wait(Object.java:502) okio.AsyncTimeout.awaitTimeout(AsyncTimeout.java:297) okio.AsyncTimeout.access$000(AsyncTimeout.java:40) okio.AsyncTimeout$Watchdog.run(AsyncTimeout.java:272)

Every time we redeploy our application (potentially many times every day) the JVM looses 1MB of stack space associated with the thread, until the JVM finally crashes with an OutOfMemmoryError or infinite GC loop.