### PR TITLE
Add default parametes to ByteString.substring

### DIFF
--- a/okio/js/src/main/kotlin/okio/ByteString.kt
+++ b/okio/js/src/main/kotlin/okio/ByteString.kt
@@ -83,18 +83,14 @@ internal actual constructor(
    */
   actual open fun toAsciiUppercase(): ByteString = commonToAsciiUppercase()
 
-  /**
-   * Returns a byte string that is a substring of this byte string, beginning at the specified
-   * index until the end of this string. Returns this byte string if `beginIndex` is 0.
-   */
-  actual open fun substring(beginIndex: Int): ByteString = commonSubstring(beginIndex, data.size)
+  // TODO move substring() when https://youtrack.jetbrains.com/issue/KT-24357 is fixed
 
   /**
    * Returns a byte string that is a substring of this byte string, beginning at the specified
-   * `beginIndex` and ends at the specified `endIndex`. Returns this byte string if
-   * `beginIndex` is 0 and `endIndex` is the length of this byte string.
+   * `beginIndex` and ends at the specified `endIndex`. Returns this byte string if `beginIndex` is
+   * 0 and `endIndex` is the length of this byte string.
    */
-  actual open fun substring(beginIndex: Int, endIndex: Int): ByteString =
+  open fun substring(beginIndex: Int = 0, endIndex: Int = size): ByteString =
       commonSubstring(beginIndex, endIndex)
 
   /** Returns the byte at `pos`.  */

--- a/okio/jvm/src/main/java/okio/ByteString.kt
+++ b/okio/jvm/src/main/java/okio/ByteString.kt
@@ -139,18 +139,15 @@ internal actual constructor(
    */
   actual open fun toAsciiUppercase(): ByteString = commonToAsciiUppercase()
 
-  /**
-   * Returns a byte string that is a substring of this byte string, beginning at the specified
-   * index until the end of this string. Returns this byte string if `beginIndex` is 0.
-   */
-  actual open fun substring(beginIndex: Int): ByteString = commonSubstring(beginIndex, data.size)
+  // TODO move substring() when https://youtrack.jetbrains.com/issue/KT-24357 is fixed
 
   /**
    * Returns a byte string that is a substring of this byte string, beginning at the specified
    * `beginIndex` and ends at the specified `endIndex`. Returns this byte string if `beginIndex` is
    * 0 and `endIndex` is the length of this byte string.
    */
-  actual open fun substring(beginIndex: Int, endIndex: Int): ByteString =
+  @JvmOverloads
+  open fun substring(beginIndex: Int = 0, endIndex: Int = size): ByteString =
       commonSubstring(beginIndex, endIndex)
 
   /** Returns the byte at `pos`.  */

--- a/okio/jvm/src/main/java/okio/SegmentedByteString.kt
+++ b/okio/jvm/src/main/java/okio/SegmentedByteString.kt
@@ -115,8 +115,6 @@ internal class SegmentedByteString(buffer: Buffer, byteCount: Int) : ByteString(
 
   override fun base64Url() = toByteString().base64Url()
 
-  override fun substring(beginIndex: Int) = toByteString().substring(beginIndex)
-
   override fun substring(beginIndex: Int, endIndex: Int) = toByteString().substring(beginIndex,
       endIndex)
 

--- a/okio/jvm/src/test/java/okio/ByteStringKotlinTest.kt
+++ b/okio/jvm/src/test/java/okio/ByteStringKotlinTest.kt
@@ -92,4 +92,12 @@ class ByteStringKotlinTest {
     val expected = ByteString.of(1, 2, 3, 4)
     assertThat(actual).isEqualTo(expected)
   }
+
+  @Test fun substring() {
+    val byteString = "abcdef".encodeUtf8()
+    assertThat(byteString.substring()).isEqualTo("abcdef".encodeUtf8())
+    assertThat(byteString.substring(endIndex= 3)).isEqualTo("abc".encodeUtf8())
+    assertThat(byteString.substring(beginIndex = 3)).isEqualTo("def".encodeUtf8())
+    assertThat(byteString.substring(beginIndex = 1, endIndex = 5)).isEqualTo("bcde".encodeUtf8())
+  }
 }

--- a/okio/src/main/kotlin/okio/ByteString.kt
+++ b/okio/src/main/kotlin/okio/ByteString.kt
@@ -66,19 +66,6 @@ internal constructor(data: ByteArray) : Comparable<ByteString> {
    */
   fun toAsciiUppercase(): ByteString
 
-  /**
-   * Returns a byte string that is a substring of this byte string, beginning at the specified
-   * index until the end of this string. Returns this byte string if `beginIndex` is 0.
-   */
-  fun substring(beginIndex: Int): ByteString
-
-  /**
-   * Returns a byte string that is a substring of this byte string, beginning at the specified
-   * `beginIndex` and ends at the specified `endIndex`. Returns this byte string if
-   * `beginIndex` is 0 and `endIndex` is the length of this byte string.
-   */
-  fun substring(beginIndex: Int, endIndex: Int): ByteString
-
   /** Returns the byte at `pos`.  */
   internal fun getByte(pos: Int): Byte
 


### PR DESCRIPTION
This moves it out of common because default parameters and expect/actual don't
interact well.