### PR TITLE
InflaterSource needs to honor read byte count

### DIFF
--- a/okio/src/main/java/okio/InflaterSource.java
+++ b/okio/src/main/java/okio/InflaterSource.java
@@ -64,7 +64,8 @@ public final class InflaterSource implements Source {
       // Decompress the inflater's compressed data into the sink.
       try {
         Segment tail = sink.writableSegment(1);
-        int bytesInflated = inflater.inflate(tail.data, tail.limit, Segment.SIZE - tail.limit);
+        int toRead = (int) Math.min(byteCount, Segment.SIZE - tail.limit);
+        int bytesInflated = inflater.inflate(tail.data, tail.limit, toRead);
         if (bytesInflated > 0) {
           tail.limit += bytesInflated;
           sink.size += bytesInflated;

--- a/okio/src/test/java/okio/InflaterSourceTest.java
+++ b/okio/src/test/java/okio/InflaterSourceTest.java
@@ -17,7 +17,6 @@ package okio;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
 import org.junit.Test;
@@ -86,6 +85,28 @@ public final class InflaterSourceTest {
       inflated.skip(i);
       assertEquals("God help us, we're in the hands of engineers.", inflated.readUtf8());
     }
+  }
+
+  @Test public void inflateSingleByte() throws Exception {
+    Buffer inflated = new Buffer();
+    Buffer deflated = decodeBase64(
+        "eJxzz09RyEjNKVAoLdZRKE9VL0pVyMxTKMlIVchIzEspVshPU0jNS8/MS00tKtYDAF6CD5s=");
+    InflaterSource source = new InflaterSource(deflated, new Inflater());
+    source.read(inflated, 1);
+    source.close();
+    assertEquals("G", inflated.readUtf8());
+    assertEquals(0, inflated.size());
+  }
+
+  @Test public void inflateByteCount() throws Exception {
+    Buffer inflated = new Buffer();
+    Buffer deflated = decodeBase64(
+        "eJxzz09RyEjNKVAoLdZRKE9VL0pVyMxTKMlIVchIzEspVshPU0jNS8/MS00tKtYDAF6CD5s=");
+    InflaterSource source = new InflaterSource(deflated, new Inflater());
+    source.read(inflated, 11);
+    source.close();
+    assertEquals("God help us", inflated.readUtf8());
+    assertEquals(0, inflated.size());
   }
 
   private Buffer decodeBase64(String s) {


### PR DESCRIPTION
Instead of reading the requested byte count, InflaterSource will read
to fill up the unused portion of the tail segment.  Correct this by
taking the minimum amount between the unused segment length and the byte
count.

Add two test cases to validate this behavior and catch any regressions.