### PR TITLE
Allow Buffer.getByte() to search backwards for the desired segment

### DIFF
--- a/benchmarks/src/main/java/com/squareup/okio/benchmarks/GetByteBenchmark.java
+++ b/benchmarks/src/main/java/com/squareup/okio/benchmarks/GetByteBenchmark.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okio.benchmarks;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okio.Buffer;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+@Fork(1)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class GetByteBenchmark {
+  Buffer buffer;
+
+  @Param({ "2097152" })
+  int bufferSize; // 2 MB = 256 Segments
+
+  @Setup
+  public void setup() throws IOException {
+    buffer = new Buffer();
+    while (buffer.size() < bufferSize) {
+      buffer.write(new byte[8192]);
+    }
+  }
+
+  @Benchmark
+  public void getByteBeginning() {
+    buffer.getByte(0);
+  }
+
+  @Benchmark
+  public void getByteEnd() {
+    buffer.getByte(buffer.size() - 1);
+  }
+
+  @Benchmark
+  public void getByteMiddle() {
+    buffer.getByte(buffer.size() / 2);
+  }
+
+  public static void main(String[] args) throws IOException, RunnerException {
+    Main.main(new String[] {
+        GetByteBenchmark.class.getName()
+    });
+  }
+}

--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -297,10 +297,18 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable {
   /** Returns the byte at {@code pos}. */
   public byte getByte(long pos) {
     checkOffsetAndCount(size, pos, 1);
-    for (Segment s = head; true; s = s.next) {
-      int segmentByteCount = s.limit - s.pos;
-      if (pos < segmentByteCount) return s.data[s.pos + (int) pos];
-      pos -= segmentByteCount;
+    if (size - pos > pos) {
+      for (Segment s = head; true; s = s.next) {
+        int segmentByteCount = s.limit - s.pos;
+        if (pos < segmentByteCount) return s.data[s.pos + (int) pos];
+        pos -= segmentByteCount;
+      }
+    } else {
+      pos -= size;
+      for (Segment s = head.prev; true; s = s.prev) {
+        pos += s.limit - s.pos;
+        if (pos >= 0) return s.data[s.pos + (int) pos];
+      }
     }
   }
 


### PR DESCRIPTION
Uses of Buffer.getByte() within the Okio project access it more often relative to the end of the Buffer instead of from the beginning.  Specifically the ReadBufferedSource.readHexadecimalUnsignedLong() and ReadBufferedSource.readDecimalLong() methods make heavy use of retrieving the latest byte from the Buffer and with this change, the unit tests for these methods with the OneByteAtATime source no longer take over a second to run.

A benchmark for this behavior has been created and verified to show significant improvement.

Before:
```
Benchmark                                    (bufferSize)    Mode  Samples  Score   Error  Units
c.s.o.b.GetByteBenchmark.getByteBeginning         2097152  sample   160460  0.037 ± 0.003  us/op
c.s.o.b.GetByteBenchmark.getByteEnd               2097152  sample   107573  1.481 ± 0.018  us/op
c.s.o.b.GetByteBenchmark.getByteMiddle            2097152  sample   112678  0.721 ± 0.013  us/op
```

After:
```
Benchmark                                    (bufferSize)    Mode  Samples  Score   Error  Units
c.s.o.b.GetByteBenchmark.getByteBeginning         2097152  sample   167078  0.035 ± 0.003  us/op
c.s.o.b.GetByteBenchmark.getByteEnd               2097152  sample   136939  0.036 ± 0.003  us/op
c.s.o.b.GetByteBenchmark.getByteMiddle            2097152  sample   120560  0.672 ± 0.015  us/op
```

In total, during all unit tests, the getByte() method is invoked 87,467 times.  Roughly 60% (52,152) of those are for bytes in the second half of the buffer.  Without the change, this results in an additional 67,196,832 passes through the segment search loop.  With the change, there are only an additional 6,213 passes through the forward loop and an additional 10,281 passes through the backwards loop.