### PR TITLE
ByteString: support creating from NIO ByteBuffers

### DIFF
--- a/okio/src/main/java/okio/ByteString.java
+++ b/okio/src/main/java/okio/ByteString.java
@@ -82,6 +82,14 @@ public class ByteString implements Serializable, Comparable<ByteString> {
     return new ByteString(copy);
   }
 
+  public static ByteString of(ByteBuffer data) {
+    if (data == null) throw new IllegalArgumentException("data == null");
+
+    byte[] copy = new byte[data.remaining()];
+    data.get(copy);
+    return new ByteString(copy);
+  }
+
   /** Returns a new byte string containing the {@code UTF-8} bytes of {@code s}. */
   public static ByteString encodeUtf8(String s) {
     if (s == null) throw new IllegalArgumentException("s == null");

--- a/okio/src/test/java/okio/ByteStringTest.java
+++ b/okio/src/test/java/okio/ByteStringTest.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,6 +84,16 @@ public final class ByteStringTest {
     ByteString byteString = ByteString.of(bytes, 2, 9);
     // Verify that the bytes were copied out.
     bytes[4] = (byte) 'a';
+    assertEquals("llo, Worl", byteString.utf8());
+  }
+
+  @Test public void ofByteBuffer() {
+    byte[] bytes = "Hello, World!".getBytes(Util.UTF_8);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    byteBuffer.position(2).limit(11);
+    ByteString byteString = ByteString.of(byteBuffer);
+    // Verify that the bytes were copied out.
+    byteBuffer.put(4, (byte) 'a');
     assertEquals("llo, Worl", byteString.utf8());
   }
 


### PR DESCRIPTION
Add support for creating ByteStrings from NIO ByteBuffers.  Useful for
projects which standardized on okio for their own code but still need to
integrate with other libraries based on NIO.

Signed-off-by: Kent R. Spillner <kspillner@acm.org>