### PR TITLE
Samples which show integration with Java NIO channels

### DIFF
--- a/samples/src/main/java/okio/samples/ByteChannelSink.java
+++ b/samples/src/main/java/okio/samples/ByteChannelSink.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.samples;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import okio.Buffer;
+import okio.Sink;
+import okio.Timeout;
+
+/**
+ * Creates a Sink around a WritableByteChannel and efficiently writes data using an UnsafeCursor.
+ *
+ * <p>This is a basic example showing another use for the UnsafeCursor. Using the
+ * {@link ByteBuffer#wrap(byte[], int, int) ByteBuffer.wrap()} along with access to Buffer segments,
+ * a WritableByteChannel can be given direct access to Buffer data without having to copy the data.
+ */
+final class ByteChannelSink implements Sink {
+  private final WritableByteChannel channel;
+  private final Timeout timeout;
+
+  private final Buffer.UnsafeCursor cursor = new Buffer.UnsafeCursor();
+
+  ByteChannelSink(WritableByteChannel channel, Timeout timeout) {
+    this.channel = channel;
+    this.timeout = timeout;
+  }
+
+  @Override public void write(Buffer source, long byteCount) throws IOException {
+    if (!channel.isOpen()) throw new IllegalStateException("closed");
+    if (byteCount == 0) return;
+
+    long remaining = byteCount;
+    while (remaining > 0) {
+      timeout.throwIfReached();
+
+      try (Buffer.UnsafeCursor ignored = source.readUnsafe(cursor)) {
+        cursor.seek(0);
+        int length = (int) Math.min(cursor.end - cursor.start, remaining);
+        int written = channel.write(ByteBuffer.wrap(cursor.data, cursor.start, length));
+        remaining -= written;
+        source.skip(written);
+      }
+    }
+  }
+
+  @Override public void flush() {}
+
+  @Override public Timeout timeout() {
+    return timeout;
+  }
+
+  @Override public void close() throws IOException {
+    channel.close();
+  }
+}

--- a/samples/src/main/java/okio/samples/ByteChannelSource.java
+++ b/samples/src/main/java/okio/samples/ByteChannelSource.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.samples;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import okio.Buffer;
+import okio.Source;
+import okio.Timeout;
+
+/**
+ * Creates a Source around a ReadableByteChannel and efficiently reads data using an UnsafeCursor.
+ *
+ * <p>This is a basic example showing another use for the UnsafeCursor. Using the
+ * {@link ByteBuffer#wrap(byte[], int, int) ByteBuffer.wrap()} along with access to Buffer segments,
+ * a ReadableByteChannel can be given direct access to Buffer data without having to copy the data.
+ */
+final class ByteChannelSource implements Source {
+  private final ReadableByteChannel channel;
+  private final Timeout timeout;
+
+  private final Buffer.UnsafeCursor cursor = new Buffer.UnsafeCursor();
+
+  ByteChannelSource(ReadableByteChannel channel, Timeout timeout) {
+    this.channel = channel;
+    this.timeout = timeout;
+  }
+
+  @Override public long read(Buffer sink, long byteCount) throws IOException {
+    if (!channel.isOpen()) throw new IllegalStateException("closed");
+
+    try (Buffer.UnsafeCursor ignored = sink.readAndWriteUnsafe(cursor)) {
+      timeout.throwIfReached();
+      long oldSize = sink.size();
+      int length = (int) Math.min(8192, byteCount);
+
+      cursor.expandBuffer(length);
+      int read = channel.read(ByteBuffer.wrap(cursor.data, cursor.start, length));
+      if (read == -1) {
+        cursor.resizeBuffer(oldSize);
+        return -1;
+      } else {
+        cursor.resizeBuffer(oldSize + read);
+        return read;
+      }
+    }
+  }
+
+  @Override public Timeout timeout() {
+    return timeout;
+  }
+
+  @Override public void close() throws IOException {
+    channel.close();
+  }
+}

--- a/samples/src/main/java/okio/samples/FileChannelSink.java
+++ b/samples/src/main/java/okio/samples/FileChannelSink.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.samples;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import okio.Buffer;
+import okio.Sink;
+import okio.Timeout;
+
+/**
+ * Special Sink for a FileChannel to take advantage of the
+ * {@link FileChannel#transferFrom(ReadableByteChannel, long, long) transfer} method available.
+ */
+final class FileChannelSink implements Sink {
+  private final FileChannel channel;
+  private final Timeout timeout;
+
+  private long position;
+
+  FileChannelSink(FileChannel channel, Timeout timeout) throws IOException {
+    this.channel = channel;
+    this.timeout = timeout;
+
+    this.position = channel.position();
+  }
+
+  @Override public void write(Buffer source, long byteCount) throws IOException {
+    if (!channel.isOpen()) throw new IllegalStateException("closed");
+    if (byteCount == 0) return;
+
+    long remaining = byteCount;
+    while (remaining > 0) {
+      long written = channel.transferFrom(source, position, remaining);
+      position += written;
+      remaining -= written;
+    }
+  }
+
+  @Override public void flush() throws IOException {
+    // Cannot alter meta data through this Sink
+    channel.force(false);
+  }
+
+  @Override public Timeout timeout() {
+    return timeout;
+  }
+
+  @Override public void close() throws IOException {
+    channel.close();
+  }
+}

--- a/samples/src/main/java/okio/samples/FileChannelSource.java
+++ b/samples/src/main/java/okio/samples/FileChannelSource.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.samples;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.WritableByteChannel;
+import okio.Buffer;
+import okio.Source;
+import okio.Timeout;
+
+/**
+ * Special Source for a FileChannel to take advantage of the
+ * {@link FileChannel#transferTo(long, long, WritableByteChannel) transfer} method available.
+ */
+final class FileChannelSource implements Source {
+  private final FileChannel channel;
+  private final Timeout timeout;
+
+  private long position;
+
+  FileChannelSource(FileChannel channel, Timeout timeout) throws IOException {
+    this.channel = channel;
+    this.timeout = timeout;
+
+    this.position = channel.position();
+  }
+
+  @Override public long read(Buffer sink, long byteCount) throws IOException {
+    if (!channel.isOpen()) throw new IllegalStateException("closed");
+    if (position == channel.size()) return -1L;
+
+    long read = channel.transferTo(position, byteCount, sink);
+    position += read;
+    return read;
+  }
+
+  @Override public Timeout timeout() {
+    return timeout;
+  }
+
+  @Override public void close() throws IOException {
+    channel.close();
+  }
+}

--- a/samples/src/main/java/okio/samples/Interceptors.java
+++ b/samples/src/main/java/okio/samples/Interceptors.java
@@ -43,7 +43,7 @@ import okio.Source;
  * {@link Buffer.UnsafeCursor} class for efficient operations on the bytes
  * being written and read.
  */
-public class Interceptors {
+public final class Interceptors {
   public void run() throws Exception {
     final byte cipher = (byte) (new Random().nextInt(256) - 128);
     System.out.println("Cipher   : " + cipher);

--- a/samples/src/test/java/okio/samples/ChannelsTest.java
+++ b/samples/src/test/java/okio/samples/ChannelsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.samples;
+
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.EnumSet;
+import java.util.Set;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.Okio;
+import okio.Sink;
+import okio.Source;
+import okio.Timeout;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public final class ChannelsTest {
+  private static final String quote =
+      "John, the kind of control you're attempting simply is... it's not "
+          + "possible. If there is one thing the history of evolution has "
+          + "taught us it's that life will not be contained. Life breaks "
+          + "free, it expands to new territories and crashes through "
+          + "barriers, painfully, maybe even dangerously, but, uh... well, "
+          + "there it is.";
+
+  private static final Set<StandardOpenOption> r = EnumSet.of(READ);
+  private static final Set<StandardOpenOption> w = EnumSet.of(WRITE);
+  private static final Set<StandardOpenOption> append = EnumSet.of(WRITE, APPEND);
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test public void testReadChannel() throws Exception {
+    ReadableByteChannel channel = new Buffer().writeUtf8(quote);
+
+    Buffer buffer = new Buffer();
+    Source source = new ByteChannelSource(channel, Timeout.NONE);
+    source.read(buffer, 75);
+
+    assertThat(buffer.readUtf8())
+        .isEqualTo("John, the kind of control you're attempting simply is... it's not possible.");
+  }
+
+  @Test public void testReadChannelFully() throws Exception {
+    ReadableByteChannel channel = new Buffer().writeUtf8(quote);
+
+    BufferedSource source = Okio.buffer(new ByteChannelSource(channel, Timeout.NONE));
+    assertThat(source.readUtf8())
+        .isEqualTo(quote);
+  }
+
+  @Test public void testWriteChannel() throws Exception {
+    Buffer channel = new Buffer();
+
+    Sink sink = new ByteChannelSink(channel, Timeout.NONE);
+    sink.write(new Buffer().writeUtf8(quote), 75);
+
+    assertThat(channel.readUtf8())
+        .isEqualTo("John, the kind of control you're attempting simply is... it's not possible.");
+  }
+
+  @Test public void testReadWriteFile() throws Exception {
+    Path path = temporaryFolder.newFile().toPath();
+
+    Sink sink = new FileChannelSink(FileChannel.open(path, w), Timeout.NONE);
+    sink.write(new Buffer().writeUtf8(quote), 317);
+    sink.close();
+    assertTrue(Files.exists(path));
+    assertEquals(quote.length(), Files.size(path));
+
+    Buffer buffer = new Buffer();
+    Source source = new FileChannelSource(FileChannel.open(path, r), Timeout.NONE);
+
+    source.read(buffer, 44);
+    assertThat(buffer.readUtf8())
+        .isEqualTo("John, the kind of control you're attempting ");
+
+    source.read(buffer, 31);
+    assertThat(buffer.readUtf8())
+        .isEqualTo("simply is... it's not possible.");
+  }
+
+  @Test public void testAppend() throws Exception {
+    Path path = temporaryFolder.newFile().toPath();
+
+    Buffer buffer = new Buffer().writeUtf8(quote);
+    Sink sink;
+    BufferedSource source;
+
+    sink = new FileChannelSink(FileChannel.open(path, w), Timeout.NONE);
+    sink.write(buffer, 75);
+    sink.close();
+    assertTrue(Files.exists(path));
+    assertEquals(75, Files.size(path));
+
+    source = Okio.buffer(new FileChannelSource(FileChannel.open(path, r), Timeout.NONE));
+    assertThat(source.readUtf8())
+        .isEqualTo("John, the kind of control you're attempting simply is... it's not possible.");
+
+    sink = new FileChannelSink(FileChannel.open(path, append), Timeout.NONE);
+    sink.write(buffer, buffer.size());
+    sink.close();
+    assertTrue(Files.exists(path));
+    assertEquals(quote.length(), Files.size(path));
+
+    source = Okio.buffer(new FileChannelSource(FileChannel.open(path, r), Timeout.NONE));
+    assertThat(source.readUtf8())
+        .isEqualTo(quote);
+  }
+}


### PR DESCRIPTION
First part of the samples shows how to create a Source or Sink from a
ReadableByteChannel or a WritableByteChannel respectively. This uses the
UnsafeCursor to give the NIO channel direct access to the bytes within
the Buffer by wrapping the internal segments with a ByteBuffer.

The second part shows how to take advantage of the FileChannel's
transferFrom and transferTo methods. Again, this allows direct access to
the data being read or written, but this time by giving the Buffer the
ByteBuffers used by the FileChannel.