### PR TITLE
Do coverage-driven testing of Buffer.select().

### DIFF
--- a/okio/jvm/src/main/java/okio/Buffer.kt
+++ b/okio/jvm/src/main/java/okio/Buffer.kt
@@ -529,11 +529,7 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
    *     contains [ab] and the options are [abc, a].
    */
   internal fun selectPrefix(options: Options, selectTruncated: Boolean = false): Int {
-    val head = head
-    if (head == null) {
-      if (selectTruncated) return -2 // A result is present but truncated.
-      return options.indexOf(ByteString.EMPTY)
-    }
+    val head = head ?: return if (selectTruncated) -2 else -1
 
     var s: Segment? = head
     var data = head.data


### PR DESCRIPTION
This found one condition that wasn't covered by the existing tests. I also wrote
targeted whitebox tests for each of the interesting cases in the code. Tests are
cheap and confidence is valuable.

One other thing this brought up is that we don't support empty byte strings any
more, which simplifies one case.