### PR TITLE
Add JApicmp to validate public API compatibility.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ buildscript {
           'gradlePlugin': "ru.vyarus:gradle-animalsniffer-plugin:${versions.animalSnifferPlugin}",
           'annotations': "org.codehaus.mojo:animal-sniffer-annotations:${versions.animalSniffer}",
       ],
+      'japicmp': 'me.champeau.gradle:japicmp-gradle-plugin:0.2.6',
       'jsr305': "com.google.code.findbugs:jsr305:${versions.jsr305}",
       'test': [
           'junit': "junit:junit:${versions.junit}",
@@ -46,6 +47,7 @@ buildscript {
     classpath deps.kotlin.gradlePlugin
     classpath deps.jmh.gradlePlugin
     classpath deps.animalSniffer.gradlePlugin
+    classpath deps.japicmp
   }
 
   repositories {

--- a/okio/build.gradle
+++ b/okio/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'java-library'
 apply plugin: 'osgi'
 apply plugin: 'org.jetbrains.kotlin.platform.jvm'
 apply plugin: 'ru.vyarus.animalsniffer'
+apply plugin: 'me.champeau.gradle.japicmp'
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"
 
@@ -20,6 +21,10 @@ animalsniffer {
   sourceSets = [sourceSets.main]
 }
 
+configurations {
+  baseline
+}
+
 dependencies {
   signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 
@@ -28,4 +33,20 @@ dependencies {
   compileOnly deps.jsr305
   testImplementation deps.test.junit
   testImplementation deps.kotlin.test.jdk
+
+  baseline('com.squareup.okio:okio:1.14.0') {
+    transitive = false
+    force = true
+  }
 }
+
+task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask, dependsOn: 'jar') {
+  oldClasspath = configurations.baseline
+  newClasspath = files(jar.archivePath)
+  onlyBinaryIncompatibleModified = true
+  failOnModification = true
+  txtOutputFile = file("$buildDir/reports/japi.txt")
+  ignoreMissingClasses = true
+  includeSynthetic = true
+}
+check.dependsOn(japicmp)


### PR DESCRIPTION
When I renamed `Okio.sink(Socket)` to `Okio.kitchenSink(Socket)`:
```
$ gw :okio:check
> Task :okio:japicmp FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':okio:japicmp'.
> A failure occurred while executing Comparing [okio-1.15.0-SNAPSHOT.jar] with [okio-1.14.0.jar]
   > Detected binary changes between okio-1.15.0-SNAPSHOT.jar and okio-1.14.0.jar. See failure report at file:///Users/jakew/dev/square/okio/okio/build/reports/japi.txt

$ cat okio/build/reports/japi.txt
Comparing binary compatibility of  against
***! MODIFIED CLASS: PUBLIC FINAL okio.Okio  (not serializable)
	---! REMOVED METHOD: PUBLIC(-) STATIC(-) okio.Sink sink(java.net.Socket)
		---  REMOVED EXCEPTION: java.io.IOException
```