### PR TITLE
catching exception instead of null checking

### DIFF
--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -114,9 +114,13 @@ public final class Okio {
    */
   public static Sink sink(Socket socket) throws IOException {
     if (socket == null) throw new IllegalArgumentException("socket == null");
-    if (socket.getOutputStream() == null) throw new IOException("socket's output stream == null");
     AsyncTimeout timeout = timeout(socket);
-    Sink sink = sink(socket.getOutputStream(), timeout);
+    Sink sink = null;
+    try {
+      sink = sink(socket.getOutputStream(), timeout);
+    } catch (IllegalArgumentException e) {
+      throw new IOException("something was null");
+    }
     return timeout.sink(sink);
   }
 
@@ -220,9 +224,13 @@ public final class Okio {
    */
   public static Source source(Socket socket) throws IOException {
     if (socket == null) throw new IllegalArgumentException("socket == null");
-    if (socket.getInputStream() == null) throw new IOException("socket's input stream == null");
     AsyncTimeout timeout = timeout(socket);
-    Source source = source(socket.getInputStream(), timeout);
+    Source source = null;
+    try {
+      source = source(socket.getInputStream(), timeout);
+    } catch (IllegalArgumentException e) {
+      throw new IOException("something was null");
+    }
     return timeout.source(source);
   }
 


### PR DESCRIPTION
I got this PR merged about a month ago https://github.com/square/okio/pull/337
For some crazy reason I'm still getting these crashes when null checking.  I don't understand why at all.  It makes 0 sense.  To resolve this issue once and for all, I'm remove the null checks I added and instead catching the `IllegalArgumentException`s and throwing `IOException`s.