### PR TITLE
Unsafe access to segment byte arrays.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -6,7 +6,9 @@
 <module name="Checker">
   <module name="SuppressWarningsFilter"/>
   <module name="NewlineAtEndOfFile"/>
-  <module name="FileLength"/>
+  <module name="FileLength">
+    <property name="max" value="2500"/>
+  </module>
   <module name="FileTabCharacter"/>
 
   <!-- Trailing spaces -->

--- a/okio/src/main/java/okio/Segment.java
+++ b/okio/src/main/java/okio/Segment.java
@@ -65,17 +65,27 @@ final class Segment {
     this.shared = false;
   }
 
-  Segment(Segment shareFrom) {
-    this(shareFrom.data, shareFrom.pos, shareFrom.limit);
-    shareFrom.shared = true;
-  }
-
-  Segment(byte[] data, int pos, int limit) {
+  Segment(byte[] data, int pos, int limit, boolean shared, boolean owner) {
     this.data = data;
     this.pos = pos;
     this.limit = limit;
-    this.owner = false;
-    this.shared = true;
+    this.shared = shared;
+    this.owner = owner;
+  }
+
+  /**
+   * Returns a new segment that shares the underlying byte array with this. Adjusting pos and limit
+   * are safe but writes are forbidden. This also marks the current segment as shared, which
+   * prevents it from being pooled.
+   */
+  Segment sharedCopy() {
+    shared = true;
+    return new Segment(data, pos, limit, true, false);
+  }
+
+  /** Returns a new segment that its own private copy of the underlying byte array. */
+  Segment unsharedCopy() {
+    return new Segment(data.clone(), pos, limit, false, true);
   }
 
   /**
@@ -121,7 +131,7 @@ final class Segment {
     //    may lead to long chains of short segments.
     // To balance these goals we only share segments when the copy will be large.
     if (byteCount >= SHARE_MINIMUM) {
-      prefix = new Segment(this);
+      prefix = sharedCopy();
     } else {
       prefix = SegmentPool.take();
       System.arraycopy(data, pos, prefix.data, 0, byteCount);

--- a/okio/src/main/java/okio/SegmentedByteString.java
+++ b/okio/src/main/java/okio/SegmentedByteString.java
@@ -195,7 +195,7 @@ final class SegmentedByteString extends ByteString {
       int segmentPos = directory[segmentCount + s];
       int nextSegmentOffset = directory[s];
       Segment segment = new Segment(segments[s], segmentPos,
-          segmentPos + nextSegmentOffset - segmentOffset);
+          segmentPos + nextSegmentOffset - segmentOffset, true, false);
       if (buffer.head == null) {
         buffer.head = segment.next = segment.prev = segment;
       } else {

--- a/okio/src/test/java/okio/BufferCursorTest.java
+++ b/okio/src/test/java/okio/BufferCursorTest.java
@@ -1,0 +1,520 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import static okio.Buffer.UnsafeCursor;
+import static okio.TestUtil.bufferWithRandomSegmentLayout;
+import static okio.TestUtil.bufferWithSegments;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+@RunWith(Parameterized.class)
+public final class BufferCursorTest {
+  enum BufferFactory {
+    EMPTY {
+      @Override Buffer newBuffer() {
+        return new Buffer();
+      }
+    },
+
+    SMALL_BUFFER {
+      @Override Buffer newBuffer() {
+        return new Buffer().writeUtf8("abcde");
+      }
+    },
+
+    SMALL_SEGMENTED_BUFFER {
+      @Override Buffer newBuffer() throws Exception {
+        return bufferWithSegments("abc", "defg", "hijkl");
+      }
+    },
+
+    LARGE_BUFFER {
+      @Override Buffer newBuffer() throws Exception {
+        Random dice = new Random(0);
+        byte[] largeByteArray = new byte[512 * 1024];
+        dice.nextBytes(largeByteArray);
+
+        return new Buffer().write(largeByteArray);
+      }
+    },
+
+    LARGE_BUFFER_WITH_RANDOM_LAYOUT {
+      @Override Buffer newBuffer() throws Exception {
+        Random dice = new Random(0);
+        byte[] largeByteArray = new byte[512 * 1024];
+        dice.nextBytes(largeByteArray);
+
+        return bufferWithRandomSegmentLayout(dice, largeByteArray);
+      }
+    };
+
+    abstract Buffer newBuffer() throws Exception;
+  }
+
+  @Parameters(name = "{0}")
+  public static List<Object[]> parameters() throws Exception {
+    List<Object[]> result = new ArrayList<>();
+    for (BufferFactory bufferFactory : BufferFactory.values()) {
+      result.add(new Object[] { bufferFactory });
+    }
+    return result;
+  }
+
+  @Parameter public BufferFactory bufferFactory;
+
+  @Test public void apiExample() throws Exception {
+    Buffer buffer = new Buffer();
+
+    try (UnsafeCursor cursor = buffer.readAndWriteUnsafe()) {
+      cursor.resizeBuffer(1000_000);
+
+      while (cursor.next() != -1) {
+        Arrays.fill(cursor.data, cursor.start, cursor.end, (byte) 'x');
+      }
+
+      cursor.seek(3);
+      cursor.data[cursor.start] = 'o';
+
+      cursor.seek(1);
+      cursor.data[cursor.start] = 'o';
+
+      cursor.resizeBuffer(4);
+    }
+
+    assertEquals(new Buffer().writeUtf8("xoxo"), buffer);
+  }
+
+  @Test public void accessSegmentBySegment() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    try (UnsafeCursor cursor = buffer.readUnsafe()) {
+      Buffer actual = new Buffer();
+      while (cursor.next() != -1L) {
+        actual.write(cursor.data, cursor.start, cursor.end - cursor.start);
+      }
+      assertEquals(buffer, actual);
+    }
+  }
+
+  @Test public void seekToNegativeOneSeeksBeforeFirstSegment() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    try (UnsafeCursor cursor = buffer.readUnsafe()) {
+      cursor.seek(-1L);
+      assertEquals(-1, cursor.offset);
+      assertEquals(null, cursor.data);
+      assertEquals(-1, cursor.start);
+      assertEquals(-1, cursor.end);
+
+      cursor.next();
+      assertEquals(0, cursor.offset);
+    }
+  }
+
+  @Test public void accessByteByByte() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    try (UnsafeCursor cursor = buffer.readUnsafe()) {
+      byte[] actual = new byte[(int) buffer.size()];
+      for (int i = 0; i < buffer.size(); i++) {
+        cursor.seek(i);
+        actual[i] = cursor.data[cursor.start];
+      }
+      assertEquals(ByteString.of(actual), buffer.snapshot());
+    }
+  }
+
+  @Test public void accessByteByByteReverse() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    try (UnsafeCursor cursor = buffer.readUnsafe()) {
+    byte[] actual = new byte[(int) buffer.size()];
+      for (int i = (int) (buffer.size() - 1); i >= 0; i--) {
+        cursor.seek(i);
+        actual[i] = cursor.data[cursor.start];
+      }
+      assertEquals(ByteString.of(actual), buffer.snapshot());
+    }
+  }
+
+  @Test public void accessByteByByteAlwaysResettingToZero() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    try (UnsafeCursor cursor = buffer.readUnsafe()) {
+      byte[] actual = new byte[(int) buffer.size()];
+      for (int i = 0; i < buffer.size(); i++) {
+        cursor.seek(i);
+        actual[i] = cursor.data[cursor.start];
+        cursor.seek(0L);
+      }
+      assertEquals(ByteString.of(actual), buffer.snapshot());
+    }
+  }
+
+  @Test public void segmentBySegmentNavigation() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    UnsafeCursor cursor = buffer.readUnsafe();
+    assertEquals(-1, cursor.offset);
+    try {
+      long lastOffset = cursor.offset;
+      while (cursor.next() != -1L) {
+        assertTrue(cursor.offset > lastOffset);
+        lastOffset = cursor.offset;
+      }
+      assertEquals(buffer.size(), cursor.offset);
+      assertNull(cursor.data);
+      assertEquals(-1, cursor.start);
+      assertEquals(-1, cursor.end);
+    } finally {
+      cursor.close();
+    }
+  }
+
+  @Test public void seekWithinSegment() throws Exception {
+    assumeTrue(bufferFactory == BufferFactory.SMALL_SEGMENTED_BUFFER);
+    Buffer buffer = bufferFactory.newBuffer();
+    assertEquals("abcdefghijkl", buffer.clone().readUtf8());
+
+    // Seek to the 'f' in the "defg" segment.
+    try (UnsafeCursor cursor = buffer.readUnsafe()) {
+      assertEquals(2, cursor.seek(5)); // 2 for 2 bytes left in the segment: "fg".
+      assertEquals(5, cursor.offset);
+      assertEquals(2, cursor.end - cursor.start);
+      assertEquals('d', (char) cursor.data[cursor.start - 2]); // Out of bounds!
+      assertEquals('e', (char) cursor.data[cursor.start - 1]); // Out of bounds!
+      assertEquals('f', (char) cursor.data[cursor.start]);
+      assertEquals('g', (char) cursor.data[cursor.start + 1]);
+    }
+  }
+
+  @Test public void acquireAndRelease() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    UnsafeCursor cursor = new UnsafeCursor();
+
+    // Nothing initialized before acquire.
+    assertEquals(-1, cursor.offset);
+    assertNull(cursor.data);
+    assertEquals(-1, cursor.start);
+    assertEquals(-1, cursor.end);
+
+    buffer.readUnsafe(cursor);
+    cursor.close();
+
+    // Nothing initialized after close.
+    assertEquals(-1, cursor.offset);
+    assertNull(cursor.data);
+    assertEquals(-1, cursor.start);
+    assertEquals(-1, cursor.end);
+  }
+
+  @Test public void doubleAcquire() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    try (UnsafeCursor cursor = buffer.readUnsafe()) {
+      buffer.readUnsafe(cursor);
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void releaseWithoutAcquire() throws Exception {
+    UnsafeCursor cursor = new UnsafeCursor();
+    try {
+      cursor.close();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void releaseAfterRelease() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    UnsafeCursor cursor = buffer.readUnsafe();
+    cursor.close();
+    try {
+      cursor.close();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void enlarge() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    long originalSize = buffer.size();
+
+    Buffer expected = deepCopy(buffer);
+    expected.writeUtf8("abc");
+
+    try (UnsafeCursor cursor = buffer.readAndWriteUnsafe()) {
+      assertEquals(originalSize, cursor.resizeBuffer(originalSize + 3));
+      cursor.seek(originalSize);
+      cursor.data[cursor.start] = 'a';
+      cursor.seek(originalSize + 1);
+      cursor.data[cursor.start] = 'b';
+      cursor.seek(originalSize + 2);
+      cursor.data[cursor.start] = 'c';
+    }
+
+    assertEquals(expected, buffer);
+  }
+
+  @Test public void enlargeByManySegments() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    long originalSize = buffer.size();
+
+    Buffer expected = deepCopy(buffer);
+    expected.writeUtf8(TestUtil.repeat('x', 1_000_000));
+
+    try (UnsafeCursor cursor = buffer.readAndWriteUnsafe()) {
+      cursor.resizeBuffer(originalSize + 1_000_000);
+      cursor.seek(originalSize);
+      do {
+        Arrays.fill(cursor.data, cursor.start, cursor.end, (byte) 'x');
+      } while (cursor.next() != -1);
+    }
+
+    assertEquals(expected, buffer);
+  }
+
+  @Test public void resizeNotAcquired() throws Exception {
+    UnsafeCursor cursor = new UnsafeCursor();
+    try {
+      cursor.resizeBuffer(10);
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void resizeAcquiredReadWrite() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+
+    try (UnsafeCursor cursor = buffer.readUnsafe()) {
+      cursor.resizeBuffer(10);
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void shrink() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    assumeTrue(buffer.size() > 3);
+    long originalSize = buffer.size();
+
+    Buffer expected = new Buffer();
+    deepCopy(buffer).copyTo(expected, 0, originalSize - 3);
+
+    try (UnsafeCursor cursor = buffer.readAndWriteUnsafe()) {
+      assertEquals(originalSize, cursor.resizeBuffer(originalSize - 3));
+    }
+
+    assertEquals(expected, buffer);
+  }
+
+  @Test public void shrinkByManySegments() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    assumeTrue(buffer.size() <= 1_000_000);
+    long originalSize = buffer.size();
+
+    Buffer toShrink = new Buffer();
+    toShrink.writeUtf8(TestUtil.repeat('x', 1_000_000));
+    deepCopy(buffer).copyTo(toShrink, 0, originalSize);
+
+    UnsafeCursor cursor = new UnsafeCursor();
+    toShrink.readAndWriteUnsafe(cursor);
+    try {
+      cursor.resizeBuffer(originalSize);
+    } finally {
+      cursor.close();
+    }
+
+    Buffer expected = new Buffer();
+    expected.writeUtf8(TestUtil.repeat('x', (int) originalSize));
+    assertEquals(expected, toShrink);
+  }
+
+  @Test public void shrinkAdjustOffset() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    assumeTrue(buffer.size() > 4);
+
+    try (UnsafeCursor cursor = buffer.readAndWriteUnsafe()) {
+      cursor.seek(buffer.size() - 1);
+      cursor.resizeBuffer(3);
+      assertEquals(3, cursor.offset);
+      assertEquals(null, cursor.data);
+      assertEquals(-1, cursor.start);
+      assertEquals(-1, cursor.end);
+    }
+  }
+
+  @Test public void resizeToSameSizeRetainsOffset() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    long originalSize = buffer.size();
+
+    try (UnsafeCursor cursor = buffer.readAndWriteUnsafe()) {
+      cursor.seek(buffer.size() / 2);
+      assertEquals(originalSize, buffer.size());
+      long offsetBefore = cursor.offset;
+      byte[] dataBefore = cursor.data;
+      int posBefore = cursor.start;
+      int limitBefore = cursor.end;
+      cursor.resizeBuffer(originalSize);
+      assertEquals(originalSize, buffer.size());
+      assertEquals(offsetBefore, cursor.offset);
+      assertEquals(dataBefore, cursor.data);
+      assertEquals(posBefore, cursor.start);
+      assertEquals(limitBefore, cursor.end);
+    }
+  }
+
+  @Test public void enlargeRetainsOffset() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    long originalSize = buffer.size();
+
+    try (UnsafeCursor cursor = buffer.readAndWriteUnsafe()) {
+      cursor.seek(buffer.size() / 2);
+      assertEquals(originalSize, buffer.size());
+      long offsetBefore = cursor.offset;
+      cursor.resizeBuffer(originalSize * 2);
+      assertEquals(originalSize * 2, buffer.size());
+      assertEquals(offsetBefore, cursor.offset);
+    }
+  }
+
+  @Test public void shrinkRetainsOffset() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+    long originalSize = buffer.size();
+
+    try (UnsafeCursor cursor = buffer.readAndWriteUnsafe()) {
+      cursor.seek(buffer.size() / 4);
+      assertEquals(originalSize, buffer.size());
+      long offsetBefore = cursor.offset;
+      cursor.resizeBuffer(originalSize / 2);
+      assertEquals(originalSize / 2, buffer.size());
+      assertEquals(offsetBefore, cursor.offset);
+    }
+  }
+
+  @Test public void acquireReadOnlyDoesNotCopySharedDataArray() throws Exception {
+    Buffer buffer = deepCopy(bufferFactory.newBuffer());
+    assumeTrue(buffer.size() > 0);
+
+    Buffer shared = buffer.clone();
+    assertTrue(buffer.head.shared);
+
+    try (UnsafeCursor cursor = buffer.readUnsafe()) {
+      cursor.seek(0);
+      assertSame(cursor.data, shared.head.data);
+    }
+  }
+
+  @Test public void acquireReadWriteDoesNotCopyUnsharedDataArray() throws Exception {
+    Buffer buffer = deepCopy(bufferFactory.newBuffer());
+    assumeTrue(buffer.size() > 0);
+    assertFalse(buffer.head.shared);
+
+    byte[] originalData = buffer.head.data;
+
+    try (UnsafeCursor cursor = buffer.readAndWriteUnsafe()) {
+      cursor.seek(0);
+      assertSame(cursor.data, originalData);
+    }
+  }
+
+  @Test public void acquireReadWriteCopiesSharedDataArray() throws Exception {
+    Buffer buffer = deepCopy(bufferFactory.newBuffer());
+    assumeTrue(buffer.size() > 0);
+
+    Buffer shared = buffer.clone();
+    assertTrue(buffer.head.shared);
+
+    try (UnsafeCursor cursor = buffer.readAndWriteUnsafe()) {
+      cursor.seek(0);
+      assertNotSame(cursor.data, shared.head.data);
+    }
+  }
+
+  @Test public void writeSharedSegments() throws Exception {
+    Buffer buffer = bufferFactory.newBuffer();
+
+    // Make a deep copy. This buffer's segments are not shared.
+    Buffer deepCopy = deepCopy(buffer);
+    assertTrue(deepCopy.head == null || !deepCopy.head.shared);
+
+    // Make a shallow copy. Both buffers' segments are shared as a side effect.
+    Buffer shallowCopy = buffer.clone();
+    assertTrue(shallowCopy.head == null || shallowCopy.head.shared);
+    assertTrue(buffer.head == null || buffer.head.shared);
+
+    Buffer expected = new Buffer();
+    expected.writeUtf8(TestUtil.repeat('x', (int) buffer.size()));
+
+    try (UnsafeCursor cursor = buffer.readAndWriteUnsafe()) {
+      while (cursor.next() != -1) {
+        Arrays.fill(cursor.data, cursor.start, cursor.end, (byte) 'x');
+      }
+    }
+
+    // The buffer was fully changed.
+    assertEquals(expected, buffer);
+
+    // The buffer we're shared with is unchanged.
+    assertEquals(deepCopy, shallowCopy);
+  }
+
+  /** As an optimization it's okay to use the same cursor on multiple buffers. */
+  @Test public void cursorReuse() throws Exception {
+    UnsafeCursor cursor = new UnsafeCursor();
+
+    Buffer buffer1 = bufferFactory.newBuffer();
+    buffer1.readUnsafe(cursor);
+    assertSame(buffer1, cursor.buffer);
+    assertFalse(cursor.readWrite);
+    cursor.close();
+    assertSame(null, cursor.buffer);
+
+    Buffer buffer2 = bufferFactory.newBuffer();
+    buffer2.readAndWriteUnsafe(cursor);
+    assertSame(buffer2, cursor.buffer);
+    assertTrue(cursor.readWrite);
+    cursor.close();
+    assertSame(null, cursor.buffer);
+  }
+
+  /** Returns a copy of {@code buffer} with no segments with {@code original}. */
+  private Buffer deepCopy(Buffer original) {
+    Buffer result = new Buffer();
+    if (original.size() == 0) return result;
+
+    result.head = original.head.unsharedCopy();
+    result.head.next = result.head.prev = result.head;
+    for (Segment s = original.head.next; s != original.head; s = s.next) {
+      result.head.prev.push(s.unsharedCopy());
+    }
+    result.size = original.size;
+
+    return result;
+  }
+}

--- a/okio/src/test/java/okio/TestUtil.java
+++ b/okio/src/test/java/okio/TestUtil.java
@@ -198,4 +198,22 @@ final class TestUtil {
 
     return result;
   }
+
+  /**
+   * Returns a new buffer containing the contents of {@code segments}, attempting to isolate each
+   * string to its own segment in the returned buffer. This clones buffers so that segments are
+   * shared, preventing compaction from occurring.
+   */
+  public static Buffer bufferWithSegments(String... segments) throws Exception {
+    Buffer result = new Buffer();
+    for (String s : segments) {
+      int offsetInSegment = s.length() < Segment.SIZE ? (Segment.SIZE - s.length()) / 2 : 0;
+      Buffer buffer = new Buffer();
+      buffer.writeUtf8(repeat('_', offsetInSegment));
+      buffer.writeUtf8(s);
+      buffer.skip(offsetInSegment);
+      result.write(buffer.clone(), buffer.size);
+    }
+    return result;
+  }
 }


### PR DESCRIPTION
This offers direct access to the byte arrays inside the buffer's
segments. It's very low-level and only appropriate for low-level
integration: compression frameworks, encryption libraries, etc.

Closes: https://github.com/square/okio/issues/141