### PR TITLE
Retain interrupted state when throwing InterruptedIOException

### DIFF
--- a/okio/src/main/java/okio/Timeout.java
+++ b/okio/src/main/java/okio/Timeout.java
@@ -221,6 +221,7 @@ public class Timeout {
         throw new InterruptedIOException("timeout");
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt(); // Retain interrupted status.
       throw new InterruptedIOException("interrupted");
     }
   }

--- a/okio/src/test/java/okio/WaitUntilNotifiedTest.java
+++ b/okio/src/test/java/okio/WaitUntilNotifiedTest.java
@@ -22,9 +22,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Test;
 
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public final class WaitUntilNotifiedTest {
   final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(0);
@@ -126,7 +126,7 @@ public final class WaitUntilNotifiedTest {
       fail();
     } catch (InterruptedIOException expected) {
       assertEquals("interrupted", expected.getMessage());
-      assertFalse(Thread.interrupted());
+      assertTrue(Thread.interrupted());
     }
     assertElapsed(0.0, start);
   }


### PR DESCRIPTION
This fixes Okio 1.x. A separate fix is required for Okio 2.x.