### PR TITLE
Fix some formatting and style problems.

### DIFF
--- a/okio/jvm/src/main/java/okio/AsyncTimeout.kt
+++ b/okio/jvm/src/main/java/okio/AsyncTimeout.kt
@@ -24,16 +24,16 @@ import java.util.concurrent.TimeUnit
  * implement timeouts where they aren't supported natively, such as to sockets that are blocked on
  * writing.
  *
- * Subclasses should override [timedOut] to take action when a timeout occurs. This method
- * will be invoked by the shared watchdog thread so it should not do any long-running operations.
- * Otherwise we risk starving other timeouts from being triggered.
+ * Subclasses should override [timedOut] to take action when a timeout occurs. This method will be
+ * invoked by the shared watchdog thread so it should not do any long-running operations. Otherwise
+ * we risk starving other timeouts from being triggered.
  *
- * Use [sink] and [source] to apply this timeout to a stream. The returned value
- * will apply the timeout to each operation on the wrapped stream.
+ * Use [sink] and [source] to apply this timeout to a stream. The returned value will apply the
+ * timeout to each operation on the wrapped stream.
  *
  * Callers should call [enter] before doing work that is subject to timeouts, and [exit] afterwards.
- * The return value of [exit] indicates whether a timeout was triggered.
- * Note that the call to [timedOut] is asynchronous, and may be called after [exit].
+ * The return value of [exit] indicates whether a timeout was triggered. Note that the call to
+ * [timedOut] is asynchronous, and may be called after [exit].
  */
 open class AsyncTimeout : Timeout() {
   /** True if this node is currently in the queue.  */
@@ -147,8 +147,8 @@ open class AsyncTimeout : Timeout() {
   }
 
   /**
-   * Returns a new source that delegates to `source`, using this to implement timeouts. This
-   * works best if [.timedOut] is overridden to interrupt `sink`'s current operation.
+   * Returns a new source that delegates to `source`, using this to implement timeouts. This works
+   * best if [AsyncTimeout.timedOut] is overridden to interrupt `sink`'s current operation.
    */
   fun source(source: Source): Source {
     return object : Source {
@@ -246,8 +246,8 @@ open class AsyncTimeout : Timeout() {
   companion object {
     /**
      * Don't write more than 64 KiB of data at a time, give or take a segment. Otherwise slow
-     * connections may suffer timeouts even when they're making (slow) progress. Without this, writing
-     * a single 1 MiB buffer may never succeed on a sufficiently slow connection.
+     * connections may suffer timeouts even when they're making (slow) progress. Without this,
+     * writing a single 1 MiB buffer may never succeed on a sufficiently slow connection.
      */
     private const val TIMEOUT_WRITE_SIZE = 64 * 1024
 
@@ -260,8 +260,8 @@ open class AsyncTimeout : Timeout() {
      * triggered. This class synchronizes on AsyncTimeout.class. This lock guards the queue.
      *
      * Head's 'next' points to the first element of the linked list. The first element is the next
-     * node to time out, or null if the queue is empty. The head is null until the watchdog thread is
-     * started and also after being idle for [.IDLE_TIMEOUT_MILLIS].
+     * node to time out, or null if the queue is empty. The head is null until the watchdog thread
+     * is started and also after being idle for [AsyncTimeout.IDLE_TIMEOUT_MILLIS].
      */
     @JvmStatic private var head: AsyncTimeout? = null
 
@@ -324,9 +324,9 @@ open class AsyncTimeout : Timeout() {
     }
 
     /**
-     * Removes and returns the node at the head of the list, waiting for it to time out if necessary.
-     * This returns [head] if there was no node at the head of the list when starting, and
-     * there continues to be no node after waiting `IDLE_TIMEOUT_NANOS`. It returns null if a
+     * Removes and returns the node at the head of the list, waiting for it to time out if
+     * necessary. This returns [head] if there was no node at the head of the list when starting,
+     * and there continues to be no node after waiting `IDLE_TIMEOUT_NANOS`. It returns null if a
      * new node was inserted while waiting. Otherwise this returns the node being waited on that has
      * been removed.
      */

--- a/okio/jvm/src/main/java/okio/BufferedSink.kt
+++ b/okio/jvm/src/main/java/okio/BufferedSink.kt
@@ -21,8 +21,8 @@ import java.nio.channels.WritableByteChannel
 import java.nio.charset.Charset
 
 /**
- * A sink that keeps a buffer internally so that callers can do small writes
- * without a performance penalty.
+ * A sink that keeps a buffer internally so that callers can do small writes without a performance
+ * penalty.
  */
 interface BufferedSink : Sink, WritableByteChannel {
   /** Returns this sink's internal buffer. */
@@ -31,23 +31,17 @@ interface BufferedSink : Sink, WritableByteChannel {
   @Throws(IOException::class)
   fun write(byteString: ByteString): BufferedSink
 
-  /**
-   * Like [OutputStream.write], this writes a complete byte array to
-   * this sink.
-   */
+  /** Like [OutputStream.write], this writes a complete byte array to this sink. */
   @Throws(IOException::class)
   fun write(source: ByteArray): BufferedSink
 
-  /**
-   * Like [OutputStream.write], this writes `byteCount`
-   * bytes of `source`, starting at `offset`.
-   */
+  /** Like [OutputStream.write], this writes `byteCount` bytes of `source`, starting at `offset`. */
   @Throws(IOException::class)
   fun write(source: ByteArray, offset: Int, byteCount: Int): BufferedSink
 
   /**
-   * Removes all bytes from `source` and appends them to this sink. Returns the
-   * number of bytes read which will be 0 if `source` is exhausted.
+   * Removes all bytes from `source` and appends them to this sink. Returns the number of bytes read
+   * which will be 0 if `source` is exhausted.
    */
   @Throws(IOException::class)
   fun writeAll(source: Source): Long
@@ -71,8 +65,8 @@ interface BufferedSink : Sink, WritableByteChannel {
   fun writeUtf8(string: String): BufferedSink
 
   /**
-   * Encodes the characters at `beginIndex` up to `endIndex` from `string` in
-   * UTF-8 and writes it to this sink.
+   * Encodes the characters at `beginIndex` up to `endIndex` from `string` in UTF-8 and writes it to
+   * this sink.
    * ```
    * Buffer buffer = new Buffer();
    * buffer.writeUtf8("I'm a hacker!\n", 6, 12);
@@ -96,8 +90,8 @@ interface BufferedSink : Sink, WritableByteChannel {
   fun writeString(string: String, charset: Charset): BufferedSink
 
   /**
-   * Encodes the characters at `beginIndex` up to `endIndex` from `string` in
-   * `charset` and writes it to this sink.
+   * Encodes the characters at `beginIndex` up to `endIndex` from `string` in `charset` and writes
+   * it to this sink.
    */
   @Throws(IOException::class)
   fun writeString(string: String, beginIndex: Int, endIndex: Int, charset: Charset): BufferedSink
@@ -302,9 +296,8 @@ interface BufferedSink : Sink, WritableByteChannel {
   override fun flush()
 
   /**
-   * Writes all buffered data to the underlying sink, if one exists. Like [flush], but
-   * weaker. Call this before this buffered sink goes out of scope so that its data can reach its
-   * destination.
+   * Writes all buffered data to the underlying sink, if one exists. Like [flush], but weaker. Call
+   * this before this buffered sink goes out of scope so that its data can reach its destination.
    * ```
    * BufferedSink b0 = new Buffer();
    * BufferedSink b1 = Okio.buffer(b0);
@@ -330,10 +323,10 @@ interface BufferedSink : Sink, WritableByteChannel {
   fun emit(): BufferedSink
 
   /**
-   * Writes complete segments to the underlying sink, if one exists. Like [flush], but
-   * weaker. Use this to limit the memory held in the buffer to a single segment. Typically
-   * application code will not need to call this: it is only necessary when application code writes
-   * directly to this [sink's buffer][buffer].
+   * Writes complete segments to the underlying sink, if one exists. Like [flush], but weaker. Use
+   * this to limit the memory held in the buffer to a single segment. Typically application code
+   * will not need to call this: it is only necessary when application code writes directly to this
+   * [sink's buffer][buffer].
    * ```
    * BufferedSink b0 = new Buffer();
    * BufferedSink b1 = Okio.buffer(b0);

--- a/okio/jvm/src/main/java/okio/BufferedSource.kt
+++ b/okio/jvm/src/main/java/okio/BufferedSource.kt
@@ -247,9 +247,8 @@ interface BufferedSource : Source, ReadableByteChannel {
   fun readHexadecimalUnsignedLong(): Long
 
   /**
-   * Reads and discards `byteCount` bytes from this source. Throws an
-   * [java.io.EOFException] if the source is exhausted before the
-   * requested bytes can be skipped.
+   * Reads and discards `byteCount` bytes from this source. Throws an [java.io.EOFException] if the
+   * source is exhausted before the requested bytes can be skipped.
    */
   @Throws(IOException::class)
   fun skip(byteCount: Long)
@@ -263,12 +262,12 @@ interface BufferedSource : Source, ReadableByteChannel {
   fun readByteString(byteCount: Long): ByteString
 
   /**
-   * Finds the first string in `options` that is a prefix of this buffer, consumes it from
-   * this buffer, and returns its index. If no byte string in `options` is a prefix of this
-   * buffer this returns -1 and no bytes are consumed.
+   * Finds the first string in `options` that is a prefix of this buffer, consumes it from this
+   * buffer, and returns its index. If no byte string in `options` is a prefix of this buffer this
+   * returns -1 and no bytes are consumed.
    *
-   * This can be used as an alternative to [readByteString] or even [readUtf8] if
-   * the set of expected values is known in advance.
+   * This can be used as an alternative to [readByteString] or even [readUtf8] if the set of
+   * expected values is known in advance.
    * ```
    * Options FIELDS = Options.of(
    *     ByteString.encodeUtf8("depth="),
@@ -299,15 +298,15 @@ interface BufferedSource : Source, ReadableByteChannel {
   fun readByteArray(byteCount: Long): ByteArray
 
   /**
-   * Removes up to `sink.length` bytes from this and copies them into `sink`. Returns
-   * the number of bytes read, or -1 if this source is exhausted.
+   * Removes up to `sink.length` bytes from this and copies them into `sink`. Returns the number of
+   * bytes read, or -1 if this source is exhausted.
    */
   @Throws(IOException::class)
   fun read(sink: ByteArray): Int
 
   /**
-   * Removes exactly `sink.length` bytes from this and copies them into `sink`. Throws
-   * an [java.io.EOFException] if the requested number of bytes cannot be read.
+   * Removes exactly `sink.length` bytes from this and copies them into `sink`. Throws an
+   * [java.io.EOFException] if the requested number of bytes cannot be read.
    */
   @Throws(IOException::class)
   fun readFully(sink: ByteArray)
@@ -418,16 +417,15 @@ interface BufferedSource : Source, ReadableByteChannel {
   fun readUtf8LineStrict(): String
 
   /**
-   * Like [readUtf8LineStrict], except this allows the caller to specify the longest
-   * allowed match. Use this to protect against streams that may not include
-   * `"\n"` or `"\r\n"`.
+   * Like [readUtf8LineStrict], except this allows the caller to specify the longest allowed match.
+   * Use this to protect against streams that may not include `"\n"` or `"\r\n"`.
    *
-   * The returned string will have at most `limit` UTF-8 bytes, and the maximum number
-   * of bytes scanned is `limit + 2`. If `limit == 0` this will always throw
-   * an `EOFException` because no bytes will be scanned.
+   * The returned string will have at most `limit` UTF-8 bytes, and the maximum number of bytes
+   * scanned is `limit + 2`. If `limit == 0` this will always throw an `EOFException` because no
+   * bytes will be scanned.
    *
-   * This method is safe. No bytes are discarded if the match fails, and the caller is free
-   * to try another match:
+   * This method is safe. No bytes are discarded if the match fails, and the caller is free to try
+   * another match:
    * ```
    * Buffer buffer = new Buffer();
    * buffer.writeUtf8("12345\r\n");
@@ -448,11 +446,11 @@ interface BufferedSource : Source, ReadableByteChannel {
    * If this source is exhausted before a complete code point can be read, this throws an
    * [java.io.EOFException] and consumes no input.
    *
-   * If this source doesn't start with a properly-encoded UTF-8 code point, this method will
-   * remove 1 or more non-UTF-8 bytes and return the replacement character (`U+FFFD`). This
-   * covers encoding problems (the input is not properly-encoded UTF-8), characters out of range
-   * (beyond the 0x10ffff limit of Unicode), code points for UTF-16 surrogates (U+d800..U+dfff) and
-   * overlong encodings (such as `0xc080` for the NUL character in modified UTF-8).
+   * If this source doesn't start with a properly-encoded UTF-8 code point, this method will remove
+   * 1 or more non-UTF-8 bytes and return the replacement character (`U+FFFD`). This covers encoding
+   * problems (the input is not properly-encoded UTF-8), characters out of range (beyond the
+   * 0x10ffff limit of Unicode), code points for UTF-16 surrogates (U+d800..U+dfff) and overlong
+   * encodings (such as `0xc080` for the NUL character in modified UTF-8).
    */
   @Throws(IOException::class)
   fun readUtf8CodePoint(): Int
@@ -473,10 +471,9 @@ interface BufferedSource : Source, ReadableByteChannel {
   fun indexOf(b: Byte): Long
 
   /**
-   * Returns the index of the first `b` in the buffer at or after `fromIndex`. This
-   * expands the buffer as necessary until `b` is found. This reads an unbounded number of
-   * bytes into the buffer. Returns -1 if the stream is exhausted before the requested byte is
-   * found.
+   * Returns the index of the first `b` in the buffer at or after `fromIndex`. This expands the
+   * buffer as necessary until `b` is found. This reads an unbounded number of bytes into the
+   * buffer. Returns -1 if the stream is exhausted before the requested byte is found.
    * ```
    * Buffer buffer = new Buffer();
    * buffer.writeUtf8("Don't move! He can't see us if we don't move.");
@@ -490,12 +487,11 @@ interface BufferedSource : Source, ReadableByteChannel {
   fun indexOf(b: Byte, fromIndex: Long): Long
 
   /**
-   * Returns the index of `b` if it is found in the range of `fromIndex` inclusive
-   * to `toIndex` exclusive. If `b` isn't found, or if `fromIndex == toIndex`,
-   * then -1 is returned.
+   * Returns the index of `b` if it is found in the range of `fromIndex` inclusive to `toIndex`
+   * exclusive. If `b` isn't found, or if `fromIndex == toIndex`, then -1 is returned.
    *
-   * The scan terminates at either `toIndex` or the end of the buffer, whichever comes
-   * first. The maximum number of bytes scanned is `toIndex-fromIndex`.
+   * The scan terminates at either `toIndex` or the end of the buffer, whichever comes first. The
+   * maximum number of bytes scanned is `toIndex-fromIndex`.
    */
   @Throws(IOException::class)
   fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long
@@ -527,10 +523,10 @@ interface BufferedSource : Source, ReadableByteChannel {
   fun indexOfElement(targetBytes: ByteString): Long
 
   /**
-   * Returns the first index in this buffer that is at or after `fromIndex` and that contains
-   * any of the bytes in `targetBytes`. This expands the buffer as necessary until a target
-   * byte is found. This reads an unbounded number of bytes into the buffer. Returns -1 if the
-   * stream is exhausted before the requested byte is found.
+   * Returns the first index in this buffer that is at or after `fromIndex` and that contains any of
+   * the bytes in `targetBytes`. This expands the buffer as necessary until a target byte is found.
+   * This reads an unbounded number of bytes into the buffer. Returns -1 if the stream is exhausted
+   * before the requested byte is found.
    * ```
    * ByteString ANY_VOWEL = ByteString.encodeUtf8("AEOIUaeoiu");
    *
@@ -545,9 +541,9 @@ interface BufferedSource : Source, ReadableByteChannel {
   fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long
 
   /**
-   * Returns true if the bytes at `offset` in this source equal `bytes`. This expands
-   * the buffer as necessary until a byte does not match, all bytes are matched, or if the stream
-   * is exhausted before enough bytes could determine a match.
+   * Returns true if the bytes at `offset` in this source equal `bytes`. This expands the buffer as
+   * necessary until a byte does not match, all bytes are matched, or if the stream is exhausted
+   * before enough bytes could determine a match.
    * ```
    * ByteString simonSays = ByteString.encodeUtf8("Simon says:");
    *
@@ -562,9 +558,9 @@ interface BufferedSource : Source, ReadableByteChannel {
   fun rangeEquals(offset: Long, bytes: ByteString): Boolean
 
   /**
-   * Returns true if `byteCount` bytes at `offset` in this source equal `bytes`
-   * at `bytesOffset`. This expands the buffer as necessary until a byte does not match, all
-   * bytes are matched, or if the stream is exhausted before enough bytes could determine a match.
+   * Returns true if `byteCount` bytes at `offset` in this source equal `bytes` at `bytesOffset`.
+   * This expands the buffer as necessary until a byte does not match, all bytes are matched, or if
+   * the stream is exhausted before enough bytes could determine a match.
    */
   @Throws(IOException::class)
   fun rangeEquals(offset: Long, bytes: ByteString, bytesOffset: Int, byteCount: Int): Boolean

--- a/okio/jvm/src/main/java/okio/ByteString.kt
+++ b/okio/jvm/src/main/java/okio/ByteString.kt
@@ -49,10 +49,8 @@ import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.security.InvalidKeyException
 import java.security.MessageDigest
-import java.security.NoSuchAlgorithmException
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
-import kotlin.jvm.Transient
 
 /**
  * An immutable sequence of bytes.
@@ -99,13 +97,8 @@ internal actual constructor(
   /** Returns the 512-bit SHA-512 hash of this byte string.  */
   open fun sha512() = digest("SHA-512")
 
-  private fun digest(algorithm: String): ByteString {
-    try {
-      return ByteString.of(*MessageDigest.getInstance(algorithm).digest(data))
-    } catch (e: NoSuchAlgorithmException) {
-      throw AssertionError(e)
-    }
-  }
+  private fun digest(algorithm: String) =
+      ByteString.of(*MessageDigest.getInstance(algorithm).digest(data))
 
   /** Returns the 160-bit SHA-1 HMAC of this byte string.  */
   open fun hmacSha1(key: ByteString) = hmac("HmacSHA1", key)
@@ -121,8 +114,6 @@ internal actual constructor(
       val mac = Mac.getInstance(algorithm)
       mac.init(SecretKeySpec(key.toByteArray(), algorithm))
       return ByteString.of(*mac.doFinal(data))
-    } catch (e: NoSuchAlgorithmException) {
-      throw AssertionError(e)
     } catch (e: InvalidKeyException) {
       throw IllegalArgumentException(e)
     }
@@ -156,8 +147,8 @@ internal actual constructor(
 
   /**
    * Returns a byte string that is a substring of this byte string, beginning at the specified
-   * `beginIndex` and ends at the specified `endIndex`. Returns this byte string if
-   * `beginIndex` is 0 and `endIndex` is the length of this byte string.
+   * `beginIndex` and ends at the specified `endIndex`. Returns this byte string if `beginIndex` is
+   * 0 and `endIndex` is the length of this byte string.
    */
   actual open fun substring(beginIndex: Int, endIndex: Int): ByteString =
       commonSubstring(beginIndex, endIndex)
@@ -304,15 +295,9 @@ internal actual constructor(
   private fun readObject(`in`: ObjectInputStream) {
     val dataLength = `in`.readInt()
     val byteString = `in`.readByteString(dataLength)
-    try {
-      val field = ByteString::class.java.getDeclaredField("data")
-      field.isAccessible = true
-      field.set(this, byteString.data)
-    } catch (e: NoSuchFieldException) {
-      throw AssertionError()
-    } catch (e: IllegalAccessException) {
-      throw AssertionError()
-    }
+    val field = ByteString::class.java.getDeclaredField("data")
+    field.isAccessible = true
+    field.set(this, byteString.data)
   }
 
   @Throws(IOException::class)

--- a/okio/jvm/src/main/java/okio/ForwardingSink.kt
+++ b/okio/jvm/src/main/java/okio/ForwardingSink.kt
@@ -31,7 +31,7 @@ abstract class ForwardingSink(
   @Throws(IOException::class)
   override fun flush() = delegate.flush()
 
-  override fun timeout(): Timeout = delegate.timeout()
+  override fun timeout() = delegate.timeout()
 
   @Throws(IOException::class)
   override fun close() = delegate.close()

--- a/okio/jvm/src/main/java/okio/ForwardingSource.kt
+++ b/okio/jvm/src/main/java/okio/ForwardingSource.kt
@@ -28,7 +28,7 @@ abstract class ForwardingSource(
   @Throws(IOException::class)
   override fun read(sink: Buffer, byteCount: Long): Long = delegate.read(sink, byteCount)
 
-  override fun timeout(): Timeout = delegate.timeout()
+  override fun timeout() = delegate.timeout()
 
   @Throws(IOException::class)
   override fun close() = delegate.close()

--- a/okio/jvm/src/main/java/okio/GzipSink.kt
+++ b/okio/jvm/src/main/java/okio/GzipSink.kt
@@ -142,4 +142,4 @@ class GzipSink(sink: Sink) : Sink {
  *
  * @see GzipSource
  */
-inline fun Sink.gzip(): GzipSink = GzipSink(this)
+inline fun Sink.gzip() = GzipSink(this)

--- a/okio/jvm/src/main/java/okio/GzipSource.kt
+++ b/okio/jvm/src/main/java/okio/GzipSource.kt
@@ -216,4 +216,4 @@ private const val SECTION_DONE: Byte = 3
  *
  * @see GzipSource
  */
-inline fun Source.gzip(): GzipSource = GzipSource(this)
+inline fun Source.gzip() = GzipSource(this)

--- a/okio/jvm/src/main/java/okio/HashingSink.kt
+++ b/okio/jvm/src/main/java/okio/HashingSink.kt
@@ -18,7 +18,6 @@ package okio
 import java.io.IOException
 import java.security.InvalidKeyException
 import java.security.MessageDigest
-import java.security.NoSuchAlgorithmException
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -43,12 +42,8 @@ class HashingSink : ForwardingSink {
   private val mac: Mac?
 
   internal constructor(sink: Sink, algorithm: String) : super(sink) {
-    try {
-      this.messageDigest = MessageDigest.getInstance(algorithm)
-      this.mac = null
-    } catch (e: NoSuchAlgorithmException) {
-      throw AssertionError()
-    }
+    this.messageDigest = MessageDigest.getInstance(algorithm)
+    this.mac = null
   }
 
   internal constructor(sink: Sink, key: ByteString, algorithm: String) : super(sink) {
@@ -57,8 +52,6 @@ class HashingSink : ForwardingSink {
         init(SecretKeySpec(key.toByteArray(), algorithm))
       }
       this.messageDigest = null
-    } catch (e: NoSuchAlgorithmException) {
-      throw AssertionError()
     } catch (e: InvalidKeyException) {
       throw IllegalArgumentException(e)
     }
@@ -93,45 +86,32 @@ class HashingSink : ForwardingSink {
    * internal state is cleared. This starts a new hash with zero bytes accepted.
    */
   @get:JvmName("hash")
-  val hash: ByteString get() {
-    val result = if (messageDigest != null) messageDigest.digest() else mac!!.doFinal()
-    return ByteString.of(*result)
-  }
+  val hash: ByteString
+    get() {
+      val result = if (messageDigest != null) messageDigest.digest() else mac!!.doFinal()
+      return ByteString.of(*result)
+    }
 
   companion object {
     /** Returns a sink that uses the obsolete MD5 hash algorithm to produce 128-bit hashes. */
-    @JvmStatic fun md5(sink: Sink): HashingSink {
-      return HashingSink(sink, "MD5")
-    }
+    @JvmStatic fun md5(sink: Sink) = HashingSink(sink, "MD5")
 
     /** Returns a sink that uses the obsolete SHA-1 hash algorithm to produce 160-bit hashes. */
-    @JvmStatic fun sha1(sink: Sink): HashingSink {
-      return HashingSink(sink, "SHA-1")
-    }
+    @JvmStatic fun sha1(sink: Sink) = HashingSink(sink, "SHA-1")
 
     /** Returns a sink that uses the SHA-256 hash algorithm to produce 256-bit hashes. */
-    @JvmStatic fun sha256(sink: Sink): HashingSink {
-      return HashingSink(sink, "SHA-256")
-    }
+    @JvmStatic fun sha256(sink: Sink) = HashingSink(sink, "SHA-256")
 
     /** Returns a sink that uses the SHA-512 hash algorithm to produce 512-bit hashes. */
-    @JvmStatic fun sha512(sink: Sink): HashingSink {
-      return HashingSink(sink, "SHA-512")
-    }
+    @JvmStatic fun sha512(sink: Sink) = HashingSink(sink, "SHA-512")
 
     /** Returns a sink that uses the obsolete SHA-1 HMAC algorithm to produce 160-bit hashes. */
-    @JvmStatic fun hmacSha1(sink: Sink, key: ByteString): HashingSink {
-      return HashingSink(sink, key, "HmacSHA1")
-    }
+    @JvmStatic fun hmacSha1(sink: Sink, key: ByteString) = HashingSink(sink, key, "HmacSHA1")
 
     /** Returns a sink that uses the SHA-256 HMAC algorithm to produce 256-bit hashes. */
-    @JvmStatic fun hmacSha256(sink: Sink, key: ByteString): HashingSink {
-      return HashingSink(sink, key, "HmacSHA256")
-    }
+    @JvmStatic fun hmacSha256(sink: Sink, key: ByteString) = HashingSink(sink, key, "HmacSHA256")
 
     /** Returns a sink that uses the SHA-512 HMAC algorithm to produce 512-bit hashes. */
-    @JvmStatic fun hmacSha512(sink: Sink, key: ByteString): HashingSink {
-      return HashingSink(sink, key, "HmacSHA512")
-    }
+    @JvmStatic fun hmacSha512(sink: Sink, key: ByteString) = HashingSink(sink, key, "HmacSHA512")
   }
 }

--- a/okio/jvm/src/main/java/okio/HashingSource.kt
+++ b/okio/jvm/src/main/java/okio/HashingSource.kt
@@ -18,7 +18,6 @@ package okio
 import java.io.IOException
 import java.security.InvalidKeyException
 import java.security.MessageDigest
-import java.security.NoSuchAlgorithmException
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -44,12 +43,8 @@ class HashingSource : ForwardingSource {
   private val mac: Mac?
 
   internal constructor(source: Source, algorithm: String) : super(source) {
-    try {
-      messageDigest = MessageDigest.getInstance(algorithm)
-      mac = null
-    } catch (e: NoSuchAlgorithmException) {
-      throw AssertionError()
-    }
+    messageDigest = MessageDigest.getInstance(algorithm)
+    mac = null
   }
 
   internal constructor(source: Source, key: ByteString, algorithm: String) : super(source) {
@@ -58,8 +53,6 @@ class HashingSource : ForwardingSource {
         init(SecretKeySpec(key.toByteArray(), algorithm))
       }
       messageDigest = null
-    } catch (e: NoSuchAlgorithmException) {
-      throw AssertionError()
     } catch (e: InvalidKeyException) {
       throw IllegalArgumentException(e)
     }
@@ -104,45 +97,35 @@ class HashingSource : ForwardingSource {
    * internal state is cleared. This starts a new hash with zero bytes supplied.
    */
   @get:JvmName("hash")
-  val hash: ByteString get() {
-    val result = if (messageDigest != null) messageDigest.digest() else mac!!.doFinal()
-    return ByteString.of(*result)
-  }
+  val hash: ByteString
+    get() {
+      val result = if (messageDigest != null) messageDigest.digest() else mac!!.doFinal()
+      return ByteString.of(*result)
+    }
 
   companion object {
     /** Returns a sink that uses the obsolete MD5 hash algorithm to produce 128-bit hashes. */
-    @JvmStatic fun md5(source: Source): HashingSource {
-      return HashingSource(source, "MD5")
-    }
+    @JvmStatic fun md5(source: Source) = HashingSource(source, "MD5")
 
     /** Returns a sink that uses the obsolete SHA-1 hash algorithm to produce 160-bit hashes. */
-    @JvmStatic fun sha1(source: Source): HashingSource {
-      return HashingSource(source, "SHA-1")
-    }
+    @JvmStatic fun sha1(source: Source) = HashingSource(source, "SHA-1")
 
     /** Returns a sink that uses the SHA-256 hash algorithm to produce 256-bit hashes. */
-    @JvmStatic fun sha256(source: Source): HashingSource {
-      return HashingSource(source, "SHA-256")
-    }
+    @JvmStatic fun sha256(source: Source) = HashingSource(source, "SHA-256")
 
     /** Returns a sink that uses the SHA-512 hash algorithm to produce 512-bit hashes. */
-    @JvmStatic fun sha512(source: Source): HashingSource {
-      return HashingSource(source, "SHA-512")
-    }
+    @JvmStatic fun sha512(source: Source) = HashingSource(source, "SHA-512")
 
     /** Returns a sink that uses the obsolete SHA-1 HMAC algorithm to produce 160-bit hashes. */
-    @JvmStatic fun hmacSha1(source: Source, key: ByteString): HashingSource {
-      return HashingSource(source, key, "HmacSHA1")
-    }
+    @JvmStatic fun hmacSha1(source: Source, key: ByteString) = HashingSource(source, key,
+        "HmacSHA1")
 
     /** Returns a sink that uses the SHA-256 HMAC algorithm to produce 256-bit hashes. */
-    @JvmStatic fun hmacSha256(source: Source, key: ByteString): HashingSource {
-      return HashingSource(source, key, "HmacSHA256")
-    }
+    @JvmStatic
+    fun hmacSha256(source: Source, key: ByteString) = HashingSource(source, key, "HmacSHA256")
 
     /** Returns a sink that uses the SHA-512 HMAC algorithm to produce 512-bit hashes. */
-    @JvmStatic fun hmacSha512(source: Source, key: ByteString): HashingSource {
-      return HashingSource(source, key, "HmacSHA512")
-    }
+    @JvmStatic
+    fun hmacSha512(source: Source, key: ByteString) = HashingSource(source, key, "HmacSHA512")
   }
 }

--- a/okio/jvm/src/main/java/okio/InflaterSource.kt
+++ b/okio/jvm/src/main/java/okio/InflaterSource.kt
@@ -25,21 +25,19 @@ import java.util.zip.DataFormatException
 import java.util.zip.Inflater
 
 /**
- * A source that uses [DEFLATE](http://tools.ietf.org/html/rfc1951)
- * to decompress data read from another source.
+ * A source that uses [DEFLATE](http://tools.ietf.org/html/rfc1951) to decompress data read from
+ * another source.
  */
 class InflaterSource
 /**
- * This internal constructor shares a buffer with its trusted caller.
- * In general we can't share a BufferedSource because the inflater holds input
- * bytes until they are inflated.
+ * This internal constructor shares a buffer with its trusted caller. In general we can't share a
+ * `BufferedSource` because the inflater holds input bytes until they are inflated.
  */
 internal constructor(private val source: BufferedSource, private val inflater: Inflater) : Source {
 
   /**
-   * When we call Inflater.setInput(), the inflater keeps our byte array until
-   * it needs input again. This tracks how many bytes the inflater is currently
-   * holding on to.
+   * When we call Inflater.setInput(), the inflater keeps our byte array until it needs input again.
+   * This tracks how many bytes the inflater is currently holding on to.
    */
   private var bufferBytesHeldByInflater = 0
   private var closed = false
@@ -82,9 +80,8 @@ internal constructor(private val source: BufferedSource, private val inflater: I
   }
 
   /**
-   * Refills the inflater with compressed data if it needs input. (And only if
-   * it needs input). Returns true if the inflater required input but the source
-   * was exhausted.
+   * Refills the inflater with compressed data if it needs input. (And only if it needs input).
+   * Returns true if the inflater required input but the source was exhausted.
    */
   @Throws(IOException::class)
   fun refill(): Boolean {

--- a/okio/jvm/src/main/java/okio/Okio.kt
+++ b/okio/jvm/src/main/java/okio/Okio.kt
@@ -35,16 +35,15 @@ import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
- * Returns a new source that buffers reads from `source`. The returned
- * source will perform bulk reads into its in-memory buffer. Use this wherever
- * you read a source to get an ergonomic and efficient access to data.
+ * Returns a new source that buffers reads from `source`. The returned source will perform bulk
+ * reads into its in-memory buffer. Use this wherever you read a source to get an ergonomic and
+ * efficient access to data.
  */
 fun Source.buffer(): BufferedSource = RealBufferedSource(this)
 
 /**
- * Returns a new sink that buffers writes to `sink`. The returned sink
- * will batch writes to `sink`. Use this wherever you write to a sink to
- * get an ergonomic and efficient access to data.
+ * Returns a new sink that buffers writes to `sink`. The returned sink will batch writes to `sink`.
+ * Use this wherever you write to a sink to get an ergonomic and efficient access to data.
  */
 fun Sink.buffer(): BufferedSink = RealBufferedSink(this)
 

--- a/okio/jvm/src/main/java/okio/RealBufferedSink.kt
+++ b/okio/jvm/src/main/java/okio/RealBufferedSink.kt
@@ -29,49 +29,42 @@ internal class RealBufferedSink(
 
   override fun buffer() = buffer
 
-  @Throws(IOException::class)
   override fun write(source: Buffer, byteCount: Long) {
     check(!closed) { "closed" }
     buffer.write(source, byteCount)
     emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun write(byteString: ByteString): BufferedSink {
     check(!closed) { "closed" }
     buffer.write(byteString)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeUtf8(string: String): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeUtf8(string)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeUtf8(string: String, beginIndex: Int, endIndex: Int): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeUtf8(string, beginIndex, endIndex)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeUtf8CodePoint(codePoint: Int): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeUtf8CodePoint(codePoint)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeString(string: String, charset: Charset): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeString(string, charset)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeString(
     string: String,
     beginIndex: Int,
@@ -83,21 +76,18 @@ internal class RealBufferedSink(
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun write(source: ByteArray): BufferedSink {
     check(!closed) { "closed" }
     buffer.write(source)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun write(source: ByteArray, offset: Int, byteCount: Int): BufferedSink {
     check(!closed) { "closed" }
     buffer.write(source, offset, byteCount)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun write(source: ByteBuffer): Int {
     check(!closed) { "closed" }
     val result = buffer.write(source)
@@ -105,7 +95,6 @@ internal class RealBufferedSink(
     return result
   }
 
-  @Throws(IOException::class)
   override fun writeAll(source: Source): Long {
     var totalBytesRead = 0L
     while (true) {
@@ -117,7 +106,6 @@ internal class RealBufferedSink(
     return totalBytesRead
   }
 
-  @Throws(IOException::class)
   override fun write(source: Source, byteCount: Long): BufferedSink {
     var byteCount = byteCount
     while (byteCount > 0L) {
@@ -129,70 +117,60 @@ internal class RealBufferedSink(
     return this
   }
 
-  @Throws(IOException::class)
   override fun writeByte(b: Int): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeByte(b)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeShort(s: Int): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeShort(s)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeShortLe(s: Int): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeShortLe(s)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeInt(i: Int): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeInt(i)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeIntLe(i: Int): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeIntLe(i)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeLong(v: Long): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeLong(v)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeLongLe(v: Long): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeLongLe(v)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeDecimalLong(v: Long): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeDecimalLong(v)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun writeHexadecimalUnsignedLong(v: Long): BufferedSink {
     check(!closed) { "closed" }
     buffer.writeHexadecimalUnsignedLong(v)
     return emitCompleteSegments()
   }
 
-  @Throws(IOException::class)
   override fun emitCompleteSegments(): BufferedSink {
     check(!closed) { "closed" }
     val byteCount = buffer.completeSegmentByteCount()
@@ -200,7 +178,6 @@ internal class RealBufferedSink(
     return this
   }
 
-  @Throws(IOException::class)
   override fun emit(): BufferedSink {
     check(!closed) { "closed" }
     val byteCount = buffer.size
@@ -235,7 +212,6 @@ internal class RealBufferedSink(
     }
   }
 
-  @Throws(IOException::class)
   override fun flush() {
     check(!closed) { "closed" }
     if (buffer.size > 0L) {
@@ -246,7 +222,6 @@ internal class RealBufferedSink(
 
   override fun isOpen() = !closed
 
-  @Throws(IOException::class)
   override fun close() {
     if (closed) return
 

--- a/okio/jvm/src/main/java/okio/RealBufferedSource.kt
+++ b/okio/jvm/src/main/java/okio/RealBufferedSource.kt
@@ -29,7 +29,6 @@ internal class RealBufferedSource(
 
   override fun buffer() = buffer
 
-  @Throws(IOException::class)
   override fun read(sink: Buffer, byteCount: Long): Long {
     require(byteCount >= 0) { "byteCount < 0: $byteCount" }
     check(!closed) { "closed" }
@@ -43,18 +42,15 @@ internal class RealBufferedSource(
     return buffer.read(sink, toRead)
   }
 
-  @Throws(IOException::class)
   override fun exhausted(): Boolean {
     check(!closed) { "closed" }
     return buffer.exhausted() && source.read(buffer, Segment.SIZE.toLong()) == -1L
   }
 
-  @Throws(IOException::class)
   override fun require(byteCount: Long) {
     if (!request(byteCount)) throw EOFException()
   }
 
-  @Throws(IOException::class)
   override fun request(byteCount: Long): Boolean {
     require(byteCount >= 0) { "byteCount < 0: $byteCount" }
     check(!closed) { "closed" }
@@ -64,25 +60,21 @@ internal class RealBufferedSource(
     return true
   }
 
-  @Throws(IOException::class)
   override fun readByte(): Byte {
     require(1)
     return buffer.readByte()
   }
 
-  @Throws(IOException::class)
   override fun readByteString(): ByteString {
     buffer.writeAll(source)
     return buffer.readByteString()
   }
 
-  @Throws(IOException::class)
   override fun readByteString(byteCount: Long): ByteString {
     require(byteCount)
     return buffer.readByteString(byteCount)
   }
 
-  @Throws(IOException::class)
   override fun select(options: Options): Int {
     check(!closed) { "closed" }
 
@@ -106,22 +98,18 @@ internal class RealBufferedSource(
     }
   }
 
-  @Throws(IOException::class)
   override fun readByteArray(): ByteArray {
     buffer.writeAll(source)
     return buffer.readByteArray()
   }
 
-  @Throws(IOException::class)
   override fun readByteArray(byteCount: Long): ByteArray {
     require(byteCount)
     return buffer.readByteArray(byteCount)
   }
 
-  @Throws(IOException::class)
   override fun read(sink: ByteArray) = read(sink, 0, sink.size)
 
-  @Throws(IOException::class)
   override fun readFully(sink: ByteArray) {
     try {
       require(sink.size.toLong())
@@ -139,7 +127,6 @@ internal class RealBufferedSource(
     buffer.readFully(sink)
   }
 
-  @Throws(IOException::class)
   override fun read(sink: ByteArray, offset: Int, byteCount: Int): Int {
     checkOffsetAndCount(sink.size.toLong(), offset.toLong(), byteCount.toLong())
 
@@ -152,7 +139,6 @@ internal class RealBufferedSource(
     return buffer.read(sink, offset, toRead)
   }
 
-  @Throws(IOException::class)
   override fun read(sink: ByteBuffer): Int {
     if (buffer.size == 0L) {
       val read = source.read(buffer, Segment.SIZE.toLong())
@@ -162,7 +148,6 @@ internal class RealBufferedSource(
     return buffer.read(sink)
   }
 
-  @Throws(IOException::class)
   override fun readFully(sink: Buffer, byteCount: Long) {
     try {
       require(byteCount)
@@ -175,7 +160,6 @@ internal class RealBufferedSource(
     buffer.readFully(sink, byteCount)
   }
 
-  @Throws(IOException::class)
   override fun readAll(sink: Sink): Long {
     var totalBytesWritten: Long = 0
     while (source.read(buffer, Segment.SIZE.toLong()) != -1L) {
@@ -192,31 +176,26 @@ internal class RealBufferedSource(
     return totalBytesWritten
   }
 
-  @Throws(IOException::class)
   override fun readUtf8(): String {
     buffer.writeAll(source)
     return buffer.readUtf8()
   }
 
-  @Throws(IOException::class)
   override fun readUtf8(byteCount: Long): String {
     require(byteCount)
     return buffer.readUtf8(byteCount)
   }
 
-  @Throws(IOException::class)
   override fun readString(charset: Charset): String {
     buffer.writeAll(source)
     return buffer.readString(charset)
   }
 
-  @Throws(IOException::class)
   override fun readString(byteCount: Long, charset: Charset): String {
     require(byteCount)
     return buffer.readString(byteCount, charset)
   }
 
-  @Throws(IOException::class)
   override fun readUtf8Line(): String? {
     val newline = indexOf('\n'.toByte())
 
@@ -231,10 +210,8 @@ internal class RealBufferedSource(
     }
   }
 
-  @Throws(IOException::class)
   override fun readUtf8LineStrict() = readUtf8LineStrict(Long.MAX_VALUE)
 
-  @Throws(IOException::class)
   override fun readUtf8LineStrict(limit: Long): String {
     require(limit >= 0) { "limit < 0: $limit" }
     val scanLength = if (limit == Long.MAX_VALUE) Long.MAX_VALUE else limit + 1
@@ -251,7 +228,6 @@ internal class RealBufferedSource(
         + " content=" + data.readByteString().hex() + '…'.toString())
   }
 
-  @Throws(IOException::class)
   override fun readUtf8CodePoint(): Int {
     require(1)
 
@@ -265,43 +241,36 @@ internal class RealBufferedSource(
     return buffer.readUtf8CodePoint()
   }
 
-  @Throws(IOException::class)
   override fun readShort(): Short {
     require(2)
     return buffer.readShort()
   }
 
-  @Throws(IOException::class)
   override fun readShortLe(): Short {
     require(2)
     return buffer.readShortLe()
   }
 
-  @Throws(IOException::class)
   override fun readInt(): Int {
     require(4)
     return buffer.readInt()
   }
 
-  @Throws(IOException::class)
   override fun readIntLe(): Int {
     require(4)
     return buffer.readIntLe()
   }
 
-  @Throws(IOException::class)
   override fun readLong(): Long {
     require(8)
     return buffer.readLong()
   }
 
-  @Throws(IOException::class)
   override fun readLongLe(): Long {
     require(8)
     return buffer.readLongLe()
   }
 
-  @Throws(IOException::class)
   override fun readDecimalLong(): Long {
     require(1)
 
@@ -322,7 +291,6 @@ internal class RealBufferedSource(
     return buffer.readDecimalLong()
   }
 
-  @Throws(IOException::class)
   override fun readHexadecimalUnsignedLong(): Long {
     require(1)
 
@@ -345,7 +313,6 @@ internal class RealBufferedSource(
     return buffer.readHexadecimalUnsignedLong()
   }
 
-  @Throws(IOException::class)
   override fun skip(byteCount: Long) {
     var byteCount = byteCount
     check(!closed) { "closed" }
@@ -359,13 +326,10 @@ internal class RealBufferedSource(
     }
   }
 
-  @Throws(IOException::class)
   override fun indexOf(b: Byte) = indexOf(b, 0L, Long.MAX_VALUE)
 
-  @Throws(IOException::class)
   override fun indexOf(b: Byte, fromIndex: Long) = indexOf(b, fromIndex, Long.MAX_VALUE)
 
-  @Throws(IOException::class)
   override fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long {
     var fromIndex = fromIndex
     check(!closed) { "closed" }
@@ -386,10 +350,8 @@ internal class RealBufferedSource(
     return -1L
   }
 
-  @Throws(IOException::class)
   override fun indexOf(bytes: ByteString) = indexOf(bytes, 0L)
 
-  @Throws(IOException::class)
   override fun indexOf(bytes: ByteString, fromIndex: Long): Long {
     var fromIndex = fromIndex
     check(!closed) { "closed" }
@@ -406,10 +368,8 @@ internal class RealBufferedSource(
     }
   }
 
-  @Throws(IOException::class)
   override fun indexOfElement(targetBytes: ByteString) = indexOfElement(targetBytes, 0L)
 
-  @Throws(IOException::class)
   override fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long {
     var fromIndex = fromIndex
     check(!closed) { "closed" }
@@ -426,11 +386,9 @@ internal class RealBufferedSource(
     }
   }
 
-  @Throws(IOException::class)
   override fun rangeEquals(offset: Long, bytes: ByteString) = rangeEquals(offset, bytes, 0,
       bytes.size)
 
-  @Throws(IOException::class)
   override fun rangeEquals(
     offset: Long,
     bytes: ByteString,
@@ -489,7 +447,6 @@ internal class RealBufferedSource(
 
   override fun isOpen() = !closed
 
-  @Throws(IOException::class)
   override fun close() {
     if (closed) return
     closed = true

--- a/okio/jvm/src/main/java/okio/Sink.kt
+++ b/okio/jvm/src/main/java/okio/Sink.kt
@@ -20,17 +20,15 @@ import java.io.Flushable
 import java.io.IOException
 
 /**
- * Receives a stream of bytes. Use this interface to write data wherever it's
- * needed: to the network, storage, or a buffer in memory. Sinks may be layered
- * to transform received data, such as to compress, encrypt, throttle, or add
- * protocol framing.
+ * Receives a stream of bytes. Use this interface to write data wherever it's needed: to the
+ * network, storage, or a buffer in memory. Sinks may be layered to transform received data, such as
+ * to compress, encrypt, throttle, or add protocol framing.
  *
- * Most application code shouldn't operate on a sink directly, but rather on a
- * [BufferedSink] which is both more efficient and more convenient. Use
- * [buffer] to wrap any sink with a buffer.
+ * Most application code shouldn't operate on a sink directly, but rather on a [BufferedSink] which
+ * is both more efficient and more convenient. Use [buffer] to wrap any sink with a buffer.
  *
- * Sinks are easy to test: just use a [Buffer] in your tests, and
- * read from it to confirm it received the data that was expected.
+ * Sinks are easy to test: just use a [Buffer] in your tests, and read from it to confirm it
+ * received the data that was expected.
  *
  * ### Comparison with OutputStream
  *
@@ -61,9 +59,8 @@ interface Sink : Closeable, Flushable {
   fun timeout(): Timeout
 
   /**
-   * Pushes all buffered bytes to their final destination and releases the
-   * resources held by this sink. It is an error to write a closed sink. It is
-   * safe to close a sink more than once.
+   * Pushes all buffered bytes to their final destination and releases the resources held by this
+   * sink. It is an error to write a closed sink. It is safe to close a sink more than once.
    */
   @Throws(IOException::class)
   override fun close()

--- a/okio/jvm/src/main/java/okio/Source.kt
+++ b/okio/jvm/src/main/java/okio/Source.kt
@@ -19,25 +19,23 @@ import java.io.Closeable
 import java.io.IOException
 
 /**
- * Supplies a stream of bytes. Use this interface to read data from wherever
- * it's located: from the network, storage, or a buffer in memory. Sources may
- * be layered to transform supplied data, such as to decompress, decrypt, or
- * remove protocol framing.
+ * Supplies a stream of bytes. Use this interface to read data from wherever it's located: from the
+ * network, storage, or a buffer in memory. Sources may be layered to transform supplied data, such
+ * as to decompress, decrypt, or remove protocol framing.
  *
- * Most applications shouldn't operate on a source directly, but rather on a
- * [BufferedSource] which is both more efficient and more convenient. Use
- * [buffer] to wrap any source with a buffer.
+ * Most applications shouldn't operate on a source directly, but rather on a [BufferedSource] which
+ * is both more efficient and more convenient. Use [buffer] to wrap any source with a buffer.
  *
- * Sources are easy to test: just use a [Buffer] in your tests, and
- * fill it with the data your application is to read.
+ * Sources are easy to test: just use a [Buffer] in your tests, and fill it with the data your
+ * application is to read.
  *
  * ### Comparison with InputStream
 
  * This interface is functionally equivalent to [java.io.InputStream].
  *
  * `InputStream` requires multiple layers when consumed data is heterogeneous: a `DataInputStream`
- * for primitive values, a `BufferedInputStream` for buffering, and `InputStreamReader` for
- * strings. This library uses `BufferedSource` for all of the above.
+ * for primitive values, a `BufferedInputStream` for buffering, and `InputStreamReader` for strings.
+ * This library uses `BufferedSource` for all of the above.
  *
  * Source avoids the impossible-to-implement [available()][java.io.InputStream.available] method.
  * Instead callers specify how many bytes they [require][BufferedSource.require].
@@ -57,9 +55,8 @@ import java.io.IOException
  */
 interface Source : Closeable {
   /**
-   * Removes at least 1, and up to `byteCount` bytes from this and appends
-   * them to `sink`. Returns the number of bytes read, or -1 if this
-   * source is exhausted.
+   * Removes at least 1, and up to `byteCount` bytes from this and appends them to `sink`. Returns
+   * the number of bytes read, or -1 if this source is exhausted.
    */
   @Throws(IOException::class)
   fun read(sink: Buffer, byteCount: Long): Long
@@ -68,8 +65,8 @@ interface Source : Closeable {
   fun timeout(): Timeout
 
   /**
-   * Closes this source and releases the resources held by this source. It is an
-   * error to read a closed source. It is safe to close a source more than once.
+   * Closes this source and releases the resources held by this source. It is an error to read a
+   * closed source. It is safe to close a source more than once.
    */
   @Throws(IOException::class)
   override fun close()

--- a/okio/jvm/src/main/java/okio/Timeout.kt
+++ b/okio/jvm/src/main/java/okio/Timeout.kt
@@ -20,41 +20,38 @@ import java.io.InterruptedIOException
 import java.util.concurrent.TimeUnit
 
 /**
- * A policy on how much time to spend on a task before giving up. When a task
- * times out, it is left in an unspecified state and should be abandoned. For
- * example, if reading from a source times out, that source should be closed and
- * the read should be retried later. If writing to a sink times out, the same
- * rules apply: close the sink and retry later.
+ * A policy on how much time to spend on a task before giving up. When a task times out, it is left
+ * in an unspecified state and should be abandoned. For example, if reading from a source times out,
+ * that source should be closed and the read should be retried later. If writing to a sink times
+ * out, the same rules apply: close the sink and retry later.
  *
  * ### Timeouts and Deadlines
+ *
  * This class offers two complementary controls to define a timeout policy.
  *
- * **Timeouts** specify the maximum time to wait for a single
- * operation to complete. Timeouts are typically used to detect problems like
- * network partitions. For example, if a remote peer doesn't return *any*
- * data for ten seconds, we may assume that the peer is unavailable.
+ * **Timeouts** specify the maximum time to wait for a single operation to complete. Timeouts are
+ * typically used to detect problems like network partitions. For example, if a remote peer doesn't
+ * return *any* data for ten seconds, we may assume that the peer is unavailable.
  *
- * **Deadlines** specify the maximum time to spend on a job,
- * composed of one or more operations. Use deadlines to set an upper bound on
- * the time invested on a job. For example, a battery-conscious app may limit
- * how much time it spends pre-loading content.
+ * **Deadlines** specify the maximum time to spend on a job, composed of one or more operations. Use
+ * deadlines to set an upper bound on the time invested on a job. For example, a battery-conscious
+ * app may limit how much time it spends pre-loading content.
  */
 open class Timeout {
   /**
-   * True if `deadlineNanoTime` is defined. There is no equivalent to null
-   * or 0 for [System.nanoTime].
+   * True if `deadlineNanoTime` is defined. There is no equivalent to null or 0 for
+   * [System.nanoTime].
    */
   private var hasDeadline = false
   private var deadlineNanoTime = 0L
   private var timeoutNanos = 0L
 
   /**
-   * Wait at most `timeout` time before aborting an operation. Using a
-   * per-operation timeout means that as long as forward progress is being made,
-   * no sequence of operations will fail.
+   * Wait at most `timeout` time before aborting an operation. Using a per-operation timeout means
+   * that as long as forward progress is being made, no sequence of operations will fail.
    *
-   * If `timeout == 0`, operations will run indefinitely. (Operating
-   * system timeouts may still apply.)
+   * If `timeout == 0`, operations will run indefinitely. (Operating system timeouts may still
+   * apply.)
    */
   open fun timeout(timeout: Long, unit: TimeUnit): Timeout {
     require(timeout >= 0) { "timeout < 0: $timeout" }
@@ -69,8 +66,7 @@ open class Timeout {
   open fun hasDeadline(): Boolean = hasDeadline
 
   /**
-   * Returns the [nano time][System.nanoTime] when the deadline will
-   * be reached.
+   * Returns the [nano time][System.nanoTime] when the deadline will be reached.
    *
    * @throws IllegalStateException if no deadline is set.
    */
@@ -80,9 +76,9 @@ open class Timeout {
   }
 
   /**
-   * Sets the [nano time][System.nanoTime] when the deadline will be
-   * reached. All operations must complete before this time. Use a deadline to
-   * set a maximum bound on the time spent on a sequence of operations.
+   * Sets the [nano time][System.nanoTime] when the deadline will be reached. All operations must
+   * complete before this time. Use a deadline to set a maximum bound on the time spent on a
+   * sequence of operations.
    */
   open fun deadlineNanoTime(deadlineNanoTime: Long): Timeout {
     this.hasDeadline = true
@@ -109,8 +105,8 @@ open class Timeout {
   }
 
   /**
-   * Throws an [InterruptedIOException] if the deadline has been reached or if the current
-   * thread has been interrupted. This method doesn't detect timeouts; that should be implemented to
+   * Throws an [InterruptedIOException] if the deadline has been reached or if the current thread
+   * has been interrupted. This method doesn't detect timeouts; that should be implemented to
    * asynchronously abort an in-progress operation.
    */
   @Throws(IOException::class)
@@ -125,13 +121,12 @@ open class Timeout {
   }
 
   /**
-   * Waits on `monitor` until it is notified. Throws [InterruptedIOException] if either
-   * the thread is interrupted or if this timeout elapses before `monitor` is notified. The
-   * caller must be synchronized on `monitor`.
+   * Waits on `monitor` until it is notified. Throws [InterruptedIOException] if either the thread
+   * is interrupted or if this timeout elapses before `monitor` is notified. The caller must be
+   * synchronized on `monitor`.
    *
-   * Here's a sample class that uses `waitUntilNotified()` to await a specific state. Note
-   * that the call is made within a loop to avoid unnecessary waiting and to mitigate spurious
-   * notifications.
+   * Here's a sample class that uses `waitUntilNotified()` to await a specific state. Note that the
+   * call is made within a loop to avoid unnecessary waiting and to mitigate spurious notifications.
    * ```
    * class Dice {
    *   Random random = new Random();
@@ -201,18 +196,13 @@ open class Timeout {
 
   companion object {
     /**
-     * An empty timeout that neither tracks nor detects timeouts. Use this when
-     * timeouts aren't necessary, such as in implementations whose operations
-     * do not block.
+     * An empty timeout that neither tracks nor detects timeouts. Use this when timeouts aren't
+     * necessary, such as in implementations whose operations do not block.
      */
     @JvmField val NONE: Timeout = object : Timeout() {
-      override fun timeout(timeout: Long, unit: TimeUnit): Timeout {
-        return this
-      }
+      override fun timeout(timeout: Long, unit: TimeUnit): Timeout = this
 
-      override fun deadlineNanoTime(deadlineNanoTime: Long): Timeout {
-        return this
-      }
+      override fun deadlineNanoTime(deadlineNanoTime: Long): Timeout = this
 
       override fun throwIfReached() {}
     }

--- a/okio/jvm/src/main/java/okio/package-info.java
+++ b/okio/jvm/src/main/java/okio/package-info.java
@@ -1,6 +1,0 @@
-/**
- * Okio complements {@link java.io} and {@link java.nio} to make it much easier to access, store,
- * and process your data.
- */
-@javax.annotation.ParametersAreNonnullByDefault
-package okio;


### PR DESCRIPTION
This changes Okio to stop catching impossible exceptions, such as when an
algorithm is required by the VM but not present at runtime.

Also don't declare exceptions in internal classes.