### PR TITLE
Fix a major bug where writeString() didn't always respect offsets.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -958,7 +958,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
           "endIndex > string.length: " + endIndex + " > " + string.length());
     }
     if (charset == null) throw new IllegalArgumentException("charset == null");
-    if (charset.equals(Util.UTF_8)) return writeUtf8(string);
+    if (charset.equals(Util.UTF_8)) return writeUtf8(string, beginIndex, endIndex);
     byte[] data = string.substring(beginIndex, endIndex).getBytes(charset);
     return write(data, 0, data.length);
   }

--- a/okio/src/test/java/okio/BufferedSinkTest.java
+++ b/okio/src/test/java/okio/BufferedSinkTest.java
@@ -187,6 +187,12 @@ public final class BufferedSinkTest {
     assertEquals(ByteString.decodeHex("00000072000000610000006e00000259"), data.readByteString());
   }
 
+  @Test public void writeUtf8SubstringWithCharset() throws IOException {
+    sink.writeString("təˈranəˌsôr", 3, 7, Charset.forName("utf-8"));
+    sink.flush();
+    assertEquals(ByteString.encodeUtf8("ranə"), data.readByteString());
+  }
+
   @Test public void writeAll() throws Exception {
     Buffer source = new Buffer().writeUtf8("abcdef");
 


### PR DESCRIPTION
Closes: https://github.com/square/okio/issues/258