### PR TITLE
Restore support for the empty set of options. (Okio 2x)

### DIFF
--- a/okio/jvm/src/main/java/okio/Options.kt
+++ b/okio/jvm/src/main/java/okio/Options.kt
@@ -32,7 +32,10 @@ class Options private constructor(
   companion object {
     @JvmStatic
     fun of(vararg byteStrings: ByteString): Options {
-      require(byteStrings.isNotEmpty()) { "no options provided" }
+      if (byteStrings.isEmpty()) {
+        // With no choices we must always return -1. Create a trie that selects from an empty set.
+        return Options(arrayOf(), intArrayOf(0, -1))
+      }
 
       // Sort the byte strings which is required when recursively building the trie. Map the sorted
       // indexes to the caller's indexes.

--- a/okio/jvm/src/test/java/okio/BufferedSourceTest.java
+++ b/okio/jvm/src/test/java/okio/BufferedSourceTest.java
@@ -987,6 +987,11 @@ public final class BufferedSourceTest {
     assertEquals(-1, source.select(options));
   }
 
+  @Test public void selectNoByteStringsFromEmptySource() throws IOException {
+    Options options = Options.of();
+    assertEquals(-1, source.select(options));
+  }
+
   @Test public void rangeEquals() throws IOException {
     sink.writeUtf8("A man, a plan, a canal. Panama.");
     assertTrue(source.rangeEquals(7 , ByteString.encodeUtf8("a plan")));

--- a/okio/jvm/src/test/java/okio/OptionsTest.kt
+++ b/okio/jvm/src/test/java/okio/OptionsTest.kt
@@ -176,11 +176,10 @@ class OptionsTest {
   }
 
   @Test fun emptyOptions() {
-    try {
-      utf8Options()
-      fail()
-    } catch (expected: IllegalArgumentException) {
-    }
+    val options = utf8Options()
+    assertSelect("", -1, options)
+    assertSelect("a", -1, options)
+    assertSelect("abc", -1, options)
   }
 
   @Test fun emptyStringInOptionsTrie() {


### PR DESCRIPTION
Moshi relies on this and it's convenient to avoid a special case in
calling code.