### PR TITLE
Add compiler flags to remove interoperability null-checks

### DIFF
--- a/okio/jvm/build.gradle
+++ b/okio/jvm/build.gradle
@@ -45,6 +45,12 @@ jmh {
   duplicateClassesStrategy = 'warn'
 }
 
+compileKotlin {
+  kotlinOptions {
+    freeCompilerArgs = ["-Xno-param-assertions", "-Xno-call-assertions"]
+  }
+}
+
 dependencies {
   signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 


### PR DESCRIPTION
`-Xno-call-assertions`: Don't generate not-null assertions for arguments of platform types
`-Xno-param-assertions`: Don't generate not-null assertions on parameters of methods accessible from Java

Although those might be valuable for interop, there's evidence that they come with a performance hit as they're executed frequently. At least it's worth comparing benchmarks.