### PR TITLE
Make Buffer conform to BufferedSource wrt/ EOF handling

### DIFF
--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -103,7 +103,10 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
   }
 
   @Override public void require(long byteCount) throws EOFException {
-    if (size < byteCount) throw new EOFException();
+    if (size < byteCount) {
+      clear(); // exhaust ourselves
+      throw new EOFException();
+    }
   }
 
   @Override public boolean request(long byteCount) {
@@ -112,7 +115,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
 
   @Override public InputStream inputStream() {
     return new InputStream() {
-      @Override public int read() {
+      @Override public int read() throws IOException {
         if (size > 0) return readByte() & 0xff;
         return -1;
       }
@@ -273,8 +276,8 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return result;
   }
 
-  @Override public byte readByte() {
-    if (size == 0) throw new IllegalStateException("size == 0");
+  @Override public byte readByte() throws EOFException {
+    if (size == 0) throw new EOFException();
 
     Segment segment = head;
     int pos = segment.pos;
@@ -304,14 +307,14 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     }
   }
 
-  @Override public short readShort() {
-    if (size < 2) throw new IllegalStateException("size < 2: " + size);
+  @Override public short readShort() throws EOFException {
+    if (size == 0) throw new EOFException();
 
     Segment segment = head;
     int pos = segment.pos;
     int limit = segment.limit;
 
-    // If the short is split across multiple segments, delegate to readByte().
+    // If the first segment does not have a full short, delegate to readByte().
     if (limit - pos < 2) {
       int s = (readByte() & 0xff) << 8
           |   (readByte() & 0xff);
@@ -333,14 +336,14 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return (short) s;
   }
 
-  @Override public int readInt() {
-    if (size < 4) throw new IllegalStateException("size < 4: " + size);
+  @Override public int readInt() throws EOFException {
+    if (size == 0) throw new EOFException();
 
     Segment segment = head;
     int pos = segment.pos;
     int limit = segment.limit;
 
-    // If the int is split across multiple segments, delegate to readByte().
+    // If the first segment does not have a full int, delegate to readByte().
     if (limit - pos < 4) {
       return (readByte() & 0xff) << 24
           |  (readByte() & 0xff) << 16
@@ -365,14 +368,14 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return i;
   }
 
-  @Override public long readLong() {
-    if (size < 8) throw new IllegalStateException("size < 8: " + size);
+  @Override public long readLong() throws EOFException {
+    if (size == 0) throw new EOFException();
 
     Segment segment = head;
     int pos = segment.pos;
     int limit = segment.limit;
 
-    // If the long is split across multiple segments, delegate to readInt().
+    // If the first segment does not have a full long, delegate to readInt().
     if (limit - pos < 8) {
       return (readInt() & 0xffffffffL) << 32
           |  (readInt() & 0xffffffffL);
@@ -399,20 +402,20 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return v;
   }
 
-  @Override public short readShortLe() {
+  @Override public short readShortLe() throws EOFException {
     return Util.reverseBytesShort(readShort());
   }
 
-  @Override public int readIntLe() {
+  @Override public int readIntLe() throws EOFException {
     return Util.reverseBytesInt(readInt());
   }
 
-  @Override public long readLongLe() {
+  @Override public long readLongLe() throws EOFException {
     return Util.reverseBytesLong(readLong());
   }
 
-  @Override public long readDecimalLong() {
-    if (size == 0) throw new IllegalStateException("size == 0");
+  @Override public long readDecimalLong() throws EOFException {
+    if (size == 0) throw new EOFException();
 
     // This value is always built negatively in order to accommodate Long.MIN_VALUE.
     long value = 0;
@@ -469,8 +472,8 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
     return negative ? value : -value;
   }
 
-  @Override public long readHexadecimalUnsignedLong() {
-    if (size == 0) throw new IllegalStateException("size == 0");
+  @Override public long readHexadecimalUnsignedLong() throws EOFException {
+    if (size == 0) throw new EOFException();
 
     long value = 0;
     int seen = 0;
@@ -760,11 +763,12 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
   }
 
   @Override public byte[] readByteArray(long byteCount) throws EOFException {
-    checkOffsetAndCount(size, 0, byteCount);
-    if (byteCount > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException("byteCount > Integer.MAX_VALUE: " + byteCount);
-    }
+    if (byteCount < 0) throw new IllegalArgumentException(
+        "byteCount < 0: " + byteCount);
+    if (byteCount > Integer.MAX_VALUE) throw new IllegalArgumentException(
+        "byteCount > Integer.MAX_VALUE: " + byteCount);
 
+    require(byteCount);
     byte[] result = new byte[(int) byteCount];
     readFully(result);
     return result;

--- a/okio/src/main/java/okio/BufferedSource.java
+++ b/okio/src/main/java/okio/BufferedSource.java
@@ -15,6 +15,7 @@
  */
 package okio;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -36,14 +37,26 @@ public interface BufferedSource extends Source {
   boolean exhausted() throws IOException;
 
   /**
-   * Returns when the buffer contains at least {@code byteCount} bytes. Throws an
-   * {@link java.io.EOFException} if the source is exhausted before the required bytes can be read.
+   * Returns when the buffer contains at least {@code byteCount} bytes.
+   *
+   * <p>If the source is exhausted before the required number of bytes can be made available, any
+   * buffered bytes are discarded and {@link EOFException} is thrown. Discarding the buffer contents
+   * in this scenario is necessary to preserve the general contract that {@link EOFException}
+   * implies that the source is definitely {@link #exhausted()} and that no further bytes can be
+   * read from it.
+   *
+   * @see #request(long)
    */
   void require(long byteCount) throws IOException;
 
   /**
-   * Returns true when the buffer contains at least {@code byteCount} bytes, expanding it as
-   * necessary. Returns false if the source is exhausted before the requested bytes can be read.
+   * Returns <code>true</code> when the buffer contains at least {@code byteCount} bytes, expanding
+   * it as necessary.
+   *
+   * <p>Returns <code>false</code> if the source is exhausted before the requested number of bytes
+   * can be made available. Note that, unlike {@link #require(long)}, this method will leave any
+   * buffered data intact, and {@link #exhausted()} will not return <code>true</code> until those
+   * bytes have been consumed.
    */
   boolean request(long byteCount) throws IOException;
 

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -57,7 +57,10 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public void require(long byteCount) throws IOException {
-    if (!request(byteCount)) throw new EOFException();
+    if (!request(byteCount)) {
+      buffer.clear(); // exhaust ourselves
+      throw new EOFException();
+    }
   }
 
   @Override public boolean request(long byteCount) throws IOException {
@@ -118,18 +121,7 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public void readFully(byte[] sink) throws IOException {
-    try {
-      require(sink.length);
-    } catch (EOFException e) {
-      // The underlying source is exhausted. Copy the bytes we got before rethrowing.
-      int offset = 0;
-      while (buffer.size > 0) {
-        int read = buffer.read(sink, offset, (int) buffer.size);
-        if (read == -1) throw new AssertionError();
-        offset += read;
-      }
-      throw e;
-    }
+    request(sink.length);
     buffer.readFully(sink);
   }
 
@@ -146,13 +138,7 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public void readFully(Buffer sink, long byteCount) throws IOException {
-    try {
-      require(byteCount);
-    } catch (EOFException e) {
-      // The underlying source is exhausted. Copy the bytes we got before rethrowing.
-      sink.writeAll(buffer);
-      throw e;
-    }
+    request(byteCount);
     buffer.readFully(sink, byteCount);
   }
 
@@ -192,8 +178,9 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public String readString(long byteCount, Charset charset) throws IOException {
-    require(byteCount);
     if (charset == null) throw new IllegalArgumentException("charset == null");
+
+    require(byteCount);
     return buffer.readString(byteCount, charset);
   }
 


### PR DESCRIPTION
Also throw IllegalArgument instead of ArrayIndexOutOfBounds for
negative byteCount.