### PR TITLE
Add pro guard rules to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,31 @@ compile 'com.squareup.okio:okio:1.11.0'
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].
 
+ProGuard
+--------
 
+If you are using ProGuard you might need to add the following option:
+```
+-dontwarn okio.**
+```
+
+License
+--------
+
+    Copyright 2013 Square, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    
  [1]: https://github.com/square/okhttp
  [2]: https://search.maven.org/remote_content?g=com.squareup.okio&a=okio&v=LATEST
  [3]: http://square.github.io/okio/1.x/okio/okio/ByteString.html


### PR DESCRIPTION
This was discussed a bit here https://github.com/square/retrofit/pull/2090

This adds the ProGuard rules for okio. The format is taken from Picasso. I also added the license footer to the README, as it seems most other Square libraries have it