### PR TITLE
Implement ReadableByteChannel and WritableByteChannel.

### DIFF
--- a/okio/src/main/java/okio/BufferedSink.java
+++ b/okio/src/main/java/okio/BufferedSink.java
@@ -17,13 +17,14 @@ package okio;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 
 /**
  * A sink that keeps a buffer internally so that callers can do small writes
  * without a performance penalty.
  */
-public interface BufferedSink extends Sink {
+public interface BufferedSink extends Sink, WritableByteChannel {
   /** Returns this sink's internal buffer. */
   Buffer buffer();
 

--- a/okio/src/main/java/okio/BufferedSource.java
+++ b/okio/src/main/java/okio/BufferedSource.java
@@ -17,6 +17,7 @@ package okio;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import javax.annotation.Nullable;
 
@@ -25,7 +26,7 @@ import javax.annotation.Nullable;
  * penalty. It also allows clients to read ahead, buffering as much as necessary before consuming
  * input.
  */
-public interface BufferedSource extends Source {
+public interface BufferedSource extends Source, ReadableByteChannel {
   /** Returns this source's internal buffer. */
   Buffer buffer();
 

--- a/okio/src/main/java/okio/RealBufferedSink.java
+++ b/okio/src/main/java/okio/RealBufferedSink.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 final class RealBufferedSink implements BufferedSink {
@@ -89,6 +90,13 @@ final class RealBufferedSink implements BufferedSink {
     if (closed) throw new IllegalStateException("closed");
     buffer.write(source, offset, byteCount);
     return emitCompleteSegments();
+  }
+
+  @Override public int write(ByteBuffer source) throws IOException {
+    if (closed) throw new IllegalStateException("closed");
+    int result = buffer.write(source);
+    emitCompleteSegments();
+    return result;
   }
 
   @Override public long writeAll(Source source) throws IOException {
@@ -216,6 +224,10 @@ final class RealBufferedSink implements BufferedSink {
       sink.write(buffer, buffer.size);
     }
     sink.flush();
+  }
+
+  @Override public boolean isOpen() {
+    return !closed;
   }
 
   @Override public void close() throws IOException {

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import javax.annotation.Nullable;
 
@@ -143,6 +144,15 @@ final class RealBufferedSource implements BufferedSource {
 
     int toRead = (int) Math.min(byteCount, buffer.size);
     return buffer.read(sink, offset, toRead);
+  }
+
+  @Override public int read(ByteBuffer sink) throws IOException {
+    if (buffer.size == 0) {
+      long read = source.read(buffer, Segment.SIZE);
+      if (read == -1) return -1;
+    }
+
+    return buffer.read(sink);
   }
 
   @Override public void readFully(Buffer sink, long byteCount) throws IOException {
@@ -447,6 +457,10 @@ final class RealBufferedSource implements BufferedSource {
         return RealBufferedSource.this + ".inputStream()";
       }
     };
+  }
+
+  @Override public boolean isOpen() {
+    return !closed;
   }
 
   @Override public void close() throws IOException {

--- a/okio/src/test/java/okio/NioTest.java
+++ b/okio/src/test/java/okio/NioTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.StandardOpenOption;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+/** Test interop between our beloved Okio and java.nio. */
+public final class NioTest {
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test public void sourceIsOpen() throws Exception {
+    BufferedSource source = Okio.buffer((Source) new Buffer());
+    assertTrue(source.isOpen());
+    source.close();
+    assertFalse(source.isOpen());
+  }
+
+  @Test public void sinkIsOpen() throws Exception {
+    BufferedSink sink = Okio.buffer((Sink) new Buffer());
+    assertTrue(sink.isOpen());
+    sink.close();
+    assertFalse(sink.isOpen());
+  }
+
+  @Test public void writableChannelNioFile() throws Exception {
+    File file = temporaryFolder.newFile();
+    FileChannel fileChannel = FileChannel.open(file.toPath(), StandardOpenOption.WRITE);
+    testWritableByteChannel(fileChannel);
+
+    BufferedSource emitted = Okio.buffer(Okio.source(file));
+    assertEquals("defghijklmnopqrstuvw", emitted.readUtf8());
+    emitted.close();
+  }
+
+  @Test public void writableChannelBuffer() throws Exception {
+    Buffer buffer = new Buffer();
+    testWritableByteChannel(buffer);
+    assertEquals("defghijklmnopqrstuvw", buffer.readUtf8());
+  }
+
+  @Test public void writableChannelBufferedSink() throws Exception {
+    Buffer buffer = new Buffer();
+    BufferedSink bufferedSink = Okio.buffer((Sink) buffer);
+    testWritableByteChannel(bufferedSink);
+    assertEquals("defghijklmnopqrstuvw", buffer.readUtf8());
+  }
+
+  @Test public void readableChannelNioFile() throws Exception {
+    File file = temporaryFolder.newFile();
+
+    BufferedSink initialData = Okio.buffer(Okio.sink(file));
+    initialData.writeUtf8("abcdefghijklmnopqrstuvwxyz");
+    initialData.close();
+
+    FileChannel fileChannel = FileChannel.open(file.toPath(), StandardOpenOption.READ);
+    testReadableByteChannel(fileChannel);
+  }
+
+  @Test public void readableChannelBuffer() throws Exception {
+    Buffer buffer = new Buffer();
+    buffer.writeUtf8("abcdefghijklmnopqrstuvwxyz");
+
+    testReadableByteChannel(buffer);
+  }
+
+  @Test public void readableChannelBufferedSource() throws Exception {
+    Buffer buffer = new Buffer();
+    BufferedSource bufferedSource = Okio.buffer((Source) buffer);
+    buffer.writeUtf8("abcdefghijklmnopqrstuvwxyz");
+
+    testReadableByteChannel(bufferedSource);
+  }
+
+  /**
+   * Does some basic writes to {@code channel}. We execute this against both Okio's channels and
+   * also a standard implementation from the JDK to confirm that their behavior is consistent.
+   */
+  private void testWritableByteChannel(WritableByteChannel channel) throws Exception {
+    assertTrue(channel.isOpen());
+
+    ByteBuffer byteBuffer = ByteBuffer.allocate(1024);
+    byteBuffer.put("abcdefghijklmnopqrstuvwxyz".getBytes(Util.UTF_8));
+    byteBuffer.flip();
+    byteBuffer.position(3);
+    byteBuffer.limit(23);
+
+    int byteCount = channel.write(byteBuffer);
+    assertEquals(20, byteCount);
+    assertEquals(23, byteBuffer.position());
+    assertEquals(23, byteBuffer.limit());
+
+    channel.close();
+    assertEquals(channel instanceof Buffer, channel.isOpen()); // Buffer.close() does nothing.
+  }
+
+  /**
+   * Does some basic reads from {@code channel}. We execute this against both Okio's channels and
+   * also a standard implementation from the JDK to confirm that their behavior is consistent.
+   */
+  private void testReadableByteChannel(ReadableByteChannel channel) throws Exception {
+    assertTrue(channel.isOpen());
+
+    ByteBuffer byteBuffer = ByteBuffer.allocate(1024);
+    byteBuffer.position(3);
+    byteBuffer.limit(23);
+
+    int byteCount = channel.read(byteBuffer);
+    assertEquals(20, byteCount);
+    assertEquals(23, byteBuffer.position());
+    assertEquals(23, byteBuffer.limit());
+
+    channel.close();
+    assertEquals(channel instanceof Buffer, channel.isOpen()); // Buffer.close() does nothing.
+
+    byteBuffer.flip();
+    byteBuffer.position(3);
+    byte[] data = new byte[byteBuffer.remaining()];
+    byteBuffer.get(data);
+    assertEquals("abcdefghijklmnopqrst", new String(data, Util.UTF_8));
+  }
+}


### PR DESCRIPTION
I was looking at hooking up Okio to Brotli. Their JNI API wants us
to implement these JNI interfaces. The cost of implementing them is
pretty low, and the upside interop should be convenient.

These new APIs require bytes to be copied. This is just how the
NIO APIs work.

Closes: https://github.com/square/okio/issues/318