### PR TITLE
Unit tests for parsing hexadecimal numbers.

### DIFF
--- a/okio/src/test/java/okio/BufferTest.java
+++ b/okio/src/test/java/okio/BufferTest.java
@@ -72,6 +72,47 @@ public final class BufferTest {
     assertEquals(Segment.SIZE * 3, buffer.completeSegmentByteCount());
   }
 
+  @Test public void readValidHexadecimalUnsignedLong() {
+    Buffer buffer = new Buffer();
+    buffer.writeUtf8("aA10");
+    assertEquals(0xaa10, buffer.readHexadecimalUnsignedLong());
+
+    buffer.clear();
+    buffer.writeUtf8("a ");
+    assertEquals(0xa, buffer.readHexadecimalUnsignedLong());
+  }
+
+  @Test public void readInvalidHexadecimalUnsignedLong() {
+    Buffer buffer = new Buffer();
+
+    try {
+      buffer.readHexadecimalUnsignedLong(); // shouldn't be able to parse an empty buffer
+      fail("should have thrown an IllegalStateException");
+    } catch (IllegalStateException exception) {
+      assertEquals("size == 0", exception.getMessage());
+    }
+
+    buffer.clear();
+    buffer.writeUtf8("h"); // not a hexadecimal number
+
+    try {
+      buffer.readHexadecimalUnsignedLong();
+      fail("should have thrown a NumberFormatException");
+    } catch (NumberFormatException exception) {
+      assertEquals("Expected leading [0-9a-fA-F] character but was 0x68", exception.getMessage());
+    }
+
+    buffer.clear();
+    buffer.writeUtf8("ffffffffffffffffffffffffffff"); // too large to fit an unsigned long
+
+    try {
+      buffer.readHexadecimalUnsignedLong();
+      fail("should have thrown a NumberFormatException");
+    } catch (NumberFormatException exception) {
+      assertEquals("Number too large: fffffffffffffffff", exception.getMessage());
+    }
+  }
+
   /** Buffer's toString is the same as ByteString's. */
   @Test public void bufferToString() throws Exception {
     assertEquals("[size=0]", new Buffer().toString());


### PR DESCRIPTION
I realised there seemed to be no unit tests for the `readHexadecimalUnsignedLong` method in the `Buffer` class. These two tests should therefore vastly improve the test coverage for that method.