### PR TITLE
Import org.junit.Assert.fail instead of junit.framework.TestCase.fail

### DIFF
--- a/okio/src/test/java/okio/PipeTest.java
+++ b/okio/src/test/java/okio/PipeTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Test;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
 
 public final class PipeTest {

--- a/okio/src/test/java/okio/WaitUntilNotifiedTest.java
+++ b/okio/src/test/java/okio/WaitUntilNotifiedTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Test;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 


### PR DESCRIPTION
Use the JUnit 4 version in the couple of places were JUnit 3 imports
still existed; this makes the imports more consistent and also fixes
compilation if the JUnit 3 version is not available.