### PR TITLE
Implement HMAC SHA-1 and HMAC-SHA-256 throughout Okio.

### DIFF
--- a/okio/src/main/java/okio/ByteString.java
+++ b/okio/src/main/java/okio/ByteString.java
@@ -25,9 +25,12 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 import static okio.Util.arrayRangeEquals;
 import static okio.Util.checkOffsetAndCount;
@@ -147,6 +150,28 @@ public class ByteString implements Serializable, Comparable<ByteString> {
       return ByteString.of(MessageDigest.getInstance(algorithm).digest(data));
     } catch (NoSuchAlgorithmException e) {
       throw new AssertionError(e);
+    }
+  }
+
+  /** Returns the 160-bit SHA-1 HMAC of this byte string. */
+  public ByteString hmacSha1(ByteString key) {
+    return hmac("HmacSHA1", key);
+  }
+
+  /** Returns the 256-bit SHA-256 HMAC of this byte string. */
+  public ByteString hmacSha256(ByteString key) {
+    return hmac("HmacSHA256", key);
+  }
+
+  private ByteString hmac(String algorithm, ByteString key) {
+    try {
+      Mac mac = Mac.getInstance(algorithm);
+      mac.init(new SecretKeySpec(key.toByteArray(), algorithm));
+      return ByteString.of(mac.doFinal(data));
+    } catch (NoSuchAlgorithmException e) {
+      throw new AssertionError(e);
+    } catch (InvalidKeyException e) {
+      throw new IllegalArgumentException(e);
     }
   }
 

--- a/okio/src/main/java/okio/SegmentedByteString.java
+++ b/okio/src/main/java/okio/SegmentedByteString.java
@@ -122,6 +122,14 @@ final class SegmentedByteString extends ByteString {
     return toByteString().sha256();
   }
 
+  @Override public ByteString hmacSha1(ByteString key) {
+    return toByteString().hmacSha1(key);
+  }
+
+  @Override public ByteString hmacSha256(ByteString key) {
+    return toByteString().hmacSha256(key);
+  }
+
   @Override public String base64Url() {
     return toByteString().base64Url();
   }

--- a/okio/src/test/java/okio/HashingSinkTest.java
+++ b/okio/src/test/java/okio/HashingSinkTest.java
@@ -17,6 +17,9 @@ package okio;
 
 import org.junit.Test;
 
+import static okio.HashingTest.HMAC_KEY;
+import static okio.HashingTest.HMAC_SHA1_abc;
+import static okio.HashingTest.HMAC_SHA256_abc;
 import static okio.HashingTest.MD5_abc;
 import static okio.HashingTest.SHA1_abc;
 import static okio.HashingTest.SHA256_abc;
@@ -48,6 +51,20 @@ public final class HashingSinkTest {
     source.writeUtf8("abc");
     hashingSink.write(source, 3L);
     assertEquals(SHA256_abc, hashingSink.hash());
+  }
+
+  @Test public void hmacSha1() throws Exception {
+    HashingSink hashingSink = HashingSink.hmacSha1(sink, HMAC_KEY);
+    source.writeUtf8("abc");
+    hashingSink.write(source, 3L);
+    assertEquals(HMAC_SHA1_abc, hashingSink.hash());
+  }
+
+  @Test public void hmacSha256() throws Exception {
+    HashingSink hashingSink = HashingSink.hmacSha256(sink, HMAC_KEY);
+    source.writeUtf8("abc");
+    hashingSink.write(source, 3L);
+    assertEquals(HMAC_SHA256_abc, hashingSink.hash());
   }
 
   @Test public void multipleWrites() throws Exception {

--- a/okio/src/test/java/okio/HashingSourceTest.java
+++ b/okio/src/test/java/okio/HashingSourceTest.java
@@ -17,6 +17,9 @@ package okio;
 
 import org.junit.Test;
 
+import static okio.HashingTest.HMAC_KEY;
+import static okio.HashingTest.HMAC_SHA1_abc;
+import static okio.HashingTest.HMAC_SHA256_abc;
 import static okio.HashingTest.MD5_abc;
 import static okio.HashingTest.SHA1_abc;
 import static okio.HashingTest.SHA256_abc;
@@ -24,6 +27,7 @@ import static okio.HashingTest.SHA256_def;
 import static okio.HashingTest.SHA256_r32k;
 import static okio.HashingTest.r32k;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public final class HashingSourceTest {
   private final Buffer source = new Buffer();
@@ -48,6 +52,20 @@ public final class HashingSourceTest {
     source.writeUtf8("abc");
     assertEquals(3L, hashingSource.read(sink, Long.MAX_VALUE));
     assertEquals(SHA256_abc, hashingSource.hash());
+  }
+
+  @Test public void hmacSha1() throws Exception {
+    HashingSource hashingSource = HashingSource.hmacSha1(source, HMAC_KEY);
+    source.writeUtf8("abc");
+    assertEquals(3L, hashingSource.read(sink, Long.MAX_VALUE));
+    assertEquals(HMAC_SHA1_abc, hashingSource.hash());
+  }
+
+  @Test public void hmacSha256() throws Exception {
+    HashingSource hashingSource = HashingSource.hmacSha256(source, HMAC_KEY);
+    source.writeUtf8("abc");
+    assertEquals(3L, hashingSource.read(sink, Long.MAX_VALUE));
+    assertEquals(HMAC_SHA256_abc, hashingSource.hash());
   }
 
   @Test public void multipleReads() throws Exception {
@@ -86,5 +104,13 @@ public final class HashingSourceTest {
     sink.writeUtf8(TestUtil.repeat('z', Segment.SIZE * 2 - 1));
     assertEquals(r32k.size(), hashingSource.read(sink, Long.MAX_VALUE));
     assertEquals(SHA256_r32k, hashingSource.hash());
+  }
+
+  @Test public void hmacEmptyKey() throws Exception {
+    try {
+      HashingSource.hmacSha256(source, ByteString.EMPTY);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
   }
 }

--- a/okio/src/test/java/okio/HashingTest.java
+++ b/okio/src/test/java/okio/HashingTest.java
@@ -20,16 +20,25 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public final class HashingTest {
+  public static final ByteString HMAC_KEY = ByteString.decodeHex("0102030405060708");
   public static final ByteString MD5_abc = ByteString.decodeHex(
       "900150983cd24fb0d6963f7d28e17f72");
   public static final ByteString SHA1_abc = ByteString.decodeHex(
       "a9993e364706816aba3e25717850c26c9cd0d89d");
+  public static final ByteString HMAC_SHA1_abc = ByteString.decodeHex(
+      "987af8649982ff7d9fbb1b8aa35099146997af51");
   public static final ByteString SHA256_abc = ByteString.decodeHex(
       "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  public static final ByteString SHA256_empty = ByteString.decodeHex(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
   public static final ByteString SHA256_def = ByteString.decodeHex(
       "cb8379ac2098aa165029e3938a51da0bcecfc008fd6795f401178647f96c5b34");
   public static final ByteString SHA256_r32k = ByteString.decodeHex(
       "3a640aa4d129671cb36a4bfbed652d732bce6b7ea83ccdd080c485b8c9ef479d");
+  public static final ByteString HMAC_SHA256_empty = ByteString.decodeHex(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  public static final ByteString HMAC_SHA256_abc = ByteString.decodeHex(
+      "446d1715583cf1c30dfffbec0df4ff1f9d39d493211ab4c97ed6f3f0eb579b47");
   public static final ByteString r32k = TestUtil.randomBytes(32768);
 
   @Test public void byteStringMd5() {
@@ -44,6 +53,14 @@ public final class HashingTest {
     assertEquals(SHA256_abc, ByteString.encodeUtf8("abc").sha256());
   }
 
+  @Test public void byteStringHmacSha1() {
+    assertEquals(HMAC_SHA1_abc, ByteString.encodeUtf8("abc").hmacSha1(HMAC_KEY));
+  }
+
+  @Test public void byteStringHmacSha256() {
+    assertEquals(HMAC_SHA256_abc, ByteString.encodeUtf8("abc").hmacSha256(HMAC_KEY));
+  }
+
   @Test public void bufferMd5() {
     assertEquals(MD5_abc, new Buffer().writeUtf8("abc").md5());
   }
@@ -54,6 +71,22 @@ public final class HashingTest {
 
   @Test public void bufferSha256() {
     assertEquals(SHA256_abc, new Buffer().writeUtf8("abc").sha256());
+  }
+
+  @Test public void hashEmptyBuffer() {
+    assertEquals(SHA256_empty, new Buffer().sha256());
+  }
+
+  @Test public void bufferHmacSha1() {
+    assertEquals(HMAC_SHA1_abc, new Buffer().writeUtf8("abc").hmacSha1(HMAC_KEY));
+  }
+
+  @Test public void bufferHmacSha256() {
+    assertEquals(HMAC_SHA256_abc, new Buffer().writeUtf8("abc").hmacSha256(HMAC_KEY));
+  }
+
+  @Test public void hmacEmptyBuffer() {
+    assertEquals(HMAC_SHA256_empty, new Buffer().sha256());
   }
 
   @Test public void bufferHashIsNotDestructive() {


### PR DESCRIPTION
This adds APIs to ByteString, Buffer, HashingSource and HashingSink.

I've forgone polymporphism in HashingSource and HashingSink because it
adds more code than it saves. I can be convinced here.

Closes: https://github.com/square/okio/issues/254