### PR TITLE
Improved test coverage for `GzipSource::updateCrc`.

### DIFF
--- a/okio/src/test/java/okio/GzipSourceTest.java
+++ b/okio/src/test/java/okio/GzipSourceTest.java
@@ -78,6 +78,22 @@ public final class GzipSourceTest {
     assertGzipped(gzipped);
   }
 
+  @Test public void gunzip_skipCRCCalculationForIrrelevantSegments() throws Exception {
+    Buffer gzipped = new Buffer();
+    gzipped.write(gzipHeader);
+    gzipped.write(deflated);
+    gzipped.write(gzipTrailer);
+
+    GzipSource source = new GzipSource(gzipped);
+    Buffer result = new Buffer();
+    source.read(result, 30);
+    result.head.pos = result.head.limit;
+    source.read(result, 100);
+    result.head.pos = 0;
+
+    assertEquals("It's a UNIX system! I know this!", result.readUtf8());
+  }
+
   /**
    * For portability, it is a good idea to export the gzipped bytes and try running gzip.  Ex.
    * {@code echo gzipped | base64 --decode | gzip -l -v}


### PR DESCRIPTION
This unit test enters the for loop on line 190 in `GzipSource`. According to OpenClover, the for loop is not covered by any test case, as seen in the screen shot below. This contribution tests that edge case.

![screenshot_20180227_141142](https://user-images.githubusercontent.com/889617/36730551-2353a642-1bc8-11e8-936e-f04e0fc89c44.png)