### PR TITLE
Import jsr305 and use it to mark @Nullable stuff.

### DIFF
--- a/okio/pom.xml
+++ b/okio/pom.xml
@@ -14,11 +14,15 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>animal-sniffer-annotations</artifactId>
       <optional>true</optional>
     </dependency>
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/okio/src/main/java/okio/AsyncTimeout.java
+++ b/okio/src/main/java/okio/AsyncTimeout.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 import static okio.Util.checkOffsetAndCount;
 
@@ -57,13 +58,13 @@ public class AsyncTimeout extends Timeout {
    * node to time out, or null if the queue is empty. The head is null until the watchdog thread is
    * started and also after being idle for {@link #IDLE_TIMEOUT_MILLIS}.
    */
-  static AsyncTimeout head;
+  static @Nullable AsyncTimeout head;
 
   /** True if this node is currently in the queue. */
   private boolean inQueue;
 
   /** The next node in the linked list. */
-  private AsyncTimeout next;
+  private @Nullable AsyncTimeout next;
 
   /** If scheduled, this is the time that the watchdog should time this out. */
   private long timeoutAt;
@@ -289,7 +290,7 @@ public class AsyncTimeout extends Timeout {
    * java.io.InterruptedIOException}. If {@code cause} is non-null it is set as the cause of the
    * returned exception.
    */
-  protected IOException newTimeoutException(IOException cause) {
+  protected IOException newTimeoutException(@Nullable IOException cause) {
     InterruptedIOException e = new InterruptedIOException("timeout");
     if (cause != null) {
       e.initCause(cause);
@@ -336,7 +337,7 @@ public class AsyncTimeout extends Timeout {
    * new node was inserted while waiting. Otherwise this returns the node being waited on that has
    * been removed.
    */
-  static AsyncTimeout awaitTimeout() throws InterruptedException {
+  static @Nullable AsyncTimeout awaitTimeout() throws InterruptedException {
     // Get the next eligible node.
     AsyncTimeout node = head.next;
 

--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -26,6 +26,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -52,7 +53,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
       { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
   static final int REPLACEMENT_CHARACTER = '\ufffd';
 
-  Segment head;
+  @Nullable Segment head;
   long size;
 
   public Buffer() {
@@ -631,7 +632,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return result;
   }
 
-  @Override public String readUtf8Line() throws EOFException {
+  @Override public @Nullable String readUtf8Line() throws EOFException {
     long newline = indexOf((byte) '\n');
 
     if (newline == -1) {

--- a/okio/src/main/java/okio/BufferedSource.java
+++ b/okio/src/main/java/okio/BufferedSource.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import javax.annotation.Nullable;
 
 /**
  * A source that keeps a buffer internally so that callers can do small reads without a performance
@@ -378,7 +379,7 @@ public interface BufferedSource extends Source {
    * break is assumed. Null is returned once the source is exhausted. Use this for human-generated
    * data, where a trailing line break is optional.
    */
-  String readUtf8Line() throws IOException;
+  @Nullable String readUtf8Line() throws IOException;
 
   /**
    * Removes and returns characters up to but not including the next line break. A line break is

--- a/okio/src/main/java/okio/ByteString.java
+++ b/okio/src/main/java/okio/ByteString.java
@@ -29,6 +29,7 @@ import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import javax.annotation.Nullable;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -197,7 +198,7 @@ public class ByteString implements Serializable, Comparable<ByteString> {
    * Decodes the Base64-encoded bytes and returns their value as a byte string.
    * Returns null if {@code base64} is not a Base64-encoded sequence of bytes.
    */
-  public static ByteString decodeBase64(String base64) {
+  public static @Nullable ByteString decodeBase64(String base64) {
     if (base64 == null) throw new IllegalArgumentException("base64 == null");
     byte[] decoded = Base64.decode(base64);
     return decoded != null ? new ByteString(decoded) : null;

--- a/okio/src/main/java/okio/HashingSink.java
+++ b/okio/src/main/java/okio/HashingSink.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import javax.annotation.Nullable;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -41,8 +42,8 @@ import static okio.Util.checkOffsetAndCount;
  * }</pre>
  */
 public final class HashingSink extends ForwardingSink {
-  private final MessageDigest messageDigest;
-  private final Mac mac;
+  private final @Nullable MessageDigest messageDigest;
+  private final @Nullable Mac mac;
 
   /** Returns a sink that uses the obsolete MD5 hash algorithm to produce 128-bit hashes. */
   public static HashingSink md5(Sink sink) {

--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -30,6 +30,7 @@ import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 import static okio.Util.checkOffsetAndCount;
@@ -223,7 +224,7 @@ public final class Okio {
 
   private static AsyncTimeout timeout(final Socket socket) {
     return new AsyncTimeout() {
-      @Override protected IOException newTimeoutException(IOException cause) {
+      @Override protected IOException newTimeoutException(@Nullable IOException cause) {
         InterruptedIOException ioe = new SocketTimeoutException("timeout");
         if (cause != null) {
           ioe.initCause(cause);

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -19,6 +19,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import javax.annotation.Nullable;
 
 import static okio.Util.checkOffsetAndCount;
 
@@ -196,7 +197,7 @@ final class RealBufferedSource implements BufferedSource {
     return buffer.readString(byteCount, charset);
   }
 
-  @Override public String readUtf8Line() throws IOException {
+  @Override public @Nullable String readUtf8Line() throws IOException {
     long newline = indexOf((byte) '\n');
 
     if (newline == -1) {

--- a/okio/src/main/java/okio/Segment.java
+++ b/okio/src/main/java/okio/Segment.java
@@ -15,6 +15,8 @@
  */
 package okio;
 
+import javax.annotation.Nullable;
+
 /**
  * A segment of a buffer.
  *
@@ -80,7 +82,7 @@ final class Segment {
    * Removes this segment of a circularly-linked list and returns its successor.
    * Returns null if the list is now empty.
    */
-  public Segment pop() {
+  public @Nullable Segment pop() {
     Segment result = next != this ? next : null;
     prev.next = next;
     next.prev = prev;

--- a/okio/src/main/java/okio/SegmentPool.java
+++ b/okio/src/main/java/okio/SegmentPool.java
@@ -15,6 +15,8 @@
  */
 package okio;
 
+import javax.annotation.Nullable;
+
 /**
  * A collection of unused segments, necessary to avoid GC churn and zero-fill.
  * This pool is a thread-safe static singleton.
@@ -25,7 +27,7 @@ final class SegmentPool {
   static final long MAX_SIZE = 64 * 1024; // 64 KiB.
 
   /** Singly-linked list of segments. */
-  static Segment next;
+  static @Nullable Segment next;
 
   /** Total bytes in this pool. */
   static long byteCount;

--- a/okio/src/main/java/okio/package-info.java
+++ b/okio/src/main/java/okio/package-info.java
@@ -2,4 +2,5 @@
  * Okio complements {@link java.io} and {@link java.nio} to make it much easier to access, store,
  * and process your data.
  */
+@javax.annotation.ParametersAreNonnullByDefault
 package okio;

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>


### PR DESCRIPTION
The result is that IntelliJ + Kotlin correctly infers the right nullability
for Okio's APIs. I used IntelliJ's "Specify types explicitly" quick fix on
the 'a' and 'b' variables below and it did the right thing.

    fun specifyTypeExplicitly(source: BufferedSource) {
      val a: String? = source.readUtf8Line()
      val b: String = source.readUtf8LineStrict()
    }