### PR TITLE
Remove test-only method `segmentSizes` from Buffer

### DIFF
--- a/okio/jvm/src/main/java/okio/Buffer.kt
+++ b/okio/jvm/src/main/java/okio/Buffer.kt
@@ -25,7 +25,6 @@ import java.nio.channels.ByteChannel
 import java.nio.charset.Charset
 import java.security.InvalidKeyException
 import java.security.MessageDigest
-import java.util.ArrayList
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -1485,19 +1484,6 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
   override fun close() {}
 
   override fun timeout() = Timeout.NONE
-
-  /** For testing. This returns the sizes of the segments in this buffer.  */
-  internal fun segmentSizes(): List<Int> {
-    if (head == null) return emptyList()
-    val result = ArrayList<Int>()
-    result.add(head!!.limit - head!!.pos)
-    var s = head!!.next
-    while (s != head) {
-      result.add(s!!.limit - s.pos)
-      s = s.next
-    }
-    return result
-  }
 
   /** Returns the 128-bit MD5 hash of this buffer.  */
   fun md5() = digest("MD5")

--- a/okio/jvm/src/test/java/okio/TestUtil.kt
+++ b/okio/jvm/src/test/java/okio/TestUtil.kt
@@ -32,7 +32,17 @@ object TestUtil {
   const val SEGMENT_SIZE = Segment.SIZE
   const val REPLACEMENT_CHARACTER: Int = Buffer.REPLACEMENT_CHARACTER
   @JvmStatic fun segmentPoolByteCount() = SegmentPool.byteCount
-  @JvmStatic fun segmentSizes(buffer: Buffer) = buffer.segmentSizes()
+
+  @JvmStatic
+  fun segmentSizes(buffer: Buffer): List<Int> {
+    val result = mutableListOf<Int>()
+    buffer.readUnsafe().use { cursor ->
+      while (cursor.next() > 0) {
+        result.add(cursor.end - cursor.start)
+      }
+    }
+    return result
+  }
 
   @JvmStatic
   fun assertByteArraysEquals(a: ByteArray, b: ByteArray) {


### PR DESCRIPTION
With the new Buffer.UnsafeCursor API, this method can be replaced by
navigating the Buffer with a cursor. This removes a method that is only
used in the test package and was marked as for testing only.