### PR TITLE
Null checking and throwing IOException

### DIFF
--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -114,6 +114,7 @@ public final class Okio {
    */
   public static Sink sink(Socket socket) throws IOException {
     if (socket == null) throw new IllegalArgumentException("socket == null");
+    if (socket.getOutputStream() == null) throw new IOException("socket's output stream == null");
     AsyncTimeout timeout = timeout(socket);
     Sink sink = sink(socket.getOutputStream(), timeout);
     return timeout.sink(sink);
@@ -219,6 +220,7 @@ public final class Okio {
    */
   public static Source source(Socket socket) throws IOException {
     if (socket == null) throw new IllegalArgumentException("socket == null");
+    if (socket.getInputStream() == null) throw new IOException("socket's input stream == null");
     AsyncTimeout timeout = timeout(socket);
     Source source = source(socket.getInputStream(), timeout);
     return timeout.source(source);


### PR DESCRIPTION
### Description
- This PR is coming from an okhttp PR that attempted to fix the issue.  I was asked to make this fix here instead.  https://github.com/square/okhttp/pull/3796
- Checking if input or output streams are null and throwing IOException so that okhttp properly catches the error.  This is to avoid an uncommon crash where a Socket's in/output stream is null

```
Fatal Exception: java.lang.IllegalArgumentException: out == null
       at okio.Okio.sink(SourceFile:69)
       at okio.Okio.sink(SourceFile:118)
       at okhttp3.internal.connection.RealConnection.connectSocket(SourceFile:251)
       at okhttp3.internal.connection.RealConnection.connect(SourceFile:158)
       at okhttp3.internal.connection.StreamAllocation.findConnection(SourceFile:256)
       at okhttp3.internal.connection.StreamAllocation.findHealthyConnection(SourceFile:134)
       at okhttp3.internal.connection.StreamAllocation.newStream(SourceFile:113)
       at okhttp3.internal.connection.ConnectInterceptor.intercept(SourceFile:42)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:147)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:121)
       at okhttp3.internal.cache.CacheInterceptor.intercept(SourceFile:93)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:147)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:121)
       at okhttp3.internal.http.BridgeInterceptor.intercept(SourceFile:93)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:147)
       at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(SourceFile:125)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:147)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:121)
       at okhttp3.RealCall.getResponseWithInterceptorChain(SourceFile:200)
       at okhttp3.RealCall$AsyncCall.execute(SourceFile:147)
       at okhttp3.internal.NamedRunnable.run(SourceFile:32)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
       at java.lang.Thread.run(Thread.java:818)
