### PR TITLE
Fix a performance bug in AsyncTimeout.sink().write().

### DIFF
--- a/okio/src/main/java/okio/AsyncTimeout.java
+++ b/okio/src/main/java/okio/AsyncTimeout.java
@@ -165,7 +165,7 @@ public class AsyncTimeout extends Timeout {
           // Count how many bytes to write. This loop guarantees we split on a segment boundary.
           long toWrite = 0L;
           for (Segment s = source.head; toWrite < TIMEOUT_WRITE_SIZE; s = s.next) {
-            int segmentSize = source.head.limit - source.head.pos;
+            int segmentSize = s.limit - s.pos;
             toWrite += segmentSize;
             if (toWrite >= byteCount) {
               toWrite = byteCount;


### PR DESCRIPTION
Previously the behavior was correct but the intended behavior was less
efficient than intended. In particular there were two problems:

 * The loop to find a segment boundary may have made more iterations
   than necessary if the first segment was very small
 * The sink write may not have been on a segment boundary, causing more
   data than necessary to be copied.

Closes: https://github.com/square/okio/issues/311