### PR TITLE
Exit the watchdog thread after being idle for 60 seconds.

### DIFF
--- a/okio/src/test/java/okio/AsyncTimeoutTest.java
+++ b/okio/src/test/java/okio/AsyncTimeoutTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.fail;
  * 1000ms, named 'a', 'b', 'c' and 'd'.
  */
 public final class AsyncTimeoutTest {
-  private final List<Timeout> timedOut = new CopyOnWriteArrayList<Timeout>();
+  private final List<Timeout> timedOut = new CopyOnWriteArrayList<>();
   private final AsyncTimeout a = new RecordingAsyncTimeout();
   private final AsyncTimeout b = new RecordingAsyncTimeout();
   private final AsyncTimeout c = new RecordingAsyncTimeout();


### PR DESCRIPTION
This should make it possible for people doing class unloading to
unload class loaders containing Okio.

Closes https://github.com/square/okio/issues/107