### PR TITLE
Explicitly declare some members as final in Okio 1.x.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -99,7 +99,7 @@
     <!-- Modifier Checks                                    -->
     <!-- See http://checkstyle.sf.net/config_modifiers.html -->
     <module name="ModifierOrder"/>
-    <module name="RedundantModifier"/>
+    <!--<module name="RedundantModifier"/>-->
 
 
     <!-- Checks for blocks. You know, those {}'s         -->

--- a/okio/src/main/java/okio/Buffer.java
+++ b/okio/src/main/java/okio/Buffer.java
@@ -63,7 +63,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
   }
 
   /** Returns the number of bytes currently in this buffer. */
-  public long size() {
+  public final long size() {
     return size;
   }
 
@@ -138,7 +138,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
   }
 
   /** Copy the contents of this to {@code out}. */
-  public Buffer copyTo(OutputStream out) throws IOException {
+  public final Buffer copyTo(OutputStream out) throws IOException {
     return copyTo(out, 0, size);
   }
 
@@ -146,7 +146,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
    * Copy {@code byteCount} bytes from this, starting at {@code offset}, to
    * {@code out}.
    */
-  public Buffer copyTo(OutputStream out, long offset, long byteCount) throws IOException {
+  public final Buffer copyTo(OutputStream out, long offset, long byteCount) throws IOException {
     if (out == null) throw new IllegalArgumentException("out == null");
     checkOffsetAndCount(size, offset, byteCount);
     if (byteCount == 0) return this;
@@ -170,7 +170,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
   }
 
   /** Copy {@code byteCount} bytes from this, starting at {@code offset}, to {@code out}. */
-  public Buffer copyTo(Buffer out, long offset, long byteCount) {
+  public final Buffer copyTo(Buffer out, long offset, long byteCount) {
     if (out == null) throw new IllegalArgumentException("out == null");
     checkOffsetAndCount(size, offset, byteCount);
     if (byteCount == 0) return this;
@@ -201,12 +201,12 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
   }
 
   /** Write the contents of this to {@code out}. */
-  public Buffer writeTo(OutputStream out) throws IOException {
+  public final Buffer writeTo(OutputStream out) throws IOException {
     return writeTo(out, size);
   }
 
   /** Write {@code byteCount} bytes from this to {@code out}. */
-  public Buffer writeTo(OutputStream out, long byteCount) throws IOException {
+  public final Buffer writeTo(OutputStream out, long byteCount) throws IOException {
     if (out == null) throw new IllegalArgumentException("out == null");
     checkOffsetAndCount(size, 0, byteCount);
 
@@ -230,13 +230,13 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
   }
 
   /** Read and exhaust bytes from {@code in} to this. */
-  public Buffer readFrom(InputStream in) throws IOException {
+  public final Buffer readFrom(InputStream in) throws IOException {
     readFrom(in, Long.MAX_VALUE, true);
     return this;
   }
 
   /** Read {@code byteCount} bytes from {@code in} to this. */
-  public Buffer readFrom(InputStream in, long byteCount) throws IOException {
+  public final Buffer readFrom(InputStream in, long byteCount) throws IOException {
     if (byteCount < 0) throw new IllegalArgumentException("byteCount < 0: " + byteCount);
     readFrom(in, byteCount, false);
     return this;
@@ -263,7 +263,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
    * number of bytes that can be flushed immediately to an underlying sink
    * without harming throughput.
    */
-  public long completeSegmentByteCount() {
+  public final long completeSegmentByteCount() {
     long result = size;
     if (result == 0) return 0;
 
@@ -298,7 +298,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
   }
 
   /** Returns the byte at {@code pos}. */
-  public byte getByte(long pos) {
+  public final byte getByte(long pos) {
     checkOffsetAndCount(size, pos, 1);
     if (size - pos > pos) {
       for (Segment s = head; true; s = s.next) {
@@ -835,7 +835,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
    * Discards all bytes in this buffer. Calling this method when you're done
    * with a buffer will return its segments to the pool.
    */
-  public void clear() {
+  public final void clear() {
     try {
       skip(size);
     } catch (EOFException e) {
@@ -1598,22 +1598,22 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
   }
 
   /** Returns the 128-bit MD5 hash of this buffer. */
-  public ByteString md5() {
+  public final ByteString md5() {
     return digest("MD5");
   }
 
   /** Returns the 160-bit SHA-1 hash of this buffer. */
-  public ByteString sha1() {
+  public final ByteString sha1() {
     return digest("SHA-1");
   }
 
   /** Returns the 256-bit SHA-256 hash of this buffer. */
-  public ByteString sha256() {
+  public final ByteString sha256() {
     return digest("SHA-256");
   }
 
   /** Returns the 512-bit SHA-512 hash of this buffer. */
-  public ByteString sha512() {
+  public final ByteString sha512() {
       return digest("SHA-512");
   }
 
@@ -1633,17 +1633,17 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
   }
 
   /** Returns the 160-bit SHA-1 HMAC of this buffer. */
-  public ByteString hmacSha1(ByteString key) {
+  public final ByteString hmacSha1(ByteString key) {
     return hmac("HmacSHA1", key);
   }
 
   /** Returns the 256-bit SHA-256 HMAC of this buffer. */
-  public ByteString hmacSha256(ByteString key) {
+  public final ByteString hmacSha256(ByteString key) {
     return hmac("HmacSHA256", key);
   }
 
   /** Returns the 512-bit SHA-512 HMAC of this buffer. */
-  public ByteString hmacSha512(ByteString key) {
+  public final ByteString hmacSha512(ByteString key) {
       return hmac("HmacSHA512", key);
   }
 
@@ -1734,7 +1734,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
   }
 
   /** Returns an immutable copy of this buffer as a byte string. */
-  public ByteString snapshot() {
+  public final ByteString snapshot() {
     if (size > Integer.MAX_VALUE) {
       throw new IllegalArgumentException("size > Integer.MAX_VALUE: " + size);
     }
@@ -1744,16 +1744,16 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
   /**
    * Returns an immutable copy of the first {@code byteCount} bytes of this buffer as a byte string.
    */
-  public ByteString snapshot(int byteCount) {
+  public final ByteString snapshot(int byteCount) {
     if (byteCount == 0) return ByteString.EMPTY;
     return new SegmentedByteString(this, byteCount);
   }
 
-  public UnsafeCursor readUnsafe() {
+  public final UnsafeCursor readUnsafe() {
     return readUnsafe(new UnsafeCursor());
   }
 
-  public UnsafeCursor readUnsafe(UnsafeCursor unsafeCursor) {
+  public final UnsafeCursor readUnsafe(UnsafeCursor unsafeCursor) {
     if (unsafeCursor.buffer != null) {
       throw new IllegalStateException("already attached to a buffer");
     }
@@ -1763,11 +1763,11 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
     return unsafeCursor;
   }
 
-  public UnsafeCursor readAndWriteUnsafe() {
+  public final UnsafeCursor readAndWriteUnsafe() {
     return readAndWriteUnsafe(new UnsafeCursor());
   }
 
-  public UnsafeCursor readAndWriteUnsafe(UnsafeCursor unsafeCursor) {
+  public final UnsafeCursor readAndWriteUnsafe(UnsafeCursor unsafeCursor) {
     if (unsafeCursor.buffer != null) {
       throw new IllegalStateException("already attached to a buffer");
     }
@@ -1992,7 +1992,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
      * size of the readable range (at least 1), or -1 if we have reached the end of the buffer and
      * there are no more bytes to read.
      */
-    public int next() {
+    public final int next() {
       if (offset == buffer.size) throw new IllegalStateException();
       if (offset == -1L) return seek(0L);
       return seek(offset + (end - start));
@@ -2003,7 +2003,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
      * Returns the number of bytes readable in {@code data} (at least 1), or -1 if there are no data
      * to read.
      */
-    public int seek(long offset) {
+    public final int seek(long offset) {
       if (offset < -1 || offset > buffer.size) {
         throw new ArrayIndexOutOfBoundsException(
             String.format("offset=%s > size=%s", offset, buffer.size));
@@ -2092,7 +2092,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
      *
      * @return the previous size of the buffer.
      */
-    public long resizeBuffer(long newSize) {
+    public final long resizeBuffer(long newSize) {
       if (buffer == null) {
         throw new IllegalStateException("not attached to a buffer");
       }
@@ -2173,7 +2173,7 @@ public final class Buffer implements BufferedSource, BufferedSink, Cloneable, By
      *     than the capacity size of a single segment (8 KiB).
      * @return the number of bytes expanded by. Not less than {@code minByteCount}.
      */
-    public long expandBuffer(int minByteCount) {
+    public final long expandBuffer(int minByteCount) {
       if (minByteCount <= 0) {
         throw new IllegalArgumentException("minByteCount <= 0: " + minByteCount);
       }

--- a/okio/src/main/java/okio/GzipSink.java
+++ b/okio/src/main/java/okio/GzipSink.java
@@ -114,7 +114,7 @@ public final class GzipSink implements Sink {
    * Returns the {@link Deflater}.
    * Use it to access stats, dictionary, compression level, etc.
    */
-  public Deflater deflater() {
+  public final Deflater deflater() {
     return deflater;
   }
 

--- a/okio/src/main/java/okio/HashingSink.java
+++ b/okio/src/main/java/okio/HashingSink.java
@@ -128,7 +128,7 @@ public final class HashingSink extends ForwardingSink {
    * <p><strong>Warning:</strong> This method is not idempotent. Each time this method is called its
    * internal state is cleared. This starts a new hash with zero bytes accepted.
    */
-  public ByteString hash() {
+  public final ByteString hash() {
     byte[] result = messageDigest != null ? messageDigest.digest() : mac.doFinal();
     return ByteString.of(result);
   }

--- a/okio/src/main/java/okio/HashingSource.java
+++ b/okio/src/main/java/okio/HashingSource.java
@@ -127,7 +127,7 @@ public final class HashingSource extends ForwardingSource {
    * <p><strong>Warning:</strong> This method is not idempotent. Each time this method is called its
    * internal state is cleared. This starts a new hash with zero bytes supplied.
    */
-  public ByteString hash() {
+  public final ByteString hash() {
     byte[] result = messageDigest != null ? messageDigest.digest() : mac.doFinal();
     return ByteString.of(result);
   }

--- a/okio/src/main/java/okio/InflaterSource.java
+++ b/okio/src/main/java/okio/InflaterSource.java
@@ -92,7 +92,7 @@ public final class InflaterSource implements Source {
    * it needs input). Returns true if the inflater required input but the source
    * was exhausted.
    */
-  public boolean refill() throws IOException {
+  public final boolean refill() throws IOException {
     if (!inflater.needsInput()) return false;
 
     releaseInflatedBytes();

--- a/okio/src/main/java/okio/Options.java
+++ b/okio/src/main/java/okio/Options.java
@@ -34,7 +34,7 @@ public final class Options extends AbstractList<ByteString> implements RandomAcc
     return byteStrings[i];
   }
 
-  @Override public int size() {
+  @Override public final int size() {
     return byteStrings.length;
   }
 }

--- a/okio/src/main/java/okio/Pipe.java
+++ b/okio/src/main/java/okio/Pipe.java
@@ -48,11 +48,11 @@ public final class Pipe {
     this.maxBufferSize = maxBufferSize;
   }
 
-  public Source source() {
+  public final Source source() {
     return source;
   }
 
-  public Sink sink() {
+  public final Sink sink() {
     return sink;
   }
 

--- a/okio/src/main/java/okio/Segment.java
+++ b/okio/src/main/java/okio/Segment.java
@@ -78,13 +78,13 @@ final class Segment {
    * are safe but writes are forbidden. This also marks the current segment as shared, which
    * prevents it from being pooled.
    */
-  Segment sharedCopy() {
+  final Segment sharedCopy() {
     shared = true;
     return new Segment(data, pos, limit, true, false);
   }
 
   /** Returns a new segment that its own private copy of the underlying byte array. */
-  Segment unsharedCopy() {
+  final Segment unsharedCopy() {
     return new Segment(data.clone(), pos, limit, false, true);
   }
 
@@ -92,7 +92,7 @@ final class Segment {
    * Removes this segment of a circularly-linked list and returns its successor.
    * Returns null if the list is now empty.
    */
-  public @Nullable Segment pop() {
+  public final @Nullable Segment pop() {
     Segment result = next != this ? next : null;
     prev.next = next;
     next.prev = prev;
@@ -105,7 +105,7 @@ final class Segment {
    * Appends {@code segment} after this segment in the circularly-linked list.
    * Returns the pushed segment.
    */
-  public Segment push(Segment segment) {
+  public final Segment push(Segment segment) {
     segment.prev = this;
     segment.next = next;
     next.prev = segment;
@@ -121,7 +121,7 @@ final class Segment {
    *
    * <p>Returns the new head of the circularly-linked list.
    */
-  public Segment split(int byteCount) {
+  public final Segment split(int byteCount) {
     if (byteCount <= 0 || byteCount > limit - pos) throw new IllegalArgumentException();
     Segment prefix;
 
@@ -147,7 +147,7 @@ final class Segment {
    * Call this when the tail and its predecessor may both be less than half
    * full. This will copy data so that segments can be recycled.
    */
-  public void compact() {
+  public final void compact() {
     if (prev == this) throw new IllegalStateException();
     if (!prev.owner) return; // Cannot compact: prev isn't writable.
     int byteCount = limit - pos;
@@ -159,7 +159,7 @@ final class Segment {
   }
 
   /** Moves {@code byteCount} bytes from this segment to {@code sink}. */
-  public void writeTo(Segment sink, int byteCount) {
+  public final void writeTo(Segment sink, int byteCount) {
     if (!sink.owner) throw new IllegalArgumentException();
     if (sink.limit + byteCount > SIZE) {
       // We can't fit byteCount bytes at the sink's current position. Shift sink first.


### PR DESCRIPTION
This will make it easier for 2.x to be compatible according to japicmp.