### PR TITLE
Return SegmentedByteString from Buffer.readByteString for large reads

### DIFF
--- a/benchmarks/src/main/java/com/squareup/okio/benchmarks/ByteStringReadWriteBenchmark.java
+++ b/benchmarks/src/main/java/com/squareup/okio/benchmarks/ByteStringReadWriteBenchmark.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.okio.benchmarks;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okio.BufferedSink;
+import okio.BufferedSource;
+import okio.Okio;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Fork(1)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ByteStringReadWriteBenchmark {
+
+  @Param({ "1000000" })
+  int size;
+
+  public static final File OriginPath =
+      new File(System.getProperty("okio.bench.origin.path", "/dev/zero"));
+
+  public static final File DestinationPath =
+      new File(System.getProperty("okio.bench.dest.path", "/dev/null"));
+
+  @Benchmark
+  public void byteStringReadAndWrite() throws IOException {
+    try (BufferedSource src = Okio.buffer(Okio.source(OriginPath))) {
+      try (BufferedSink sink = Okio.buffer(Okio.sink(DestinationPath))) {
+        sink.write(src.readByteString(size));
+      }
+    }
+  }
+}

--- a/okio/src/test/java/okio/BufferTest.java
+++ b/okio/src/test/java/okio/BufferTest.java
@@ -176,11 +176,11 @@ public final class BufferTest {
     assertEquals(segmentsSizes, src.segmentSizes());
 
     ByteString string = src.readByteString();
-    assertTrue("ByteString is segmented", string instanceof SegmentedByteString);
+    assertTrue("ByteString should be segmented", string instanceof SegmentedByteString);
 
     Buffer dst = new Buffer().write(string);
     assertEquals(segmentsSizes, dst.segmentSizes());
-    assertTrue("destination Buffer shares segment with ByteString", ((SegmentedByteString) string).segments[0] == dst.head.data);
+    assertTrue("destination Buffer should share segment with ByteString", ((SegmentedByteString) string).segments[0] == dst.head.data);
   }
 
 


### PR DESCRIPTION
This improves performance by avoiding a copy each on both the input and output side when doing IO with large byte strings. One use case where this happens in practice is using Wire with protobufs that contain large amounts of binary data. (We're using Okio / and Wire both on the server and Android.)

#### Alternative Ideas

An alternative (or even complementary) approach I am considering is enhancing `RealBuffered{Source,Sink}` to bypass the buffer when reading or writing a large `byte[]` or `ByteString`, similar to what `Buffered{Input,Output}Stream` does when reading/writing a block larger than it's buffer size.

A fairly straightforward way of doing this would be to create extended `Source` and `Sink` interfaces that directly support `byte[]` reads / writes. `RealBuffered{Source,Sink}` could then have corresponding sub-classes that delegate to those unbuffered methods for large reads or writes. `Okio.buffer` would create the correct variant depending on whether the source/sink supports the extended interface. The `{Input,Output}Stream` source and sink implementations would be the primary ones that would need to support this extended interface.

(Another approach would be to try to avoid any changes to `Source` and `Sink` implementations and instead have the `RealBufferedSink` turn (for example) a large `write(byte[])` into a `sink.write()` with a special one-off `Buffer` that directly wraps the array to be written. This seems very complex though due to the large API of `Buffer`)
