### PR TITLE
Restore support for the empty set of options.

### DIFF
--- a/okio/src/main/java/okio/Options.java
+++ b/okio/src/main/java/okio/Options.java
@@ -33,7 +33,10 @@ public final class Options extends AbstractList<ByteString> implements RandomAcc
   }
 
   public static Options of(ByteString... byteStrings) {
-    if (byteStrings.length == 0) throw new IllegalArgumentException("no options provided");
+    if (byteStrings.length == 0) {
+      // With no choices we must always return -1. Create a trie that selects from an empty set.
+      return new Options(new ByteString[0], new int[] { 0, -1 });
+    }
 
     // Sort the byte strings which is required when recursively building the trie. Map the sorted
     // indexes to the caller's indexes.

--- a/okio/src/test/java/okio/BufferedSourceTest.java
+++ b/okio/src/test/java/okio/BufferedSourceTest.java
@@ -963,11 +963,8 @@ public final class BufferedSourceTest {
   }
 
   @Test public void selectNoByteStringsFromEmptySource() throws IOException {
-    try {
-      Options.of();
-      fail();
-    } catch (IllegalArgumentException expected) {
-    }
+    Options options = Options.of();
+    assertEquals(-1, source.select(options));
   }
 
   @Test public void selectEmptyByteString() throws IOException {

--- a/okio/src/test/java/okio/OptionsTest.java
+++ b/okio/src/test/java/okio/OptionsTest.java
@@ -173,11 +173,10 @@ public final class OptionsTest {
   }
 
   @Test public void emptyOptions() {
-    try {
-      utf8Options();
-      fail();
-    } catch (IllegalArgumentException expected) {
-    }
+    Options options = utf8Options();
+    assertSelect("", -1, options);
+    assertSelect("a", -1, options);
+    assertSelect("abc", -1, options);
   }
 
   @Test public void emptyStringInOptionsTrie() {


### PR DESCRIPTION
Moshi relies on this and it's convenient to avoid a special case in
calling code.