### PR TITLE
Print JApicmp output on build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
 after_success:
   - .buildscript/deploy_snapshot.sh
 
+after_failure:
+  - cat okio/build/reports/japi.txt
+
 env:
   global:
     - secure: "gpdzVacMwUxhoHU1Ettfowgx0axV/L12bjoR8O4iKbRskE3Wr8AgM2GXmFMjoMVDr7vy45YhtOatuSlSKkwZRfgNIcAcTv8axjaFFt7xnPozXXPTU+pkIfaw5DnHzCwJlOo29mmY767Hz4CLomJi8znqKl5VguPAqXo/I8BqKwc="


### PR DESCRIPTION
Closes #392 

This will `cat` even if the failure wasn't caused by Japicmp, maybe there's a cleaner solution