### PR TITLE
Avoid excess ByteArray copies when creating ByteStrings

### DIFF
--- a/okio/js/src/main/kotlin/okio/ByteString.kt
+++ b/okio/js/src/main/kotlin/okio/ByteString.kt
@@ -182,7 +182,7 @@ internal actual constructor(
     actual val EMPTY: ByteString = COMMON_EMPTY
 
     /** Returns a new byte string containing a clone of the bytes of `data`. */
-    actual fun of(vararg data: Byte) = commonOf(*data.copyOf())
+    actual fun of(vararg data: Byte) = commonOf(data)
 
     // TODO move toByteString() when https://youtrack.jetbrains.com/issue/KT-22818 is fixed
 

--- a/okio/jvm/src/main/java/okio/Buffer.kt
+++ b/okio/jvm/src/main/java/okio/Buffer.kt
@@ -1591,7 +1591,7 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
         s = s.next!!
       }
     }
-    return ByteString.of(*messageDigest.digest())
+    return ByteString(messageDigest.digest())
   }
 
   /** Returns the 160-bit SHA-1 HMAC of this buffer.  */
@@ -1615,7 +1615,7 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
           s = s.next!!
         }
       }
-      return ByteString.of(*mac.doFinal())
+      return ByteString(mac.doFinal())
     } catch (e: InvalidKeyException) {
       throw IllegalArgumentException(e)
     }

--- a/okio/jvm/src/main/java/okio/ByteString.kt
+++ b/okio/jvm/src/main/java/okio/ByteString.kt
@@ -99,7 +99,7 @@ internal actual constructor(
   open fun sha512() = digest("SHA-512")
 
   private fun digest(algorithm: String) =
-      ByteString.of(*MessageDigest.getInstance(algorithm).digest(data))
+      ByteString(MessageDigest.getInstance(algorithm).digest(data))
 
   /** Returns the 160-bit SHA-1 HMAC of this byte string.  */
   open fun hmacSha1(key: ByteString) = hmac("HmacSHA1", key)
@@ -114,7 +114,7 @@ internal actual constructor(
     try {
       val mac = Mac.getInstance(algorithm)
       mac.init(SecretKeySpec(key.toByteArray(), algorithm))
-      return ByteString.of(*mac.doFinal(data))
+      return ByteString(mac.doFinal(data))
     } catch (e: InvalidKeyException) {
       throw IllegalArgumentException(e)
     }
@@ -301,7 +301,7 @@ internal actual constructor(
 
     /** Returns a new byte string containing a clone of the bytes of `data`. */
     @JvmStatic
-    actual fun of(vararg data: Byte) = commonOf(*data.copyOf())
+    actual fun of(vararg data: Byte) = commonOf(data)
 
     // TODO move toByteString() when https://youtrack.jetbrains.com/issue/KT-22818 is fixed
 

--- a/okio/jvm/src/main/java/okio/HashingSink.kt
+++ b/okio/jvm/src/main/java/okio/HashingSink.kt
@@ -89,7 +89,7 @@ class HashingSink : ForwardingSink {
   val hash: ByteString
     get() {
       val result = if (messageDigest != null) messageDigest.digest() else mac!!.doFinal()
-      return ByteString.of(*result)
+      return ByteString(result)
     }
 
   companion object {

--- a/okio/jvm/src/main/java/okio/HashingSource.kt
+++ b/okio/jvm/src/main/java/okio/HashingSource.kt
@@ -100,7 +100,7 @@ class HashingSource : ForwardingSource {
   val hash: ByteString
     get() {
       val result = if (messageDigest != null) messageDigest.digest() else mac!!.doFinal()
-      return ByteString.of(*result)
+      return ByteString(result)
     }
 
   companion object {

--- a/okio/jvm/src/test/java/okio/ByteStringTest.java
+++ b/okio/jvm/src/test/java/okio/ByteStringTest.java
@@ -93,6 +93,14 @@ public final class ByteStringTest {
   @Parameter(0) public Factory factory;
   @Parameter(1) public String name;
 
+  @Test public void ofCopy() {
+    byte[] bytes = "Hello, World!".getBytes(Charsets.UTF_8);
+    ByteString byteString = ByteString.of(bytes);
+    // Verify that the bytes were copied out.
+    bytes[4] = (byte) 'a';
+    assertEquals("Hello, World!", byteString.utf8());
+  }
+
   @Test public void ofCopyRange() {
     byte[] bytes = "Hello, World!".getBytes(Charsets.UTF_8);
     ByteString byteString = ByteString.of(bytes, 2, 9);

--- a/okio/jvm/src/test/java/okio/HashingSinkTest.java
+++ b/okio/jvm/src/test/java/okio/HashingSinkTest.java
@@ -99,10 +99,12 @@ public final class HashingSinkTest {
     HashingSink hashingSink = HashingSink.sha256(sink);
     source.writeUtf8("abc");
     hashingSink.write(source, 3L);
-    assertEquals(SHA256_abc, hashingSink.hash());
+    ByteString hash_abc = hashingSink.hash();
+    assertEquals(SHA256_abc, hash_abc);
     source.writeUtf8("def");
     hashingSink.write(source, 3L);
     assertEquals(SHA256_def, hashingSink.hash());
+    assertEquals(SHA256_abc, hash_abc);
   }
 
   @Test public void multipleSegments() throws Exception {

--- a/okio/jvm/src/test/java/okio/HashingSourceTest.java
+++ b/okio/jvm/src/test/java/okio/HashingSourceTest.java
@@ -101,10 +101,12 @@ public final class HashingSourceTest {
     HashingSource hashingSource = HashingSource.sha256(source);
     source.writeUtf8("abc");
     assertEquals(3L, hashingSource.read(sink, Long.MAX_VALUE));
-    assertEquals(SHA256_abc, hashingSource.hash());
+    ByteString hash_abc = hashingSource.hash();
+    assertEquals(SHA256_abc, hash_abc);
     source.writeUtf8("def");
     assertEquals(3L, hashingSource.read(sink, Long.MAX_VALUE));
     assertEquals(SHA256_def, hashingSource.hash());
+    assertEquals(SHA256_abc, hash_abc);
   }
 
   @Test public void multipleSegments() throws Exception {

--- a/okio/src/main/kotlin/okio/common/ByteString.kt
+++ b/okio/src/main/kotlin/okio/common/ByteString.kt
@@ -212,7 +212,7 @@ internal val COMMON_HEX_DIGITS =
 
 internal val COMMON_EMPTY = ByteString.of()
 
-internal fun commonOf(vararg data: Byte) = ByteString(data.copyOf())
+internal fun commonOf(data: ByteArray) = ByteString(data.copyOf())
 
 internal fun String.commonEncodeUtf8(): ByteString {
   val byteString = ByteString(asUtf8ToByteArray())


### PR DESCRIPTION
ByteString.of() was copying the data 2 extra times before passing it to
the commonOf() method. Avoid these extra copies by converting the
commonOf() method to take a ByteArray directly and only copy the array
in that method.

MessageDigests and Macs create unique ByteArrays which can safely be
wrapped directly with a ByteString without having to copy the array.
Avoid the spread operator and using the ByteString.of() create method.