### PR TITLE
Allow length of readUtf8LineStrict to be limited.

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -642,11 +642,16 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
   }
 
   @Override public String readUtf8LineStrict() throws EOFException {
-    long newline = indexOf((byte) '\n');
+    return readUtf8LineStrict(Long.MAX_VALUE);
+  }
+
+  @Override public String readUtf8LineStrict(long maxRead) throws EOFException {
+    if (maxRead < 1) throw new IllegalArgumentException("maxRead < 1");
+    long newline = indexOf((byte) '\n', 0, maxRead);
     if (newline == -1) {
       Buffer data = new Buffer();
       copyTo(data, 0, Math.min(32, size));
-      throw new EOFException("\\n not found: size=" + size()
+      throw new EOFException("\\n not found: scanLength=" + Math.min(size(), maxRead)
           + " content=" + data.readByteString().hex() + "…");
     }
     return readUtf8Line(newline);
@@ -1263,7 +1268,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
   }
 
   @Override public long indexOf(byte b) {
-    return indexOf(b, 0);
+    return indexOf(b, 0, Long.MAX_VALUE);
   }
 
   /**
@@ -1271,7 +1276,17 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
    * -1 if this buffer does not contain {@code b} in that range.
    */
   @Override public long indexOf(byte b, long fromIndex) {
-    if (fromIndex < 0) throw new IllegalArgumentException("fromIndex < 0");
+    return indexOf(b, fromIndex, Long.MAX_VALUE);
+  }
+
+  @Override public long indexOf(byte b, long fromIndex, long toIndex) {
+    if (fromIndex < 0 || toIndex < fromIndex) {
+      throw new IllegalArgumentException(
+          String.format("size=%s fromIndex=%s toIndex=%s", size, fromIndex, toIndex));
+    }
+
+    if (toIndex > size) toIndex = size;
+    if (fromIndex == toIndex) return -1L;
 
     Segment s;
     long offset;
@@ -1301,9 +1316,11 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     }
 
     // Scan through the segments, searching for b.
-    while (offset < size) {
+    while (offset < toIndex) {
       byte[] data = s.data;
-      for (int pos = (int) (s.pos + fromIndex - offset), limit = s.limit; pos < limit; pos++) {
+      int limit = (int) Math.min(s.limit, s.pos + toIndex - offset);
+      int pos = (int) (s.pos + fromIndex - offset);
+      for (; pos < limit; pos++) {
         if (data[pos] == b) {
           return pos - s.pos + offset;
         }

--- a/okio/src/main/java/okio/BufferedSource.java
+++ b/okio/src/main/java/okio/BufferedSource.java
@@ -392,6 +392,30 @@ public interface BufferedSource extends Source {
   String readUtf8LineStrict() throws IOException;
 
   /**
+   * Like {@link #readUtf8LineStrict()}, but allows the caller to specify the maximum number
+   * of bytes that should be read. If {@code maxRead} is reached without finding a line break,
+   * then an {@link java.io.EOFException} is thrown. A common use case is parsing headers,
+   * to protect against a sender that never sends {@code "\n"} or {@code "\r\n"}.
+   *
+   * <p>This method is safe. No bytes are discarded if the match fails, and the caller is free
+   * to try another match:<pre>{@code
+   *
+   *   Buffer buffer = new Buffer();
+   *   buffer.writeUtf8("12345\r\n");
+   *
+   *   // This will throw! A newline character (\n)
+   *   // must be read within maxRead.
+   *   buffer.readUtf8LineStrict(5);
+   *
+   *   // No bytes have been consumed, so the caller
+   *   // can recover from the exception and
+   *   // try again.
+   *   assertEquals("12345", buffer.readUtf8LineStrict(100));
+   * }</pre>
+   */
+  String readUtf8LineStrict(long maxRead) throws IOException;
+
+  /**
    * Removes and returns a single UTF-8 code point, reading between 1 and 4 bytes as necessary.
    *
    * <p>If this source is exhausted before a complete code point can be read, this throws an {@link
@@ -432,6 +456,16 @@ public interface BufferedSource extends Source {
    * }</pre>
    */
   long indexOf(byte b, long fromIndex) throws IOException;
+
+  /**
+   * Returns the index of {@code b} if it is found in the range of {@code fromIndex} inclusive
+   * to {@code toIndex} exclusive. If {@code b} isn't found, or if {@code fromIndex == toIndex},
+   * then -1 is returned.
+   *
+   * <p>The scan terminates at either {@code toIndex} or the end of the buffer, whichever comes
+   * first. The maximum number of bytes scanned is {@code toIndex-fromIndex}.
+   */
+  long indexOf(byte b, long fromIndex, long toIndex) throws IOException;
 
   /** Equivalent to {@link #indexOf(ByteString, long) indexOf(bytes, 0)}. */
   long indexOf(ByteString bytes) throws IOException;

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -207,11 +207,16 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public String readUtf8LineStrict() throws IOException {
-    long newline = indexOf((byte) '\n');
+    return readUtf8LineStrict(Long.MAX_VALUE);
+  }
+
+  @Override public String readUtf8LineStrict(long maxRead) throws IOException {
+    if (maxRead < 1) throw new IllegalArgumentException("maxRead < 1");
+    long newline = indexOf((byte) '\n', 0, maxRead);
     if (newline == -1L) {
       Buffer data = new Buffer();
       buffer.copyTo(data, 0, Math.min(32, buffer.size()));
-      throw new EOFException("\\n not found: size=" + buffer.size()
+      throw new EOFException("\\n not found: scanLength=" + Math.min(buffer.size(), maxRead)
           + " content=" + data.readByteString().hex() + "…");
     }
     return buffer.readUtf8Line(newline);
@@ -311,14 +316,22 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public long indexOf(byte b) throws IOException {
-    return indexOf(b, 0);
+    return indexOf(b, 0, Long.MAX_VALUE);
   }
 
   @Override public long indexOf(byte b, long fromIndex) throws IOException {
-    if (closed) throw new IllegalStateException("closed");
+    return indexOf(b, fromIndex, Long.MAX_VALUE);
+  }
 
-    while (true) {
-      long result = buffer.indexOf(b, fromIndex);
+  @Override public long indexOf(byte b, long fromIndex, long toIndex) throws IOException {
+    if (closed) throw new IllegalStateException("closed");
+    if (fromIndex < 0 || toIndex < fromIndex) {
+      throw new IllegalArgumentException(
+          String.format("fromIndex=%s toIndex=%s", fromIndex, toIndex));
+    }
+
+    while (fromIndex < toIndex) {
+      long result = buffer.indexOf(b, fromIndex, toIndex);
       if (result != -1) return result;
 
       long lastBufferSize = buffer.size;
@@ -327,6 +340,7 @@ final class RealBufferedSource implements BufferedSource {
       // Keep searching, picking up from where we left off.
       fromIndex = Math.max(fromIndex, lastBufferSize);
     }
+    return -1L;
   }
 
   @Override public long indexOf(ByteString bytes) throws IOException {

--- a/okio/src/test/java/okio/BufferedSourceTest.java
+++ b/okio/src/test/java/okio/BufferedSourceTest.java
@@ -468,10 +468,76 @@ public final class BufferedSourceTest {
     assertEquals(-1, source.indexOf((byte) 'e'));
   }
 
-  @Test public void indexOfByteWithOffset() throws IOException {
+  @Test public void indexOfByteWithStartOffset() throws IOException {
     sink.writeUtf8("a").writeUtf8(repeat('b', Segment.SIZE)).writeUtf8("c");
     assertEquals(-1, source.indexOf((byte) 'a', 1));
     assertEquals(15, source.indexOf((byte) 'b', 15));
+  }
+
+  @Test public void indexOfByteWithBothOffsets() throws IOException {
+    byte a = (byte) 'a';
+    byte c = (byte) 'c';
+
+    int size;
+    if (factory == Factory.ONE_BYTE_AT_A_TIME) {
+      // Larger segment sizes for ONE_BYTE_AT_A_TIME
+      // cause Travis to kill the test.
+      size =  Segment.SIZE  + 10;
+    } else {
+      size = Segment.SIZE * 5;
+    }
+
+    byte[] bytes = new byte[size];
+    Arrays.fill(bytes, a);
+
+    // These are tricky places where the buffer
+    // starts, ends, or segments come together.
+    int[] points = {
+        0,                       1,                   2,
+        Segment.SIZE - 1,        Segment.SIZE,        Segment.SIZE + 1,
+        size / 2 - 1,            size / 2,            size / 2 + 1,
+        size - Segment.SIZE - 1, size - Segment.SIZE, size - Segment.SIZE + 1,
+        size - 3,                size - 2,            size - 1
+    };
+
+    // In each iteration, we write c to the known point
+    // and then search for it using different windows.
+    // Some of the windows don't overlap with c's position,
+    // and therefore a match shouldn't be found.
+    for (int p : points) {
+      bytes[p] = c;
+      sink.write(bytes);
+
+      assertEquals( p, source.indexOf(c, 0,      size     ));
+      assertEquals( p, source.indexOf(c, 0,      p + 1    ));
+      assertEquals( p, source.indexOf(c, p,      size     ));
+      assertEquals( p, source.indexOf(c, p,      p + 1    ));
+      assertEquals( p, source.indexOf(c, p / 2,  p * 2 + 1));
+      assertEquals(-1, source.indexOf(c, 0,      p / 2    ));
+      assertEquals(-1, source.indexOf(c, 0,      p        ));
+      assertEquals(-1, source.indexOf(c, 0,      0        ));
+      assertEquals(-1, source.indexOf(c, p,      p        ));
+
+      // reset
+      source.readUtf8();
+      bytes[p] = a;
+    }
+  }
+
+  @Test public void indexOfByteInvalidBoundsThrows() throws IOException {
+    sink.writeUtf8("abc");
+
+    try {
+      source.indexOf((byte) 'a', -1);
+      fail("Expected failure: fromIndex < 0");
+    } catch (IllegalArgumentException expected) {
+    }
+
+    try {
+      source.indexOf((byte) 'a', 10, 0);
+      fail("Expected failure: fromIndex > toIndex");
+    } catch (IllegalArgumentException expected) {
+    }
   }
 
   @Test public void indexOfByteString() throws IOException {

--- a/okio/src/test/java/okio/ReadUtf8LineTest.java
+++ b/okio/src/test/java/okio/ReadUtf8LineTest.java
@@ -90,7 +90,38 @@ public final class ReadUtf8LineTest {
       source.readUtf8LineStrict();
       fail();
     } catch (EOFException expected) {
-      assertEquals("\\n not found: size=0 content=…", expected.getMessage());
+      assertEquals("\\n not found: scanLength=0 content=…", expected.getMessage());
+    }
+  }
+
+  @Test public void readUtf8LineStrictWithLimits() throws IOException {
+    data.writeUtf8("abc\ndef\r\nghi\n");
+    assertEquals("abc", source.readUtf8LineStrict(10));
+    assertEquals("def", source.readUtf8LineStrict(10));
+
+    try {
+      source.readUtf8LineStrict(3);
+      fail("Expected failure: maxRead must include \\n");
+    } catch (EOFException expected) {
+      assertEquals("\\n not found: scanLength=3 content=6768690a…", expected.getMessage());
+    }
+
+    // No bytes should be consumed after a failed match.
+    assertEquals("ghi", source.readUtf8LineStrict(10));
+  }
+
+  @Test public void readUtf8LineStrictNonPositiveThrows() throws IOException {
+
+    try {
+      source.readUtf8LineStrict(0);
+      fail("Expected failure: maxRead must be positive");
+    } catch (IllegalArgumentException expected) {
+    }
+
+    try {
+      source.readUtf8LineStrict(-1);
+      fail("Expected failure: maxRead must be positive");
+    } catch (IllegalArgumentException expected) {
     }
   }
 
@@ -100,7 +131,7 @@ public final class ReadUtf8LineTest {
       source.readUtf8LineStrict();
       fail();
     } catch (EOFException expected) {
-      assertEquals("\\n not found: size=33 content=616161616161616162626262626262626363636363636363"
+      assertEquals("\\n not found: scanLength=33 content=616161616161616162626262626262626363636363636363"
           + "6464646464646464…", expected.getMessage());
     }
   }


### PR DESCRIPTION
I ran into needing this while using okio to write an HTTP server, and I think it should address issue #153 .

Two API additions:

1. BufferedOutputStream.readUtf8LineStrict accepts a maxByteCount parameter. If the line break isn't found by that limit, an EOFException is thrown.  (Is that the right exception??)
2. BufferedOutputStream.indexOf includes a marker for ending the search. If reached, -1 is returned.

I thought about whether readUtf8Line should get the maxByteCount parameter as well. If added, it would have a contract of questionable utility: return a string at end of line, EOF, or when this count parameter is reached. In any case, if the method is desirable, it should be easy to add.

Additionally, there are indexOf methods that search for ByteStrings. Those aren't covered by this PR either, but should be similarly easy to add if wanted.

Test output: [mvn-clean-verify.txt](https://github.com/square/okio/files/692663/mvn-clean-verify.txt)
Related issue: #153 Optional limits on methods like readLine() 