### PR TITLE
Documentation improvement for Sink and Source.

### DIFF
--- a/okio/src/main/java/okio/Sink.java
+++ b/okio/src/main/java/okio/Sink.java
@@ -38,7 +38,7 @@ import java.io.IOException;
  * <p>{@code OutputStream} requires multiple layers when emitted data is
  * heterogeneous: a {@code DataOutputStream} for primitive values, a {@code
  * BufferedOutputStream} for buffering, and {@code OutputStreamWriter} for
- * charset encoding. This class uses {@code BufferedSink} for all of the above.
+ * charset encoding. This library uses {@code BufferedSink} for all of the above.
  *
  * <p>Sink is also easier to layer: there is no {@linkplain
  * java.io.OutputStream#write(int) single-byte write} method that is awkward to

--- a/okio/src/main/java/okio/Source.java
+++ b/okio/src/main/java/okio/Source.java
@@ -37,7 +37,7 @@ import java.io.IOException;
  * <p>{@code InputStream} requires multiple layers when consumed data is
  * heterogeneous: a {@code DataInputStream} for primitive values, a {@code
  * BufferedInputStream} for buffering, and {@code InputStreamReader} for
- * strings. This class uses {@code BufferedSource} for all of the above.
+ * strings. This library uses {@code BufferedSource} for all of the above.
  *
  * <p>Source avoids the impossible-to-implement {@linkplain
  * java.io.InputStream#available available()} method. Instead callers specify


### PR DESCRIPTION
`Sink` and `Source` are not really classes. They're interfaces. In general I think it makes more sense to communicate that this library uses BufferedSink/Source to achieve the equivalent of the Java APIs.

In case you don't agree with it feel free to close.