### PR TITLE
Change Pipe's sink.flush() to not block.

### DIFF
--- a/okio/src/main/java/okio/Pipe.java
+++ b/okio/src/main/java/okio/Pipe.java
@@ -83,23 +83,16 @@ public final class Pipe {
     @Override public void flush() throws IOException {
       synchronized (buffer) {
         if (sinkClosed) throw new IllegalStateException("closed");
-
-        while (buffer.size() > 0) {
-          if (sourceClosed) throw new IOException("source is closed");
-          timeout.waitUntilNotified(buffer);
-        }
+        if (sourceClosed && buffer.size() > 0) throw new IOException("source is closed");
       }
     }
 
     @Override public void close() throws IOException {
       synchronized (buffer) {
         if (sinkClosed) return;
-        try {
-          flush();
-        } finally {
-          sinkClosed = true;
-          buffer.notifyAll(); // Notify the source that no more bytes are coming.
-        }
+        if (sourceClosed && buffer.size() > 0) throw new IOException("source is closed");
+        sinkClosed = true;
+        buffer.notifyAll(); // Notify the source that no more bytes are coming.
       }
     }
 

--- a/okio/src/test/java/okio/PipeTest.java
+++ b/okio/src/test/java/okio/PipeTest.java
@@ -26,8 +26,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Test;
 
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public final class PipeTest {
   final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(2);
@@ -200,85 +201,36 @@ public final class PipeTest {
     }
   }
 
-  @Test public void sinkFlushWaitsForReaderToReadEverything() throws Exception {
-    final Buffer readBuffer = new Buffer();
-    final Pipe pipe = new Pipe(100L);
-    executorService.execute(new Runnable() {
-      @Override public void run() {
-        try {
-          Thread.sleep(1000);
-          pipe.source().read(readBuffer, 3);
-          Thread.sleep(1000);
-          pipe.source().read(readBuffer, 3);
-        } catch (InterruptedException | IOException e) {
-          throw new AssertionError(e);
-        }
-      }
-    });
-
-    double start = now();
-    pipe.sink().write(new Buffer().writeUtf8("abcdef"), 6);
+  @Test public void sinkFlushDoesntWaitForReader() throws Exception {
+    Pipe pipe = new Pipe(100L);
+    pipe.sink().write(new Buffer().writeUtf8("abc"), 3);
     pipe.sink().flush();
-    assertElapsed(2000.0, start);
-    assertEquals("abcdef", readBuffer.readUtf8());
+
+    BufferedSource bufferedSource = Okio.buffer(pipe.source());
+    assertEquals("abc", bufferedSource.readUtf8(3));
   }
 
   @Test public void sinkFlushFailsIfReaderIsClosedBeforeAllDataIsRead() throws Exception {
-    final Pipe pipe = new Pipe(100L);
-    executorService.execute(new Runnable() {
-      @Override public void run() {
-        try {
-          Thread.sleep(1000);
-          pipe.source().read(new Buffer(), 3);
-          Thread.sleep(1000);
-          pipe.source().close();
-        } catch (InterruptedException | IOException e) {
-          throw new AssertionError(e);
-        }
-      }
-    });
-
-    double start = now();
-    pipe.sink().write(new Buffer().writeUtf8("abcdef"), 6);
+    Pipe pipe = new Pipe(100L);
+    pipe.sink().write(new Buffer().writeUtf8("abc"), 3);
+    pipe.source().close();
     try {
       pipe.sink().flush();
       fail();
     } catch (IOException expected) {
       assertEquals("source is closed", expected.getMessage());
-      assertElapsed(2000.0, start);
     }
   }
 
   @Test public void sinkCloseFailsIfReaderIsClosedBeforeAllDataIsRead() throws Exception {
-    final Pipe pipe = new Pipe(100L);
-    executorService.execute(new Runnable() {
-      @Override public void run() {
-        try {
-          Thread.sleep(1000);
-          pipe.source().read(new Buffer(), 3);
-          Thread.sleep(1000);
-          pipe.source().close();
-        } catch (InterruptedException | IOException e) {
-          throw new AssertionError(e);
-        }
-      }
-    });
-
-    double start = now();
-    pipe.sink().write(new Buffer().writeUtf8("abcdef"), 6);
+    Pipe pipe = new Pipe(100L);
+    pipe.sink().write(new Buffer().writeUtf8("abc"), 3);
+    pipe.source().close();
     try {
       pipe.sink().close();
       fail();
     } catch (IOException expected) {
       assertEquals("source is closed", expected.getMessage());
-      assertElapsed(2000.0, start);
-    }
-
-    try {
-      pipe.sink().flush();
-      fail();
-    } catch (IllegalStateException expected) {
-      assertEquals("closed", expected.getMessage());
     }
   }
 
@@ -303,6 +255,16 @@ public final class PipeTest {
     Pipe pipe = new Pipe(100L);
     pipe.sink().close();
     pipe.sink().close();
+  }
+
+  @Test public void sinkCloseDoesntWaitForSourceRead() throws Exception {
+    Pipe pipe = new Pipe(100L);
+    pipe.sink().write(new Buffer().writeUtf8("abc"), 3);
+    pipe.sink().close();
+
+    BufferedSource bufferedSource = Okio.buffer(pipe.source());
+    assertEquals("abc", bufferedSource.readUtf8());
+    assertTrue(bufferedSource.exhausted());
   }
 
   @Test public void sourceClose() throws Exception {


### PR DESCRIPTION
The current behavior blocks until a reader reads the data. This is unlikely
to be useful (there's no guarantee the consumed data is handled) and makes
certain use cases more difficult to implement.

Closes: https://github.com/square/okio/issues/272