### PR TITLE
'limit' in readUtf8LineStrict should specify maximum return length, not the maximum scan length

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -647,14 +647,21 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
 
   @Override public String readUtf8LineStrict(long limit) throws EOFException {
     if (limit < 0) throw new IllegalArgumentException("limit < 0: " + limit);
-    long newline = indexOf((byte) '\n', 0, limit);
-    if (newline == -1) {
-      Buffer data = new Buffer();
-      copyTo(data, 0, Math.min(32, size));
-      throw new EOFException("\\n not found: scanLength=" + Math.min(size(), limit)
-          + " content=" + data.readByteString().hex() + "…");
+    if (limit == 0) throw new EOFException("limit == 0");
+    long scanLength = limit == Long.MAX_VALUE ? Long.MAX_VALUE : limit + 1;
+    long newline = indexOf((byte) '\n', 0, scanLength);
+    if (newline != -1) {
+      return readUtf8Line(newline);
+    } else if (
+        size() > scanLength
+            && getByte(scanLength - 1) == '\r'
+            && getByte(scanLength) == '\n') {
+      return readUtf8Line(scanLength);
     }
-    return readUtf8Line(newline);
+    Buffer data = new Buffer();
+    copyTo(data, 0, Math.min(32, size()));
+    throw new EOFException("\\n not found: limit=" + Math.min(size(), limit)
+        + " content=" + data.readByteString().hex() + '…');
   }
 
   String readUtf8Line(long newline) throws EOFException {

--- a/okio/src/main/java/okio/BufferedSource.java
+++ b/okio/src/main/java/okio/BufferedSource.java
@@ -392,10 +392,13 @@ public interface BufferedSource extends Source {
   String readUtf8LineStrict() throws IOException;
 
   /**
-   * Like {@link #readUtf8LineStrict()}, but this allows the caller to specify a maximum number of
-   * bytes to scan. If {@code limit} bytes are scanned without finding a line break, then an {@link
-   * java.io.EOFException} is thrown. A common use case is protecting against input that doesn't
-   * include {@code "\n"} or {@code "\r\n"}.
+   * Like {@link #readUtf8LineStrict()}, except this allows the caller to specify the longest
+   * allowed match. Use this to protect against streams that may not include
+   * {@code "\n"} or {@code "\r\n"}.
+   *
+   * <p>The returned string will have at most {@code limit} UTF-8 bytes, and the maximum number
+   * of bytes scanned is {@code limit + 2}. If {@code limit == 0} this will always throw
+   * an {@code EOFException} because no bytes will be scanned.
    *
    * <p>This method is safe. No bytes are discarded if the match fails, and the caller is free
    * to try another match: <pre>{@code
@@ -403,15 +406,12 @@ public interface BufferedSource extends Source {
    *   Buffer buffer = new Buffer();
    *   buffer.writeUtf8("12345\r\n");
    *
-   *   // This will throw! A newline character (\n) must be read within the limit.
-   *   buffer.readUtf8LineStrict(5);
+   *   // This will throw! There must be \r\n or \n at the limit or before it.
+   *   buffer.readUtf8LineStrict(4);
    *
    *   // No bytes have been consumed so the caller can retry.
-   *   assertEquals("12345", buffer.readUtf8LineStrict(100));
+   *   assertEquals("12345", buffer.readUtf8LineStrict(5));
    * }</pre>
-   *
-   * <p>The returned string be up to {@code limit - 1} UTF-8 bytes. If {@code limit == 0} this will
-   * always throw an {@code EOFException} because no bytes will be scanned.
    */
   String readUtf8LineStrict(long limit) throws IOException;
 

--- a/okio/src/test/java/okio/BufferedSourceTest.java
+++ b/okio/src/test/java/okio/BufferedSourceTest.java
@@ -475,18 +475,15 @@ public final class BufferedSourceTest {
   }
 
   @Test public void indexOfByteWithBothOffsets() throws IOException {
+    if (factory == Factory.ONE_BYTE_AT_A_TIME) {
+      // When run on Travis, ONE_BYTE_AT_A_TIME
+      // causes out-of-memory errors.
+      return;
+    }
     byte a = (byte) 'a';
     byte c = (byte) 'c';
 
-    int size;
-    if (factory == Factory.ONE_BYTE_AT_A_TIME) {
-      // Larger segment sizes for ONE_BYTE_AT_A_TIME
-      // cause Travis to kill the test.
-      size =  Segment.SIZE + 10;
-    } else {
-      size = Segment.SIZE * 5;
-    }
-
+    int size = Segment.SIZE * 5;
     byte[] bytes = new byte[size];
     Arrays.fill(bytes, a);
 

--- a/okio/src/test/java/okio/ReadUtf8LineTest.java
+++ b/okio/src/test/java/okio/ReadUtf8LineTest.java
@@ -90,34 +90,52 @@ public final class ReadUtf8LineTest {
       source.readUtf8LineStrict();
       fail();
     } catch (EOFException expected) {
-      assertEquals("\\n not found: scanLength=0 content=…", expected.getMessage());
+      assertEquals("\\n not found: limit=0 content=…", expected.getMessage());
     }
   }
 
   @Test public void readUtf8LineStrictWithLimits() throws IOException {
-    data.writeUtf8("abc\ndef\r\nghi\n");
-    assertEquals("abc", source.readUtf8LineStrict(10));
-    assertEquals("def", source.readUtf8LineStrict(10));
+    int[] lens = {1, Segment.SIZE - 2, Segment.SIZE - 1, Segment.SIZE, Segment.SIZE * 10};
+    for (int len : lens) {
+      data.writeUtf8(TestUtil.repeat('a', len)).writeUtf8("\n");
+      assertEquals(len, source.readUtf8LineStrict(len).length());
+      source.readUtf8();
 
-    try {
-      source.readUtf8LineStrict(3);
-      fail("Expected failure: maxRead must include \\n");
-    } catch (EOFException expected) {
-      assertEquals("\\n not found: scanLength=3 content=6768690a…", expected.getMessage());
+      data.writeUtf8(TestUtil.repeat('a', len)).writeUtf8("\n").writeUtf8(TestUtil.repeat('a', len));
+      assertEquals(len, source.readUtf8LineStrict(len).length());
+      source.readUtf8();
+
+      data.writeUtf8(TestUtil.repeat('a', len)).writeUtf8("\r\n");
+      assertEquals(len, source.readUtf8LineStrict(len).length());
+      source.readUtf8();
+
+      data.writeUtf8(TestUtil.repeat('a', len)).writeUtf8("\r\n").writeUtf8(TestUtil.repeat('a', len));
+      assertEquals(len, source.readUtf8LineStrict(len).length());
+      source.readUtf8();
     }
+  }
 
-    // No bytes should be consumed after a failed match.
-    assertEquals("ghi", source.readUtf8LineStrict(10));
+  @Test public void readUtf8LineStrictNoBytesConsumedOnFailure() throws IOException {
+    data.writeUtf8("abc\n");
+    try {
+      source.readUtf8LineStrict(2);
+      fail();
+    } catch (EOFException expected) {
+      assertEquals("\\n not found: limit=2 content=6162630a…", expected.getMessage());
+    }
+    assertEquals("abc", source.readUtf8LineStrict(3));
   }
 
   @Test public void readUtf8LineStrictNonPositive() throws IOException {
+    data.writeUtf8("\r\n");
     try {
       source.readUtf8LineStrict(0);
+      fail("Expected failure: limit must be greater than 0");
     } catch (EOFException expected) {
     }
     try {
       source.readUtf8LineStrict(-1);
-      fail("Expected failure: limit must be positive");
+      fail("Expected failure: limit must be greater than 0");
     } catch (IllegalArgumentException expected) {
     }
   }
@@ -128,8 +146,35 @@ public final class ReadUtf8LineTest {
       source.readUtf8LineStrict();
       fail();
     } catch (EOFException expected) {
-      assertEquals("\\n not found: scanLength=33 content=616161616161616162626262626262626363636363636363"
+      assertEquals("\\n not found: limit=33 content=616161616161616162626262626262626363636363636363"
           + "6464646464646464…", expected.getMessage());
+    }
+  }
+
+  @Test public void newlineAtEnd() throws IOException {
+    data.writeUtf8("abc\n");
+    assertEquals("abc", source.readUtf8LineStrict(3));
+    assertTrue(source.exhausted());
+
+    data.writeUtf8("abc\r\n");
+    assertEquals("abc", source.readUtf8LineStrict(3));
+    assertTrue(source.exhausted());
+
+    data.writeUtf8("abc\r");
+    try {
+      source.readUtf8LineStrict(3);
+      fail();
+    } catch (EOFException expected) {
+      assertEquals("\\n not found: limit=3 content=6162630d…", expected.getMessage());
+    }
+    source.readUtf8();
+
+    data.writeUtf8("abc");
+    try {
+      source.readUtf8LineStrict(3);
+      fail();
+    } catch (EOFException expected) {
+      assertEquals("\\n not found: limit=3 content=616263…", expected.getMessage());
     }
   }
 

--- a/okio/src/test/java/okio/RealBufferedSourceTest.java
+++ b/okio/src/test/java/okio/RealBufferedSourceTest.java
@@ -78,6 +78,19 @@ public final class RealBufferedSourceTest {
     }
   }
 
+  @Test public void indexOfStopsReadingAtLimit() throws Exception {
+    Buffer buffer = new Buffer().writeUtf8("abcdef");
+    BufferedSource bufferedSource = new RealBufferedSource(new ForwardingSource(buffer) {
+      @Override public long read(Buffer sink, long byteCount) throws IOException {
+        return super.read(sink, Math.min(1, byteCount));
+      }
+    });
+
+    assertEquals(6, buffer.size());
+    assertEquals(-1, bufferedSource.indexOf((byte) 'e', 0, 4));
+    assertEquals(2, buffer.size());
+  }
+
   @Test public void requireTracksBufferFirst() throws Exception {
     Buffer source = new Buffer();
     source.writeUtf8("bb");


### PR DESCRIPTION
I liked your idea in PR #278 to change limit to be "the maximum number of bytes returned" instead of "the maximum number of bytes scanned."

I'm not pumped about the duplicate code that this adds in Buffer.readUtf8LineStrict and RealBufferedSource.readUtf8LineStrict, but I didn't see a clean way to avoid that. I'll keep thinking about that while I work on adding limits to the other limitable methods.

(Related to #153, Optional limits on methods like readLine())