### PR TITLE
Implement UTF-8 encode and decode for JS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.versions = [
       'kotlin': '1.2.60',
-      'kotlinNative': '0.8',
+      'kotlinNative': '0.8.2',
       'jmhPlugin': '0.4.5',
       'animalSnifferPlugin': '1.4.3',
       'dokka': '0.9.16',

--- a/okio/js/src/main/kotlin/okio/-Platform.kt
+++ b/okio/js/src/main/kotlin/okio/-Platform.kt
@@ -16,6 +16,8 @@
 
 package okio
 
+import okio.internal.commonAsUtf8ToByteArray
+import okio.internal.commonToUtf8String
 import kotlin.annotation.AnnotationTarget.FIELD
 import kotlin.annotation.AnnotationTarget.FILE
 import kotlin.annotation.AnnotationTarget.FUNCTION
@@ -46,27 +48,10 @@ internal actual fun arraycopy(
   }
 }
 
-internal actual fun hashCode(a: ByteArray): Int {
-  var result = 1
-  for (element in a) {
-    result = 31 * result + element
-  }
-  return result
-}
+internal actual fun ByteArray.toUtf8String(): String = commonToUtf8String()
 
-internal actual fun ByteArray.toUtf8String(): String = "" // TODO
-
-internal actual fun CharArray.createString(): String = buildString {
-  for (c in this) append(c)
-}
-
-internal actual fun String.asUtf8ToByteArray(): ByteArray = byteArrayOf() // TODO
-
-// TODO remove if https://youtrack.jetbrains.com/issue/KT-20641 provides a better solution
-actual open class IndexOutOfBoundsException actual constructor(
-  message: String
-) : RuntimeException()
+internal actual fun String.asUtf8ToByteArray(): ByteArray = commonAsUtf8ToByteArray()
 
 actual open class ArrayIndexOutOfBoundsException actual constructor(
-  message: String
+  message: String?
 ) : IndexOutOfBoundsException(message)

--- a/okio/js/src/main/kotlin/okio/ByteString.kt
+++ b/okio/js/src/main/kotlin/okio/ByteString.kt
@@ -16,7 +16,6 @@
 package okio
 
 import okio.internal.COMMON_EMPTY
-import okio.internal.COMMON_HEX_DIGITS
 import okio.internal.commonBase64
 import okio.internal.commonBase64Url
 import okio.internal.commonCompareTo
@@ -96,7 +95,10 @@ internal actual constructor(
       commonSubstring(beginIndex, endIndex)
 
   /** Returns the byte at `pos`.  */
-  internal actual open fun internalGet(pos: Int) = commonGetByte(pos)
+  internal actual open fun internalGet(pos: Int): Byte {
+    if (pos >= size || pos < 0) throw ArrayIndexOutOfBoundsException("size=$size pos=$pos")
+    return commonGetByte(pos)
+  }
 
   /** Returns the byte at `index`.  */
   actual operator fun get(index: Int): Byte = internalGet(index)
@@ -177,8 +179,6 @@ internal actual constructor(
   actual override fun toString() = commonToString()
 
   actual companion object {
-    internal actual val HEX_DIGITS = COMMON_HEX_DIGITS
-
     /** A singleton empty `ByteString`.  */
     actual val EMPTY: ByteString = COMMON_EMPTY
 

--- a/okio/jvm/build.gradle
+++ b/okio/jvm/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     force = true
   }
 
+  jmh deps.kotlin.stdLib.jdk6
   jmh deps.jmh.core
   jmh deps.jmh.generator
 }

--- a/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/BenchmarkUtils.kt
+++ b/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/BenchmarkUtils.kt
@@ -1,0 +1,17 @@
+package com.squareup.okio.benchmarks
+
+import okio.internal.commonAsUtf8ToByteArray
+import okio.internal.commonToUtf8String
+
+// Necessary to make an invisible functions visible to Java.
+object BenchmarkUtils {
+  @JvmStatic
+  fun ByteArray.decodeUtf8(): String {
+    return commonToUtf8String()
+  }
+
+  @JvmStatic
+  fun String.encodeUtf8(): ByteArray {
+    return commonAsUtf8ToByteArray()
+  }
+}

--- a/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/BenchmarkUtils.kt
+++ b/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/BenchmarkUtils.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.okio.benchmarks
 
 import okio.internal.commonAsUtf8ToByteArray

--- a/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/BufferUtf8Benchmark.java
+++ b/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/BufferUtf8Benchmark.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2018 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okio.benchmarks;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import kotlin.text.StringsKt;
+import okio.Buffer;
+import okio.ByteString;
+
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+@Fork(1)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class BufferUtf8Benchmark {
+
+  private static final Map<String, String> strings = new HashMap<>();
+  static {
+    strings.put(
+        "ascii",
+        StringsKt.repeat(
+            "Um, I'll tell you the problem with the scientific power that you're using here, "
+                + "it didn't require any discipline to attain it. You read what others had done and you "
+                + "took the next step. You didn't earn the knowledge for yourselves, so you don't take any "
+                + "responsibility for it. You stood on the shoulders of geniuses to accomplish something "
+                + "as fast as you could, and before you even knew what you had, you patented it, and "
+                + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
+                + "sell it.",
+            500));
+
+    strings.put(
+        "sparse",
+        StringsKt.repeat(
+            "Um, I'll tell you the problem with the scientific power that you're using here, "
+                + "it didn't require any discipline to attain it. 𝒀ο𝗎 read what others had done and you "
+                + "took the next step. 𝘠ⲟ𝖚 didn't earn the knowledge for yourselves, so you don't take any "
+                + "responsibility for it. 𝛶𝛔𝔲 stood on the shoulders of geniuses to accomplish something "
+                + "as fast as you could, and before you even knew what you had, you patented it, and "
+                + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
+                + "sell it.",
+            500));
+
+    strings.put(
+        "utf8",
+        StringsKt.repeat(
+            "Սｍ, I'll 𝓽𝖾ll ᶌօ𝘂 ᴛℎ℮ 𝜚𝕣०ｂl𝖾ｍ ｗі𝕥𝒽 𝘵𝘩𝐞 𝓼𝙘𝐢𝔢𝓷𝗍𝜄𝚏𝑖ｃ 𝛠𝝾ｗ𝚎𝑟 𝕥ｈ⍺𝞃 𝛄𝓸𝘂'𝒓𝗲 υ𝖘𝓲𝗇ɡ 𝕙𝚎𝑟ｅ, "
+                + "𝛊𝓽 ⅆ𝕚𝐝𝝿'𝗍 𝔯𝙚𝙦ᴜ𝜾𝒓𝘦 𝔞𝘯𝐲 ԁ𝜄𝑠𝚌ι𝘱lι𝒏ｅ 𝑡𝜎 𝕒𝚝𝖙𝓪і𝞹 𝔦𝚝. 𝒀ο𝗎 𝔯𝑒⍺𝖉 ｗ𝐡𝝰𝔱 𝞂𝞽һ𝓮𝓇ƽ հ𝖺𝖉 ⅾ𝛐𝝅ⅇ 𝝰πԁ 𝔂ᴑᴜ 𝓉ﮨ၀𝚔 "
+                + "т𝒽𝑒 𝗇𝕖ⅹ𝚝 𝔰𝒕е𝓅. 𝘠ⲟ𝖚 𝖉ⅰԁ𝝕'τ 𝙚𝚊ｒ𝞹 𝘵Ꮒ𝖾 𝝒𝐧هｗl𝑒𝖉ƍ𝙚 𝓯૦ｒ 𝔂𝞼𝒖𝕣𝑠𝕖l𝙫𝖊𝓼, 𐑈о ｙ𝘰𝒖 ⅆە𝗇'ｔ 𝜏α𝒌𝕖 𝛂𝟉ℽ "
+                + "𝐫ⅇ𝗌ⲣ๐ϖ𝖘ꙇᖯ𝓲l𝓲𝒕𝘆 𝐟𝞼𝘳 𝚤𝑡. 𝛶𝛔𝔲 ｓ𝕥σσ𝐝 ﮩ𝕟 𝒕𝗁𝔢 𝘴𝐡𝜎ᴜlⅾ𝓮𝔯𝚜 𝛐𝙛 ᶃ𝚎ᴨᎥս𝚜𝘦𝓈 𝓽𝞸 ａ𝒄𝚌𝞸ｍρl𝛊ꜱ𝐡 𝓈𝚘ｍ𝚎𝞃𝔥⍳𝞹𝔤 𝐚𝗌 𝖋ａ𝐬𝒕 "
+                + "αｓ γ𝛐𝕦 𝔠ﻫ𝛖lԁ, 𝚊π𝑑 Ь𝑒𝙛૦𝓇𝘦 𝓎٥𝖚 ⅇｖℯ𝝅 𝜅ո𝒆ｗ ｗ𝗵𝒂𝘁 ᶌ੦𝗎 ｈ𝐚𝗱, 𝜸ﮨ𝒖 𝓹𝝰𝔱𝖾𝗇𝓽𝔢ⅆ і𝕥, 𝚊𝜛𝓭 𝓹𝖺ⅽϰ𝘢ℊеᏧ 𝑖𝞃, "
+                + "𝐚𝛑ꓒ 𝙨l𝔞р𝘱𝔢𝓭 ɩ𝗍 ہ𝛑 𝕒 ｐl𝛂ѕᴛ𝗂𝐜 l𝞄ℼ𝔠𝒽𝑏ﮪ⨯, 𝔞ϖ𝒹 ｎ𝛔ｗ 𝛾𝐨𝞄'𝗿𝔢 ꜱ℮ll𝙞ｎɡ ɩ𝘁, 𝙮𝕠𝛖 ｗ𝑎ℼ𝚗𝛂 𝕤𝓮ll 𝙞𝓉.",
+            500));
+  }
+
+  @Param({"ascii", "sparse", "utf8"})
+  String encoding;
+
+  Buffer buffer;
+  ByteString decode;
+  String encode;
+
+  @Setup
+  public void setup() {
+    buffer = new Buffer();
+    encode = strings.get(encoding);
+
+    Buffer temp = new Buffer();
+    temp.writeUtf8(encode);
+    decode = temp.snapshot();
+  }
+
+  @Benchmark
+  public void writeUtf8() {
+    buffer.writeUtf8(encode);
+    buffer.clear();
+  }
+
+  @Benchmark
+  public String readUtf8() {
+    buffer.write(decode);
+    return buffer.readUtf8();
+  }
+
+  public static void main(String[] args) throws IOException, RunnerException {
+    Main.main(new String[] { BufferUtf8Benchmark.class.getName()});
+  }
+}

--- a/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/BufferUtf8Benchmark.java
+++ b/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/BufferUtf8Benchmark.java
@@ -20,10 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import kotlin.text.StringsKt;
-import okio.Buffer;
-import okio.ByteString;
-
 import org.openjdk.jmh.Main;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -38,6 +34,9 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.RunnerException;
 
+import okio.Buffer;
+import okio.ByteString;
+
 @Fork(1)
 @Warmup(iterations = 5, time = 2)
 @Measurement(iterations = 5, time = 2)
@@ -45,57 +44,73 @@ import org.openjdk.jmh.runner.RunnerException;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 public class BufferUtf8Benchmark {
-
   private static final Map<String, String> strings = new HashMap<>();
+
   static {
     strings.put(
         "ascii",
-        StringsKt.repeat(
-            "Um, I'll tell you the problem with the scientific power that you're using here, "
-                + "it didn't require any discipline to attain it. You read what others had done and you "
-                + "took the next step. You didn't earn the knowledge for yourselves, so you don't take any "
-                + "responsibility for it. You stood on the shoulders of geniuses to accomplish something "
-                + "as fast as you could, and before you even knew what you had, you patented it, and "
-                + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
-                + "sell it.",
-            500));
-
-    strings.put(
-        "sparse",
-        StringsKt.repeat(
-            "Um, I'll tell you the problem with the scientific power that you're using here, "
-                + "it didn't require any discipline to attain it. 𝒀ο𝗎 read what others had done and you "
-                + "took the next step. 𝘠ⲟ𝖚 didn't earn the knowledge for yourselves, so you don't take any "
-                + "responsibility for it. 𝛶𝛔𝔲 stood on the shoulders of geniuses to accomplish something "
-                + "as fast as you could, and before you even knew what you had, you patented it, and "
-                + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
-                + "sell it.",
-            500));
+        "Um, I'll tell you the problem with the scientific power that you're using here, "
+            + "it didn't require any discipline to attain it. You read what others had done and you "
+            + "took the next step. You didn't earn the knowledge for yourselves, so you don't take any "
+            + "responsibility for it. You stood on the shoulders of geniuses to accomplish something "
+            + "as fast as you could, and before you even knew what you had, you patented it, and "
+            + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
+            + "sell it.");
 
     strings.put(
         "utf8",
-        StringsKt.repeat(
-            "Սｍ, I'll 𝓽𝖾ll ᶌօ𝘂 ᴛℎ℮ 𝜚𝕣०ｂl𝖾ｍ ｗі𝕥𝒽 𝘵𝘩𝐞 𝓼𝙘𝐢𝔢𝓷𝗍𝜄𝚏𝑖ｃ 𝛠𝝾ｗ𝚎𝑟 𝕥ｈ⍺𝞃 𝛄𝓸𝘂'𝒓𝗲 υ𝖘𝓲𝗇ɡ 𝕙𝚎𝑟ｅ, "
-                + "𝛊𝓽 ⅆ𝕚𝐝𝝿'𝗍 𝔯𝙚𝙦ᴜ𝜾𝒓𝘦 𝔞𝘯𝐲 ԁ𝜄𝑠𝚌ι𝘱lι𝒏ｅ 𝑡𝜎 𝕒𝚝𝖙𝓪і𝞹 𝔦𝚝. 𝒀ο𝗎 𝔯𝑒⍺𝖉 ｗ𝐡𝝰𝔱 𝞂𝞽һ𝓮𝓇ƽ հ𝖺𝖉 ⅾ𝛐𝝅ⅇ 𝝰πԁ 𝔂ᴑᴜ 𝓉ﮨ၀𝚔 "
-                + "т𝒽𝑒 𝗇𝕖ⅹ𝚝 𝔰𝒕е𝓅. 𝘠ⲟ𝖚 𝖉ⅰԁ𝝕'τ 𝙚𝚊ｒ𝞹 𝘵Ꮒ𝖾 𝝒𝐧هｗl𝑒𝖉ƍ𝙚 𝓯૦ｒ 𝔂𝞼𝒖𝕣𝑠𝕖l𝙫𝖊𝓼, 𐑈о ｙ𝘰𝒖 ⅆە𝗇'ｔ 𝜏α𝒌𝕖 𝛂𝟉ℽ "
-                + "𝐫ⅇ𝗌ⲣ๐ϖ𝖘ꙇᖯ𝓲l𝓲𝒕𝘆 𝐟𝞼𝘳 𝚤𝑡. 𝛶𝛔𝔲 ｓ𝕥σσ𝐝 ﮩ𝕟 𝒕𝗁𝔢 𝘴𝐡𝜎ᴜlⅾ𝓮𝔯𝚜 𝛐𝙛 ᶃ𝚎ᴨᎥս𝚜𝘦𝓈 𝓽𝞸 ａ𝒄𝚌𝞸ｍρl𝛊ꜱ𝐡 𝓈𝚘ｍ𝚎𝞃𝔥⍳𝞹𝔤 𝐚𝗌 𝖋ａ𝐬𝒕 "
-                + "αｓ γ𝛐𝕦 𝔠ﻫ𝛖lԁ, 𝚊π𝑑 Ь𝑒𝙛૦𝓇𝘦 𝓎٥𝖚 ⅇｖℯ𝝅 𝜅ո𝒆ｗ ｗ𝗵𝒂𝘁 ᶌ੦𝗎 ｈ𝐚𝗱, 𝜸ﮨ𝒖 𝓹𝝰𝔱𝖾𝗇𝓽𝔢ⅆ і𝕥, 𝚊𝜛𝓭 𝓹𝖺ⅽϰ𝘢ℊеᏧ 𝑖𝞃, "
-                + "𝐚𝛑ꓒ 𝙨l𝔞р𝘱𝔢𝓭 ɩ𝗍 ہ𝛑 𝕒 ｐl𝛂ѕᴛ𝗂𝐜 l𝞄ℼ𝔠𝒽𝑏ﮪ⨯, 𝔞ϖ𝒹 ｎ𝛔ｗ 𝛾𝐨𝞄'𝗿𝔢 ꜱ℮ll𝙞ｎɡ ɩ𝘁, 𝙮𝕠𝛖 ｗ𝑎ℼ𝚗𝛂 𝕤𝓮ll 𝙞𝓉.",
-            500));
+        "Սｍ, I'll 𝓽𝖾ll ᶌօ𝘂 ᴛℎ℮ 𝜚𝕣०ｂl𝖾ｍ ｗі𝕥𝒽 𝘵𝘩𝐞 𝓼𝙘𝐢𝔢𝓷𝗍𝜄𝚏𝑖ｃ 𝛠𝝾ｗ𝚎𝑟 𝕥ｈ⍺𝞃 𝛄𝓸𝘂'𝒓𝗲 υ𝖘𝓲𝗇ɡ 𝕙𝚎𝑟ｅ, "
+            + "𝛊𝓽 ⅆ𝕚𝐝𝝿'𝗍 𝔯𝙚𝙦ᴜ𝜾𝒓𝘦 𝔞𝘯𝐲 ԁ𝜄𝑠𝚌ι𝘱lι𝒏ｅ 𝑡𝜎 𝕒𝚝𝖙𝓪і𝞹 𝔦𝚝. 𝒀ο𝗎 𝔯𝑒⍺𝖉 ｗ𝐡𝝰𝔱 𝞂𝞽һ𝓮𝓇ƽ հ𝖺𝖉 ⅾ𝛐𝝅ⅇ 𝝰πԁ 𝔂ᴑᴜ 𝓉ﮨ၀𝚔 "
+            + "т𝒽𝑒 𝗇𝕖ⅹ𝚝 𝔰𝒕е𝓅. 𝘠ⲟ𝖚 𝖉ⅰԁ𝝕'τ 𝙚𝚊ｒ𝞹 𝘵Ꮒ𝖾 𝝒𝐧هｗl𝑒𝖉ƍ𝙚 𝓯૦ｒ 𝔂𝞼𝒖𝕣𝑠𝕖l𝙫𝖊𝓼, 𐑈о ｙ𝘰𝒖 ⅆە𝗇'ｔ 𝜏α𝒌𝕖 𝛂𝟉ℽ "
+            + "𝐫ⅇ𝗌ⲣ๐ϖ𝖘ꙇᖯ𝓲l𝓲𝒕𝘆 𝐟𝞼𝘳 𝚤𝑡. 𝛶𝛔𝔲 ｓ𝕥σσ𝐝 ﮩ𝕟 𝒕𝗁𝔢 𝘴𝐡𝜎ᴜlⅾ𝓮𝔯𝚜 𝛐𝙛 ᶃ𝚎ᴨᎥս𝚜𝘦𝓈 𝓽𝞸 ａ𝒄𝚌𝞸ｍρl𝛊ꜱ𝐡 𝓈𝚘ｍ𝚎𝞃𝔥⍳𝞹𝔤 𝐚𝗌 𝖋ａ𝐬𝒕 "
+            + "αｓ γ𝛐𝕦 𝔠ﻫ𝛖lԁ, 𝚊π𝑑 Ь𝑒𝙛૦𝓇𝘦 𝓎٥𝖚 ⅇｖℯ𝝅 𝜅ո𝒆ｗ ｗ𝗵𝒂𝘁 ᶌ੦𝗎 ｈ𝐚𝗱, 𝜸ﮨ𝒖 𝓹𝝰𝔱𝖾𝗇𝓽𝔢ⅆ і𝕥, 𝚊𝜛𝓭 𝓹𝖺ⅽϰ𝘢ℊеᏧ 𝑖𝞃, "
+            + "𝐚𝛑ꓒ 𝙨l𝔞р𝘱𝔢𝓭 ɩ𝗍 ہ𝛑 𝕒 ｐl𝛂ѕᴛ𝗂𝐜 l𝞄ℼ𝔠𝒽𝑏ﮪ⨯, 𝔞ϖ𝒹 ｎ𝛔ｗ 𝛾𝐨𝞄'𝗿𝔢 ꜱ℮ll𝙞ｎɡ ɩ𝘁, 𝙮𝕠𝛖 ｗ𝑎ℼ𝚗𝛂 𝕤𝓮ll 𝙞𝓉.");
+
+    // The first 't' is actually a '𝓽'
+    strings.put(
+        "sparse",
+        "Um, I'll 𝓽ell you the problem with the scientific power that you're using here, "
+            + "it didn't require any discipline to attain it. You read what others had done and you "
+            + "took the next step. You didn't earn the knowledge for yourselves, so you don't take any "
+            + "responsibility for it. You stood on the shoulders of geniuses to accomplish something "
+            + "as fast as you could, and before you even knew what you had, you patented it, and "
+            + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
+            + "sell it.");
+
+    strings.put("2bytes", "\u0080\u07ff");
+
+    strings.put("3bytes", "\u0800\ud7ff\ue000\uffff");
+
+    strings.put("4bytes", "\ud835\udeca");
+
+    // high surrogate, 'a', low surrogate, and 'a'
+    strings.put("bad", "\ud800\u0061\udc00\u0061");
   }
 
-  @Param({"ascii", "sparse", "utf8"})
+  @Param({"20", "2000", "200000"})
+  int length;
+
+  @Param({"ascii", "utf8", "sparse", "2bytes", "3bytes", "4bytes", "bad"})
   String encoding;
 
   Buffer buffer;
-  ByteString decode;
   String encode;
+  ByteString decode;
 
   @Setup
   public void setup() {
-    buffer = new Buffer();
-    encode = strings.get(encoding);
+    String part = strings.get(encoding);
 
+    // Make all the strings the same length for comparison
+    StringBuilder builder = new StringBuilder(length + 1_000);
+    while (builder.length() < length) {
+      builder.append(part);
+    }
+    builder.setLength(length);
+
+    // Prepare a string and ByteString for encoding and decoding
+    buffer = new Buffer();
+    encode = builder.toString();
     Buffer temp = new Buffer();
     temp.writeUtf8(encode);
     decode = temp.snapshot();
@@ -114,6 +129,6 @@ public class BufferUtf8Benchmark {
   }
 
   public static void main(String[] args) throws IOException, RunnerException {
-    Main.main(new String[] { BufferUtf8Benchmark.class.getName()});
+    Main.main(new String[] {BufferUtf8Benchmark.class.getName()});
   }
 }

--- a/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/Utf8Benchmark.java
+++ b/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/Utf8Benchmark.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2018 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okio.benchmarks;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+@Fork(1)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class Utf8Benchmark {
+  private static final Charset utf8 = StandardCharsets.UTF_8;
+  private static final Map<String, String> strings = new HashMap<>();
+
+  static {
+    strings.put(
+        "ascii",
+        "Um, I'll tell you the problem with the scientific power that you're using here, "
+            + "it didn't require any discipline to attain it. You read what others had done and you "
+            + "took the next step. You didn't earn the knowledge for yourselves, so you don't take any "
+            + "responsibility for it. You stood on the shoulders of geniuses to accomplish something "
+            + "as fast as you could, and before you even knew what you had, you patented it, and "
+            + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
+            + "sell it.");
+
+    strings.put(
+        "utf8",
+        "Սｍ, I'll 𝓽𝖾ll ᶌօ𝘂 ᴛℎ℮ 𝜚𝕣०ｂl𝖾ｍ ｗі𝕥𝒽 𝘵𝘩𝐞 𝓼𝙘𝐢𝔢𝓷𝗍𝜄𝚏𝑖ｃ 𝛠𝝾ｗ𝚎𝑟 𝕥ｈ⍺𝞃 𝛄𝓸𝘂'𝒓𝗲 υ𝖘𝓲𝗇ɡ 𝕙𝚎𝑟ｅ, "
+            + "𝛊𝓽 ⅆ𝕚𝐝𝝿'𝗍 𝔯𝙚𝙦ᴜ𝜾𝒓𝘦 𝔞𝘯𝐲 ԁ𝜄𝑠𝚌ι𝘱lι𝒏ｅ 𝑡𝜎 𝕒𝚝𝖙𝓪і𝞹 𝔦𝚝. 𝒀ο𝗎 𝔯𝑒⍺𝖉 ｗ𝐡𝝰𝔱 𝞂𝞽һ𝓮𝓇ƽ հ𝖺𝖉 ⅾ𝛐𝝅ⅇ 𝝰πԁ 𝔂ᴑᴜ 𝓉ﮨ၀𝚔 "
+            + "т𝒽𝑒 𝗇𝕖ⅹ𝚝 𝔰𝒕е𝓅. 𝘠ⲟ𝖚 𝖉ⅰԁ𝝕'τ 𝙚𝚊ｒ𝞹 𝘵Ꮒ𝖾 𝝒𝐧هｗl𝑒𝖉ƍ𝙚 𝓯૦ｒ 𝔂𝞼𝒖𝕣𝑠𝕖l𝙫𝖊𝓼, 𐑈о ｙ𝘰𝒖 ⅆە𝗇'ｔ 𝜏α𝒌𝕖 𝛂𝟉ℽ "
+            + "𝐫ⅇ𝗌ⲣ๐ϖ𝖘ꙇᖯ𝓲l𝓲𝒕𝘆 𝐟𝞼𝘳 𝚤𝑡. 𝛶𝛔𝔲 ｓ𝕥σσ𝐝 ﮩ𝕟 𝒕𝗁𝔢 𝘴𝐡𝜎ᴜlⅾ𝓮𝔯𝚜 𝛐𝙛 ᶃ𝚎ᴨᎥս𝚜𝘦𝓈 𝓽𝞸 ａ𝒄𝚌𝞸ｍρl𝛊ꜱ𝐡 𝓈𝚘ｍ𝚎𝞃𝔥⍳𝞹𝔤 𝐚𝗌 𝖋ａ𝐬𝒕 "
+            + "αｓ γ𝛐𝕦 𝔠ﻫ𝛖lԁ, 𝚊π𝑑 Ь𝑒𝙛૦𝓇𝘦 𝓎٥𝖚 ⅇｖℯ𝝅 𝜅ո𝒆ｗ ｗ𝗵𝒂𝘁 ᶌ੦𝗎 ｈ𝐚𝗱, 𝜸ﮨ𝒖 𝓹𝝰𝔱𝖾𝗇𝓽𝔢ⅆ і𝕥, 𝚊𝜛𝓭 𝓹𝖺ⅽϰ𝘢ℊеᏧ 𝑖𝞃, "
+            + "𝐚𝛑ꓒ 𝙨l𝔞р𝘱𝔢𝓭 ɩ𝗍 ہ𝛑 𝕒 ｐl𝛂ѕᴛ𝗂𝐜 l𝞄ℼ𝔠𝒽𝑏ﮪ⨯, 𝔞ϖ𝒹 ｎ𝛔ｗ 𝛾𝐨𝞄'𝗿𝔢 ꜱ℮ll𝙞ｎɡ ɩ𝘁, 𝙮𝕠𝛖 ｗ𝑎ℼ𝚗𝛂 𝕤𝓮ll 𝙞𝓉.");
+
+    strings.put(
+        "sparse",
+        "Um, I'll tell you the problem with the scientific power that you're using here, "
+            + "it didn't require any discipline to attain it. 𝒀ο𝗎 read what others had done and you "
+            + "took the next step. 𝘠ⲟ𝖚 didn't earn the knowledge for yourselves, so you don't take any "
+            + "responsibility for it. 𝛶𝛔𝔲 stood on the shoulders of geniuses to accomplish something "
+            + "as fast as you could, and before you even knew what you had, you patented it, and "
+            + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
+            + "sell it.");
+
+    strings.put("2bytes", "\u0080\u07ff");
+
+    strings.put("3bytes", "\u0800\ud7ff\ue000\uffff");
+
+    strings.put("4bytes", "\ud835\udeca");
+
+    // high surrogate, 'a', low surrogate, and 'a'
+    strings.put("bad", "\ud800\u0061\udc00\u0061");
+  }
+
+  @Param({"short", "long"})
+  String length;
+
+  @Param({"ascii", "utf8", "sparse", "2bytes", "3bytes", "4bytes", "bad"})
+  String encoding;
+
+  String encode;
+  byte[] decodeArray;
+
+  @Setup
+  public void setup() {
+    String part = strings.get(encoding);
+
+    // Try to make all the strings about the same length for comparison
+    int target = "long".equals(length) ? 250_000 : 2_500;
+    StringBuilder builder = new StringBuilder(target + 1_000);
+    while (builder.length() < target) {
+      builder.append(part);
+    }
+
+    // Prepare a string and byte array for encoding and decoding
+    encode = builder.toString();
+    decodeArray = encode.getBytes(utf8);
+  }
+
+  @Benchmark
+  public byte[] stringToBytesOkio() {
+    return BenchmarkUtils.encodeUtf8(encode);
+  }
+
+  @Benchmark
+  public byte[] stringToBytesJava() {
+    return encode.getBytes(utf8);
+  }
+
+  @Benchmark
+  public String bytesToStringOkio() {
+    // For ASCII only encoding, this will never be faster than Java. Because
+    // Java can trust the decoded char array and it will be the correct size for
+    // ASCII, it is able to avoid the extra defensive copy Okio is forced to
+    // make because it doesn't have access to String internals.
+    return BenchmarkUtils.decodeUtf8(decodeArray);
+  }
+
+  @Benchmark
+  public String bytesToStringJava() {
+    return new String(decodeArray, utf8);
+  }
+
+  public static void main(String[] args) throws IOException, RunnerException {
+    Main.main(new String[] {Utf8Benchmark.class.getName()});
+  }
+}

--- a/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/Utf8Benchmark.java
+++ b/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/Utf8Benchmark.java
@@ -66,12 +66,13 @@ public class Utf8Benchmark {
             + "αｓ γ𝛐𝕦 𝔠ﻫ𝛖lԁ, 𝚊π𝑑 Ь𝑒𝙛૦𝓇𝘦 𝓎٥𝖚 ⅇｖℯ𝝅 𝜅ո𝒆ｗ ｗ𝗵𝒂𝘁 ᶌ੦𝗎 ｈ𝐚𝗱, 𝜸ﮨ𝒖 𝓹𝝰𝔱𝖾𝗇𝓽𝔢ⅆ і𝕥, 𝚊𝜛𝓭 𝓹𝖺ⅽϰ𝘢ℊеᏧ 𝑖𝞃, "
             + "𝐚𝛑ꓒ 𝙨l𝔞р𝘱𝔢𝓭 ɩ𝗍 ہ𝛑 𝕒 ｐl𝛂ѕᴛ𝗂𝐜 l𝞄ℼ𝔠𝒽𝑏ﮪ⨯, 𝔞ϖ𝒹 ｎ𝛔ｗ 𝛾𝐨𝞄'𝗿𝔢 ꜱ℮ll𝙞ｎɡ ɩ𝘁, 𝙮𝕠𝛖 ｗ𝑎ℼ𝚗𝛂 𝕤𝓮ll 𝙞𝓉.");
 
+    // The first 't' is actually a '𝓽'
     strings.put(
         "sparse",
-        "Um, I'll tell you the problem with the scientific power that you're using here, "
-            + "it didn't require any discipline to attain it. 𝒀ο𝗎 read what others had done and you "
-            + "took the next step. 𝘠ⲟ𝖚 didn't earn the knowledge for yourselves, so you don't take any "
-            + "responsibility for it. 𝛶𝛔𝔲 stood on the shoulders of geniuses to accomplish something "
+        "Um, I'll 𝓽ell you the problem with the scientific power that you're using here, "
+            + "it didn't require any discipline to attain it. You read what others had done and you "
+            + "took the next step. You didn't earn the knowledge for yourselves, so you don't take any "
+            + "responsibility for it. You stood on the shoulders of geniuses to accomplish something "
             + "as fast as you could, and before you even knew what you had, you patented it, and "
             + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
             + "sell it.");
@@ -86,8 +87,8 @@ public class Utf8Benchmark {
     strings.put("bad", "\ud800\u0061\udc00\u0061");
   }
 
-  @Param({"short", "long"})
-  String length;
+  @Param({"20", "2000", "200000"})
+  int length;
 
   @Param({"ascii", "utf8", "sparse", "2bytes", "3bytes", "4bytes", "bad"})
   String encoding;
@@ -99,12 +100,12 @@ public class Utf8Benchmark {
   public void setup() {
     String part = strings.get(encoding);
 
-    // Try to make all the strings about the same length for comparison
-    int target = "long".equals(length) ? 250_000 : 2_500;
-    StringBuilder builder = new StringBuilder(target + 1_000);
-    while (builder.length() < target) {
+    // Make all the strings the same length for comparison
+    StringBuilder builder = new StringBuilder(length + 1_000);
+    while (builder.length() < length) {
       builder.append(part);
     }
+    builder.setLength(length);
 
     // Prepare a string and byte array for encoding and decoding
     encode = builder.toString();
@@ -123,7 +124,7 @@ public class Utf8Benchmark {
 
   @Benchmark
   public String bytesToStringOkio() {
-    // For ASCII only encoding, this will never be faster than Java. Because
+    // For ASCII only decoding, this will never be faster than Java. Because
     // Java can trust the decoded char array and it will be the correct size for
     // ASCII, it is able to avoid the extra defensive copy Okio is forced to
     // make because it doesn't have access to String internals.

--- a/okio/jvm/src/main/java/okio/-Platform.kt
+++ b/okio/jvm/src/main/java/okio/-Platform.kt
@@ -17,8 +17,6 @@
 @file:JvmName("-Platform")
 package okio
 
-import java.util.Arrays
-
 actual typealias JvmOverloads = kotlin.jvm.JvmOverloads
 actual typealias JvmField = kotlin.jvm.JvmField
 actual typealias JvmStatic = kotlin.jvm.JvmStatic
@@ -34,15 +32,9 @@ internal actual fun arraycopy(
   System.arraycopy(src, srcPos, dest, destPos, length)
 }
 
-internal actual fun hashCode(a: ByteArray): Int = Arrays.hashCode(a)
-
 internal actual fun ByteArray.toUtf8String(): String = String(this, Charsets.UTF_8)
-
-internal actual fun CharArray.createString(): String = String(this)
 
 internal actual fun String.asUtf8ToByteArray(): ByteArray = toByteArray(Charsets.UTF_8)
 
 // TODO remove if https://youtrack.jetbrains.com/issue/KT-20641 provides a better solution
-actual typealias IndexOutOfBoundsException = java.lang.IndexOutOfBoundsException
-
 actual typealias ArrayIndexOutOfBoundsException = java.lang.ArrayIndexOutOfBoundsException

--- a/okio/jvm/src/main/java/okio/Buffer.kt
+++ b/okio/jvm/src/main/java/okio/Buffer.kt
@@ -761,7 +761,7 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
       else -> {
         // We expected the first byte of a code point but got something else.
         skip(1)
-        return REPLACEMENT_CHARACTER
+        return REPLACEMENT_CODE_POINT
       }
     }
 
@@ -781,7 +781,7 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
         codePoint = codePoint or (b and 0x3f)
       } else {
         skip(i.toLong())
-        return REPLACEMENT_CHARACTER
+        return REPLACEMENT_CODE_POINT
       }
     }
 
@@ -789,13 +789,13 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
 
     return when {
       codePoint > 0x10ffff -> {
-        REPLACEMENT_CHARACTER // Reject code points larger than the Unicode maximum.
+        REPLACEMENT_CODE_POINT // Reject code points larger than the Unicode maximum.
       }
       codePoint in 0xd800..0xdfff -> {
-        REPLACEMENT_CHARACTER // Reject partial surrogates.
+        REPLACEMENT_CODE_POINT // Reject partial surrogates.
       }
       codePoint < min -> {
-        REPLACEMENT_CHARACTER // Reject overlong code points.
+        REPLACEMENT_CODE_POINT // Reject overlong code points.
       }
       else -> codePoint
     }
@@ -928,16 +928,22 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
 
         c < 0x800 -> {
           // Emit a 11-bit character with 2 bytes.
-          writeByte(c shr 6          or 0xc0) // 110xxxxx
-          writeByte(c       and 0x3f or 0x80) // 10xxxxxx
+          val tail = writableSegment(2)
+          tail.data[tail.limit    ] = (c shr 6          or 0xc0).toByte() // 110xxxxx
+          tail.data[tail.limit + 1] = (c       and 0x3f or 0x80).toByte() // 10xxxxxx
+          tail.limit += 2
+          size += 2L
           i++
         }
 
         c < 0xd800 || c > 0xdfff -> {
           // Emit a 16-bit character with 3 bytes.
-          writeByte(c shr 12          or 0xe0) // 1110xxxx
-          writeByte(c shr  6 and 0x3f or 0x80) // 10xxxxxx
-          writeByte(c        and 0x3f or 0x80) // 10xxxxxx
+          val tail = writableSegment(3)
+          tail.data[tail.limit    ] = (c shr 12          or 0xe0).toByte() // 1110xxxx
+          tail.data[tail.limit + 1] = (c shr  6 and 0x3f or 0x80).toByte() // 10xxxxxx
+          tail.data[tail.limit + 2] = (c        and 0x3f or 0x80).toByte() // 10xxxxxx
+          tail.limit += 3
+          size += 3L
           i++
         }
 
@@ -953,13 +959,16 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
             // UTF-16 high surrogate: 110110xxxxxxxxxx (10 bits)
             // UTF-16 low surrogate:  110111yyyyyyyyyy (10 bits)
             // Unicode code point:    00010000000000000000 + xxxxxxxxxxyyyyyyyyyy (21 bits)
-            val codePoint = 0x010000 + (c and 0xd800.inv() shl 10 or (low and 0xdc00.inv()))
+            val codePoint = 0x010000 + (c and 0x03ff shl 10 or (low and 0x03ff))
 
             // Emit a 21-bit character with 4 bytes.
-            writeByte(codePoint shr 18          or 0xf0) // 11110xxx
-            writeByte(codePoint shr 12 and 0x3f or 0x80) // 10xxxxxx
-            writeByte(codePoint shr  6 and 0x3f or 0x80) // 10xxyyyy
-            writeByte(codePoint        and 0x3f or 0x80) // 10yyyyyy
+            val tail = writableSegment(4)
+            tail.data[tail.limit    ] = (codePoint shr 18          or 0xf0).toByte() // 11110xxx
+            tail.data[tail.limit + 1] = (codePoint shr 12 and 0x3f or 0x80).toByte() // 10xxxxxx
+            tail.data[tail.limit + 2] = (codePoint shr  6 and 0x3f or 0x80).toByte() // 10xxyyyy
+            tail.data[tail.limit + 3] = (codePoint        and 0x3f or 0x80).toByte() // 10yyyyyy
+            tail.limit += 4
+            size += 4L
             i += 2
           }
         }
@@ -977,8 +986,11 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
       }
       codePoint < 0x800 -> {
         // Emit a 11-bit code point with 2 bytes.
-        writeByte(codePoint shr 6          or 0xc0) // 110xxxxx
-        writeByte(codePoint       and 0x3f or 0x80) // 10xxxxxx
+        val tail = writableSegment(2)
+        tail.data[tail.limit    ] = (codePoint shr 6          or 0xc0).toByte() // 110xxxxx
+        tail.data[tail.limit + 1] = (codePoint       and 0x3f or 0x80).toByte() // 10xxxxxx
+        tail.limit += 2
+        size += 2L
       }
       codePoint in 0xd800..0xdfff -> {
         // Emit a replacement character for a partial surrogate.
@@ -986,16 +998,22 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
       }
       codePoint < 0x10000 -> {
         // Emit a 16-bit code point with 3 bytes.
-        writeByte(codePoint shr 12          or 0xe0) // 1110xxxx
-        writeByte(codePoint shr  6 and 0x3f or 0x80) // 10xxxxxx
-        writeByte(codePoint        and 0x3f or 0x80) // 10xxxxxx
+        val tail = writableSegment(3)
+        tail.data[tail.limit    ] = (codePoint shr 12          or 0xe0).toByte() // 1110xxxx
+        tail.data[tail.limit + 1] = (codePoint shr  6 and 0x3f or 0x80).toByte() // 10xxxxxx
+        tail.data[tail.limit + 2] = (codePoint        and 0x3f or 0x80).toByte() // 10xxxxxx
+        tail.limit += 3
+        size += 3L
       }
       codePoint <= 0x10ffff -> {
         // Emit a 21-bit code point with 4 bytes.
-        writeByte(codePoint shr 18          or 0xf0) // 11110xxx
-        writeByte(codePoint shr 12 and 0x3f or 0x80) // 10xxxxxx
-        writeByte(codePoint shr  6 and 0x3f or 0x80) // 10xxxxxx
-        writeByte(codePoint        and 0x3f or 0x80) // 10xxxxxx
+        val tail = writableSegment(4)
+        tail.data[tail.limit    ] = (codePoint shr 18          or 0xf0).toByte() // 11110xxx
+        tail.data[tail.limit + 1] = (codePoint shr 12 and 0x3f or 0x80).toByte() // 10xxxxxx
+        tail.data[tail.limit + 2] = (codePoint shr  6 and 0x3f or 0x80).toByte() // 10xxyyyy
+        tail.data[tail.limit + 3] = (codePoint        and 0x3f or 0x80).toByte() // 10yyyyyy
+        tail.limit += 4
+        size += 4L
       }
       else -> {
         throw IllegalArgumentException("Unexpected code point: ${Integer.toHexString(codePoint)}")

--- a/okio/jvm/src/main/java/okio/ByteString.kt
+++ b/okio/jvm/src/main/java/okio/ByteString.kt
@@ -16,7 +16,6 @@
 package okio
 
 import okio.internal.COMMON_EMPTY
-import okio.internal.COMMON_HEX_DIGITS
 import okio.internal.commonBase64
 import okio.internal.commonBase64Url
 import okio.internal.commonCompareTo
@@ -284,7 +283,6 @@ internal actual constructor(
   fun size() = size
 
   actual companion object {
-    internal actual val HEX_DIGITS = COMMON_HEX_DIGITS
     private const val serialVersionUID = 1L
 
     /** A singleton empty `ByteString`.  */

--- a/okio/jvm/src/test/java/okio/ByteStringKotlinTest.kt
+++ b/okio/jvm/src/test/java/okio/ByteStringKotlinTest.kt
@@ -15,89 +15,52 @@
  */
 package okio
 
-import okio.ByteString.Companion.decodeBase64
-import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encode
 import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.readByteString
 import okio.ByteString.Companion.toByteString
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.nio.ByteBuffer
-import kotlin.test.fail
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ByteStringKotlinTest {
-  @Test fun get() {
-    val actual = "abc".encodeUtf8()
-    assertThat(actual[0]).isEqualTo('a'.toByte())
-    assertThat(actual[1]).isEqualTo('b'.toByte())
-    assertThat(actual[2]).isEqualTo('c'.toByte())
-    try {
-      actual[-1]
-      fail()
-    } catch (expected: IndexOutOfBoundsException) {
-    }
-    try {
-      actual[3]
-      fail()
-    } catch (expected: IndexOutOfBoundsException) {
-    }
-  }
-
-  @Test fun decodeBase64() {
-    val actual = "YfCfjalj".decodeBase64()
-    val expected = "a\uD83C\uDF69c".encodeUtf8()
-    assertThat(actual).isEqualTo(expected)
-  }
-
-  @Test fun decodeBase64Invalid() {
-    val actual = ";-)".decodeBase64()
-    assertThat(actual).isNull()
-  }
-
-  @Test fun decodeHex() {
-    val actual = "CAFEBABE".decodeHex()
-    val expected = ByteString.of(-54, -2, -70, -66)
-    assertThat(actual).isEqualTo(expected)
-  }
-
   @Test fun arrayToByteString() {
     val actual = byteArrayOf(1, 2, 3, 4).toByteString()
     val expected = ByteString.of(1, 2, 3, 4)
-    assertThat(actual).isEqualTo(expected)
+    assertEquals(actual, expected)
   }
 
   @Test fun arraySubsetToByteString() {
     val actual = byteArrayOf(1, 2, 3, 4).toByteString(1, 2)
     val expected = ByteString.of(2, 3)
-    assertThat(actual).isEqualTo(expected)
+    assertEquals(actual, expected)
   }
 
   @Test fun byteBufferToByteString() {
     val actual = ByteBuffer.wrap(byteArrayOf(1, 2, 3, 4)).toByteString()
     val expected = ByteString.of(1, 2, 3, 4)
-    assertThat(actual).isEqualTo(expected)
+    assertEquals(actual, expected)
   }
 
   @Test fun stringEncodeByteStringDefaultCharset() {
     val actual = "a\uD83C\uDF69c".encode()
     val expected = "a\uD83C\uDF69c".encodeUtf8()
-    assertThat(actual).isEqualTo(expected)
+    assertEquals(actual, expected)
   }
 
   @Test fun streamReadByteString() {
     val stream = ByteArrayInputStream(byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8))
     val actual = stream.readByteString(4)
     val expected = ByteString.of(1, 2, 3, 4)
-    assertThat(actual).isEqualTo(expected)
+    assertEquals(actual, expected)
   }
 
   @Test fun substring() {
     val byteString = "abcdef".encodeUtf8()
-    assertThat(byteString.substring()).isEqualTo("abcdef".encodeUtf8())
-    assertThat(byteString.substring(endIndex= 3)).isEqualTo("abc".encodeUtf8())
-    assertThat(byteString.substring(beginIndex = 3)).isEqualTo("def".encodeUtf8())
-    assertThat(byteString.substring(beginIndex = 1, endIndex = 5)).isEqualTo("bcde".encodeUtf8())
+    assertEquals(byteString.substring(), "abcdef".encodeUtf8())
+    assertEquals(byteString.substring(endIndex= 3), "abc".encodeUtf8())
+    assertEquals(byteString.substring(beginIndex = 3), "def".encodeUtf8())
+    assertEquals(byteString.substring(beginIndex = 1, endIndex = 5), "bcde".encodeUtf8())
   }
 }

--- a/okio/jvm/src/test/java/okio/TestUtil.kt
+++ b/okio/jvm/src/test/java/okio/TestUtil.kt
@@ -30,7 +30,7 @@ object TestUtil {
   // Necessary to make an internal member visible to Java.
   const val SEGMENT_POOL_MAX_SIZE = SegmentPool.MAX_SIZE
   const val SEGMENT_SIZE = Segment.SIZE
-  const val REPLACEMENT_CHARACTER: Int = okio.REPLACEMENT_CHARACTER
+  const val REPLACEMENT_CODE_POINT: Int = okio.REPLACEMENT_CODE_POINT
   @JvmStatic fun segmentPoolByteCount() = SegmentPool.byteCount
 
   @JvmStatic

--- a/okio/jvm/src/test/java/okio/Utf8Test.java
+++ b/okio/jvm/src/test/java/okio/Utf8Test.java
@@ -19,7 +19,7 @@ import java.io.EOFException;
 import kotlin.text.Charsets;
 import org.junit.Test;
 
-import static okio.TestUtil.REPLACEMENT_CHARACTER;
+import static okio.TestUtil.REPLACEMENT_CODE_POINT;
 import static okio.TestUtil.SEGMENT_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -114,7 +114,7 @@ public final class Utf8Test {
   @Test public void readLeadingContinuationByteReturnsReplacementCharacter() throws Exception {
     Buffer buffer = new Buffer();
     buffer.writeByte(0xbf);
-    assertEquals(REPLACEMENT_CHARACTER, buffer.readUtf8CodePoint());
+    assertEquals(REPLACEMENT_CODE_POINT, buffer.readUtf8CodePoint());
     assertTrue(buffer.exhausted());
   }
 
@@ -133,11 +133,11 @@ public final class Utf8Test {
     // 5-byte and 6-byte code points are not supported.
     Buffer buffer = new Buffer();
     buffer.write(ByteString.decodeHex("f888808080"));
-    assertEquals(REPLACEMENT_CHARACTER, buffer.readUtf8CodePoint());
-    assertEquals(REPLACEMENT_CHARACTER, buffer.readUtf8CodePoint());
-    assertEquals(REPLACEMENT_CHARACTER, buffer.readUtf8CodePoint());
-    assertEquals(REPLACEMENT_CHARACTER, buffer.readUtf8CodePoint());
-    assertEquals(REPLACEMENT_CHARACTER, buffer.readUtf8CodePoint());
+    assertEquals(REPLACEMENT_CODE_POINT, buffer.readUtf8CodePoint());
+    assertEquals(REPLACEMENT_CODE_POINT, buffer.readUtf8CodePoint());
+    assertEquals(REPLACEMENT_CODE_POINT, buffer.readUtf8CodePoint());
+    assertEquals(REPLACEMENT_CODE_POINT, buffer.readUtf8CodePoint());
+    assertEquals(REPLACEMENT_CODE_POINT, buffer.readUtf8CodePoint());
     assertTrue(buffer.exhausted());
   }
 
@@ -145,7 +145,7 @@ public final class Utf8Test {
     // Use a non-continuation byte where a continuation byte is expected.
     Buffer buffer = new Buffer();
     buffer.write(ByteString.decodeHex("df20"));
-    assertEquals(REPLACEMENT_CHARACTER, buffer.readUtf8CodePoint());
+    assertEquals(REPLACEMENT_CODE_POINT, buffer.readUtf8CodePoint());
     assertEquals(0x20, buffer.readUtf8CodePoint()); // Non-continuation character not consumed.
     assertTrue(buffer.exhausted());
   }
@@ -154,17 +154,17 @@ public final class Utf8Test {
     // A 4-byte encoding with data above the U+10ffff Unicode maximum.
     Buffer buffer = new Buffer();
     buffer.write(ByteString.decodeHex("f4908080"));
-    assertEquals(REPLACEMENT_CHARACTER, buffer.readUtf8CodePoint());
+    assertEquals(REPLACEMENT_CODE_POINT, buffer.readUtf8CodePoint());
     assertTrue(buffer.exhausted());
   }
 
   @Test public void readSurrogateCodePoint() throws Exception {
     Buffer buffer = new Buffer();
     buffer.write(ByteString.decodeHex("eda080"));
-    assertEquals(REPLACEMENT_CHARACTER, buffer.readUtf8CodePoint());
+    assertEquals(REPLACEMENT_CODE_POINT, buffer.readUtf8CodePoint());
     assertTrue(buffer.exhausted());
     buffer.write(ByteString.decodeHex("edbfbf"));
-    assertEquals(REPLACEMENT_CHARACTER, buffer.readUtf8CodePoint());
+    assertEquals(REPLACEMENT_CODE_POINT, buffer.readUtf8CodePoint());
     assertTrue(buffer.exhausted());
   }
 
@@ -172,7 +172,7 @@ public final class Utf8Test {
     // Use 2 bytes to encode data that only needs 1 byte.
     Buffer buffer = new Buffer();
     buffer.write(ByteString.decodeHex("c080"));
-    assertEquals(REPLACEMENT_CHARACTER, buffer.readUtf8CodePoint());
+    assertEquals(REPLACEMENT_CODE_POINT, buffer.readUtf8CodePoint());
     assertTrue(buffer.exhausted());
   }
 

--- a/okio/native/src/main/kotlin/okio/-Platform.kt
+++ b/okio/native/src/main/kotlin/okio/-Platform.kt
@@ -16,6 +16,7 @@
 
 package okio
 
+import okio.internal.commonAsUtf8ToByteArray
 import kotlin.annotation.AnnotationTarget.FIELD
 import kotlin.annotation.AnnotationTarget.FILE
 import kotlin.annotation.AnnotationTarget.FUNCTION
@@ -46,25 +47,8 @@ internal actual fun arraycopy(
   }
 }
 
-internal actual fun hashCode(a: ByteArray): Int {
-  var result = 1
-  for (element in a) {
-    result = 31 * result + element
-  }
-  return result
-}
-
 internal actual fun ByteArray.toUtf8String(): String = stringFromUtf8()
 
-internal actual fun CharArray.createString(): String = String(this)
+internal actual fun String.asUtf8ToByteArray(): ByteArray = commonAsUtf8ToByteArray()
 
-internal actual fun String.asUtf8ToByteArray(): ByteArray = toUtf8()
-
-// TODO remove if https://youtrack.jetbrains.com/issue/KT-20641 provides a better solution
-actual open class IndexOutOfBoundsException actual constructor(
-  message: String
-) : RuntimeException()
-
-actual open class ArrayIndexOutOfBoundsException actual constructor(
-  message: String
-) : IndexOutOfBoundsException(message)
+actual typealias ArrayIndexOutOfBoundsException = kotlin.ArrayIndexOutOfBoundsException

--- a/okio/native/src/main/kotlin/okio/-Platform.kt
+++ b/okio/native/src/main/kotlin/okio/-Platform.kt
@@ -49,6 +49,11 @@ internal actual fun arraycopy(
 
 internal actual fun ByteArray.toUtf8String(): String = stringFromUtf8()
 
+// We are NOT using the Kotlin/Native function `toUtf8()` because it encodes
+// invalide UTF-16 characters as '\ufffd' instead of '?' like Okio does. In an
+// effort to keep the library consistent with itself, we use the Okio encoder
+// implementation instead. This will hopefully help avoid weird gotcha's as this
+// library starts to be used more across platforms.
 internal actual fun String.asUtf8ToByteArray(): ByteArray = commonAsUtf8ToByteArray()
 
 actual typealias ArrayIndexOutOfBoundsException = kotlin.ArrayIndexOutOfBoundsException

--- a/okio/native/src/main/kotlin/okio/ByteString.kt
+++ b/okio/native/src/main/kotlin/okio/ByteString.kt
@@ -17,7 +17,6 @@
 package okio
 
 import okio.internal.COMMON_EMPTY
-import okio.internal.COMMON_HEX_DIGITS
 import okio.internal.commonBase64
 import okio.internal.commonBase64Url
 import okio.internal.commonCompareTo
@@ -178,8 +177,6 @@ internal actual constructor(
   actual override fun toString() = commonToString()
 
   actual companion object {
-    internal actual val HEX_DIGITS = COMMON_HEX_DIGITS
-
     /** A singleton empty `ByteString`.  */
     actual val EMPTY: ByteString = COMMON_EMPTY
 

--- a/okio/src/main/kotlin/okio/-Platform.kt
+++ b/okio/src/main/kotlin/okio/-Platform.kt
@@ -46,16 +46,9 @@ internal expect fun arraycopy(
   length: Int
 )
 
-internal expect fun hashCode(a: ByteArray): Int
-
 internal expect fun ByteArray.toUtf8String(): String
-
-internal expect fun CharArray.createString(): String
 
 internal expect fun String.asUtf8ToByteArray(): ByteArray
 
 // TODO make internal https://youtrack.jetbrains.com/issue/KT-19664
-expect open class IndexOutOfBoundsException(message: String) : RuntimeException
-
-// TODO make internal https://youtrack.jetbrains.com/issue/KT-19664
-expect class ArrayIndexOutOfBoundsException(message: String) : IndexOutOfBoundsException
+expect class ArrayIndexOutOfBoundsException(message: String?) : IndexOutOfBoundsException

--- a/okio/src/main/kotlin/okio/-Util.kt
+++ b/okio/src/main/kotlin/okio/-Util.kt
@@ -59,6 +59,9 @@ internal fun Long.reverseBytes(): Long {
 internal inline infix fun Byte.shr(other: Int): Int = toInt() shr other
 
 @Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
+internal inline infix fun Byte.shl(other: Int): Int = toInt() shl other
+
+@Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
 internal inline infix fun Byte.and(other: Int): Int = toInt() and other
 
 @Suppress("NOTHING_TO_INLINE") // Syntactic sugar.

--- a/okio/src/main/kotlin/okio/ByteString.kt
+++ b/okio/src/main/kotlin/okio/ByteString.kt
@@ -108,7 +108,7 @@ internal constructor(data: ByteArray) : Comparable<ByteString> {
 
   fun indexOf(other: ByteString, fromIndex: Int = 0): Int
 
-  open fun indexOf(other: ByteArray, fromIndex: Int = 0): Int
+  fun indexOf(other: ByteArray, fromIndex: Int = 0): Int
 
   override fun equals(other: Any?): Boolean
 
@@ -123,8 +123,7 @@ internal constructor(data: ByteArray) : Comparable<ByteString> {
   override fun toString(): String
 
   companion object {
-    internal val HEX_DIGITS: CharArray
-
+    // TODO null in JS and Native - https://youtrack.jetbrains.com/issue/KT-26497
     /** A singleton empty `ByteString`.  */
     @JvmField
     val EMPTY: ByteString

--- a/okio/src/main/kotlin/okio/Utf8.kt
+++ b/okio/src/main/kotlin/okio/Utf8.kt
@@ -110,89 +110,354 @@ fun String.utf8Size(beginIndex: Int = 0, endIndex: Int = length): Long {
   return result
 }
 
-internal const val REPLACEMENT_CHARACTER: Int = '\ufffd'.toInt()
+internal const val REPLACEMENT_BYTE: Byte = '?'.toByte()
+internal const val REPLACEMENT_CHARACTER: Char = '\ufffd'
+internal const val REPLACEMENT_CODE_POINT: Int = REPLACEMENT_CHARACTER.toInt()
 
-internal fun codePointByteCount(codePoint: Int): Int = when {
-  codePoint < 0x80 -> 1 // A 7-bit character with 1 byte.
-  codePoint < 0x800 -> 2 // An 11-bit character with 2 bytes.
-  codePoint < 0x10000 -> 3 // A 16-bit character with 3 bytes.
-  else -> 4 // A 21-bit character with 4 bytes.
-}
-
-internal fun codePointCharCount(codePoint: Int): Int = when {
-  codePoint < 0x10000 -> 1 // At most a 16-bit character.
-  else -> 2 // A 21-bit character.
-}
-
-internal fun isIsoControl(codePoint: Int): Boolean =
+@Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
+internal inline fun isIsoControl(codePoint: Int): Boolean =
   (codePoint in 0x00..0x1F) || (codePoint in 0x7F..0x9F)
 
-// TODO: Combine with Buffer.readUtf8CodePoint if possible
-internal fun ByteArray.codePointAt(index: Int): Int {
-  val b0 = this[index]
+@Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
+internal inline fun isUtf8Continuation(byte: Byte): Boolean {
+  // 0b10xxxxxx
+  return byte and 0xc0 == 0x80
+}
 
-  var codePoint: Int
-  val byteCount: Int
-  val min: Int
+// TODO combine with Buffer.writeUtf8?
+// TODO combine with Buffer.writeUtf8CodePoint?
+internal inline fun String.processUtf8Bytes(
+  beginIndex: Int,
+  endIndex: Int,
+  yield: (Byte) -> Unit
+) {
+  // Transcode a UTF-16 String to UTF-8 bytes.
+  var index = beginIndex
+  while (index < endIndex) {
+    val c = this[index]
+
+    when {
+      c < '\u0080' -> {
+        // Emit a 7-bit character with 1 byte.
+        yield(c.toByte()) // 0xxxxxxx
+        index++
+
+        // Assume there is going to be more ASCII
+        while (index < endIndex && this[index] < '\u0080') {
+          yield(this[index++].toByte())
+        }
+      }
+
+      c < '\u0800' -> {
+        // Emit a 11-bit character with 2 bytes.
+        /* ktlint-disable no-multi-spaces */
+        yield((c.toInt() shr 6          or 0xc0).toByte()) // 110xxxxx
+        yield((c.toInt()       and 0x3f or 0x80).toByte()) // 10xxxxxx
+        /* ktlint-enable no-multi-spaces */
+        index++
+      }
+
+      c !in '\ud800'..'\udfff' -> {
+        // Emit a 16-bit character with 3 bytes.
+        /* ktlint-disable no-multi-spaces */
+        yield((c.toInt() shr 12          or 0xe0).toByte()) // 1110xxxx
+        yield((c.toInt() shr  6 and 0x3f or 0x80).toByte()) // 10xxxxxx
+        yield((c.toInt()        and 0x3f or 0x80).toByte()) // 10xxxxxx
+        /* ktlint-enable no-multi-spaces */
+        index++
+      }
+
+      else -> {
+        // c is a surrogate. Make sure it is a high surrogate & that its successor is a low
+        // surrogate. If not, the UTF-16 is invalid, in which case we emit a replacement
+        // byte.
+        if (c > '\udbff' ||
+            endIndex <= index + 1 ||
+            this[index + 1] !in '\udc00'..'\udfff') {
+          yield(REPLACEMENT_BYTE)
+          index++
+        } else {
+          // UTF-16 high surrogate: 110110xxxxxxxxxx (10 bits)
+          // UTF-16 low surrogate:  110111yyyyyyyyyy (10 bits)
+          // Unicode code point:    00010000000000000000 + xxxxxxxxxxyyyyyyyyyy (21 bits)
+          val codePoint = (((c.toInt() shl 10) + this[index + 1].toInt()) +
+            (0x010000 - (0xd800 shl 10) - 0xdc00))
+
+          // Emit a 21-bit character with 4 bytes.
+          /* ktlint-disable no-multi-spaces */
+          yield((codePoint shr 18          or 0xf0).toByte()) // 11110xxx
+          yield((codePoint shr 12 and 0x3f or 0x80).toByte()) // 10xxxxxx
+          yield((codePoint shr 6  and 0x3f or 0x80).toByte()) // 10xxyyyy
+          yield((codePoint        and 0x3f or 0x80).toByte()) // 10yyyyyy
+          /* ktlint-enable no-multi-spaces */
+          index += 2
+        }
+      }
+    }
+  }
+}
+
+// TODO combine with Buffer.readUtf8CodePoint?
+internal inline fun ByteArray.processUtf8CodePoints(
+  beginIndex: Int,
+  endIndex: Int,
+  yield: (Int) -> Unit
+) {
+  var index = beginIndex
+  while (index < endIndex) {
+    val b0 = this[index]
+    when {
+      b0 >= 0 -> {
+        // 0b0xxxxxxx
+        yield(b0.toInt())
+        index++
+
+        // Assume there is going to be more ASCII
+        while (index < endIndex && this[index] >= 0) {
+          yield(this[index++].toInt())
+        }
+      }
+      b0 shr 5 == -2 -> {
+        // 0b110xxxxx
+        index += process2Utf8Bytes(index, endIndex) { yield(it) }
+      }
+      b0 shr 4 == -2 -> {
+        // 0b1110xxxx
+        index += process3Utf8Bytes(index, endIndex) { yield(it) }
+      }
+      b0 shr 3 == -2 -> {
+        // 0b11110xxx
+        index += process4Utf8Bytes(index, endIndex) { yield(it) }
+      }
+      else -> {
+        // 0b10xxxxxx - Unexpected continuation
+        // 0b111111xxx - Unknown encoding
+        yield(REPLACEMENT_CODE_POINT)
+        index++
+      }
+    }
+  }
+}
+
+// TODO combine with Buffer.readUtf8?
+internal inline fun ByteArray.processUtf8Chars(
+  beginIndex: Int,
+  endIndex: Int,
+  yield: (Char) -> Unit
+) {
+  var index = beginIndex
+  while (index < endIndex) {
+    val b0 = this[index]
+    when {
+      b0 >= 0 -> {
+        // 0b0xxxxxxx
+        yield(b0.toChar())
+        index++
+
+        // Assume there is going to be more ASCII
+        // This is almost double the performance of the outer loop
+        while (index < endIndex && this[index] >= 0) {
+          yield(this[index++].toChar())
+        }
+      }
+      b0 shr 5 == -2 -> {
+        // 0b110xxxxx
+        index += process2Utf8Bytes(index, endIndex) { yield(it.toChar()) }
+      }
+      b0 shr 4 == -2 -> {
+        // 0b1110xxxx
+        index += process3Utf8Bytes(index, endIndex) { yield(it.toChar()) }
+      }
+      b0 shr 3 == -2 -> {
+        // 0b11110xxx
+        index += process4Utf8Bytes(index, endIndex) { codePoint ->
+          if (codePoint != REPLACEMENT_CODE_POINT) {
+            // Unicode code point:    00010000000000000000 + xxxxxxxxxxyyyyyyyyyy (21 bits)
+            // UTF-16 high surrogate: 110110xxxxxxxxxx (10 bits)
+            // UTF-16 low surrogate:  110111yyyyyyyyyy (10 bits)
+            /* ktlint-disable no-multi-spaces */
+            yield(((codePoint ushr 10   ) + (0xd800 - (0x010000 ushr 10))).toChar())
+            yield(((codePoint and 0x03ff) + (0xdc00                     )).toChar())
+            /* ktlint-enable no-multi-spaces */
+          } else {
+            yield(REPLACEMENT_CHARACTER)
+          }
+        }
+      }
+      else -> {
+        // 0b10xxxxxx - Unexpected continuation
+        // 0b111111xxx - Unknown encoding
+        yield(REPLACEMENT_CHARACTER)
+        index++
+      }
+    }
+  }
+}
+
+/* ktlint-disable indent */
+internal val mask2 =
+    ((0xc0.toByte() shl 6) xor
+     (0x80.toByte().toInt()))
+/* ktlint-enable indent */
+
+internal inline fun ByteArray.process2Utf8Bytes(
+  beginIndex: Int,
+  endIndex: Int,
+  yield: (Int) -> Unit
+): Int {
+  if (endIndex <= beginIndex + 1) {
+    yield(REPLACEMENT_CODE_POINT)
+    // Only 1 byte remaining - underflow
+    return 1
+  }
+
+  val b0 = this[beginIndex]
+  val b1 = this[beginIndex + 1]
+  if (!isUtf8Continuation(b1)) {
+    yield(REPLACEMENT_CODE_POINT)
+    return 1
+  }
+
+  val codePoint =
+    (mask2
+        xor (b1.toInt())
+        xor (b0.toInt() shl 6))
+
   when {
-    b0 and 0x80 == 0 -> {
-      // 0xxxxxxx.
-      codePoint = b0 and 0x7f
-      byteCount = 1 // 7 bits (ASCII).
-      min = 0x0
-    }
-    b0 and 0xe0 == 0xc0 -> {
-      // 0x110xxxxx
-      codePoint = b0 and 0x1f
-      byteCount = 2 // 11 bits (5 + 6).
-      min = 0x80
-    }
-    b0 and 0xf0 == 0xe0 -> {
-      // 0x1110xxxx
-      codePoint = b0 and 0x0f
-      byteCount = 3 // 16 bits (4 + 6 + 6).
-      min = 0x800
-    }
-    b0 and 0xf8 == 0xf0 -> {
-      // 0x11110xxx
-      codePoint = b0 and 0x07
-      byteCount = 4 // 21 bits (3 + 6 + 6 + 6).
-      min = 0x10000
+    codePoint < 0x80 -> {
+      yield(REPLACEMENT_CODE_POINT) // Reject overlong code points.
     }
     else -> {
-      // We expected the first byte of a code point but got something else.
-      return REPLACEMENT_CHARACTER
+      yield(codePoint)
     }
   }
+  return 2
+}
 
-  if (size < index + byteCount) {
-    // Not enough remaining data to interpret as a code point.
-    return REPLACEMENT_CHARACTER
-  }
+/* ktlint-disable indent */
+internal val mask3 =
+    ((0xe0.toByte() shl 12) xor
+     (0x80.toByte() shl 6) xor
+     (0x80.toByte().toInt()))
+/* ktlint-enable indent */
 
-  // Read the continuation bytes. If we encounter a non-continuation byte, the sequence thus far is
-  // decoded as the replacement character.
-  for (i in 1 until byteCount) {
-    val b = this[index + i]
-    if (b and 0xc0 == 0x80) {
-      // 0x10xxxxxx
-      codePoint = codePoint shl 6
-      codePoint = codePoint or (b and 0x3f)
+internal inline fun ByteArray.process3Utf8Bytes(
+  beginIndex: Int,
+  endIndex: Int,
+  yield: (Int) -> Unit
+): Int {
+  if (endIndex <= beginIndex + 2) {
+    // At least 2 bytes remaining
+    yield(REPLACEMENT_CODE_POINT)
+    if (endIndex <= beginIndex + 1 || !isUtf8Continuation(this[beginIndex + 1])) {
+      // Only 1 byte remaining - underflow
+      // Or 2nd byte is not a continuation - malformed
+      return 1
     } else {
-      return REPLACEMENT_CHARACTER
+      // Only 2 bytes remaining - underflow
+      return 2
     }
   }
 
-  return when {
-    codePoint > 0x10ffff -> {
-      REPLACEMENT_CHARACTER // Reject code points larger than the Unicode maximum.
+  val b0 = this[beginIndex]
+  val b1 = this[beginIndex + 1]
+  if (!isUtf8Continuation(b1)) {
+    yield(REPLACEMENT_CODE_POINT)
+    return 1
+  }
+  val b2 = this[beginIndex + 2]
+  if (!isUtf8Continuation(b2)) {
+    yield(REPLACEMENT_CODE_POINT)
+    return 2
+  }
+
+  val codePoint =
+    (mask3
+        xor (b2.toInt())
+        xor (b1.toInt() shl 6)
+        xor (b0.toInt() shl 12))
+
+  when {
+    codePoint < 0x800 -> {
+      yield(REPLACEMENT_CODE_POINT) // Reject overlong code points.
     }
     codePoint in 0xd800..0xdfff -> {
-      REPLACEMENT_CHARACTER // Reject partial surrogates.
+      yield(REPLACEMENT_CODE_POINT) // Reject partial surrogates.
     }
-    codePoint < min -> {
-      REPLACEMENT_CHARACTER // Reject overlong code points.
+    else -> {
+      yield(codePoint)
     }
-    else -> codePoint
   }
+  return 3
+}
+
+/* ktlint-disable indent */
+internal val mask4 =
+    ((0xf0.toByte() shl 18) xor
+     (0x80.toByte() shl 12) xor
+     (0x80.toByte() shl 6) xor
+     (0x80.toByte().toInt()))
+/* ktlint-enable indent */
+
+internal inline fun ByteArray.process4Utf8Bytes(
+  beginIndex: Int,
+  endIndex: Int,
+  yield: (Int) -> Unit
+): Int {
+  if (endIndex <= beginIndex + 3) {
+    // At least 3 bytes remaining
+    yield(REPLACEMENT_CODE_POINT)
+    if (endIndex <= beginIndex + 1 || !isUtf8Continuation(this[beginIndex + 1])) {
+      // Only 1 byte remaining - underflow
+      // Or 2nd byte is not a continuation - malformed
+      return 1
+    } else if (endIndex <= beginIndex + 2 || !isUtf8Continuation(this[beginIndex + 2])) {
+      // Only 2 bytes remaining - underflow
+      // Or 3rd byte is not a continuation - malformed
+      return 2
+    } else {
+      // Only 3 bytes remaining - underflow
+      return 3
+    }
+  }
+
+  val b0 = this[beginIndex]
+  val b1 = this[beginIndex + 1]
+  if (!isUtf8Continuation(b1)) {
+    yield(REPLACEMENT_CODE_POINT)
+    return 1
+  }
+  val b2 = this[beginIndex + 2]
+  if (!isUtf8Continuation(b2)) {
+    yield(REPLACEMENT_CODE_POINT)
+    return 2
+  }
+  val b3 = this[beginIndex + 3]
+  if (!isUtf8Continuation(b3)) {
+    yield(REPLACEMENT_CODE_POINT)
+    return 3
+  }
+
+  val codePoint =
+    (mask4
+        xor (b3.toInt())
+        xor (b2.toInt() shl 6)
+        xor (b1.toInt() shl 12)
+        xor (b0.toInt() shl 18))
+
+  when {
+    codePoint > 0x10ffff -> {
+      yield(REPLACEMENT_CODE_POINT) // Reject code points larger than the Unicode maximum.
+    }
+    codePoint in 0xd800..0xdfff -> {
+      yield(REPLACEMENT_CODE_POINT) // Reject partial surrogates.
+    }
+    codePoint < 0x10000 -> {
+      yield(REPLACEMENT_CODE_POINT) // Reject overlong code points.
+    }
+    else -> {
+      yield(codePoint)
+    }
+  }
+  return 4
 }

--- a/okio/src/main/kotlin/okio/internal/-Utf8.kt
+++ b/okio/src/main/kotlin/okio/internal/-Utf8.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package okio.internal
+
+import okio.processUtf8Bytes
+import okio.processUtf8Chars
+
+// TODO For benchmarking, these methods need to be available but preferably invisible
+// to everything else. Putting them in this file, `-Utf8.kt`, makes them invisible to
+// Java but still visible to Kotlin.
+
+fun ByteArray.commonToUtf8String(): String {
+  val chars = CharArray(size)
+
+  var length = 0
+  processUtf8Chars(0, size) { c ->
+    chars[length++] = c
+  }
+
+  return String(chars, 0, length)
+}
+
+fun String.commonAsUtf8ToByteArray(): ByteArray {
+  val bytes = ByteArray(4 * length)
+
+  // Assume ASCII until a UTF-8 code point is observed. This is ugly but yields
+  // about a 2x performance increase for pure ASCII.
+  for (index in 0 until length) {
+    val b0 = this[index]
+    if (b0 >= '\u0080') {
+      var size = index
+      processUtf8Bytes(index, length) { c ->
+        bytes[size++] = c
+      }
+      return bytes.copyOf(size)
+    }
+    bytes[index] = b0.toByte()
+  }
+
+  return bytes.copyOf(length)
+}

--- a/okio/src/main/kotlin/okio/internal/-Utf8.kt
+++ b/okio/src/main/kotlin/okio/internal/-Utf8.kt
@@ -17,7 +17,7 @@
 package okio.internal
 
 import okio.processUtf8Bytes
-import okio.processUtf8Chars
+import okio.processUtf16Chars
 
 // TODO For benchmarking, these methods need to be available but preferably invisible
 // to everything else. Putting them in this file, `-Utf8.kt`, makes them invisible to
@@ -27,7 +27,7 @@ fun ByteArray.commonToUtf8String(): String {
   val chars = CharArray(size)
 
   var length = 0
-  processUtf8Chars(0, size) { c ->
+  processUtf16Chars(0, size) { c ->
     chars[length++] = c
   }
 

--- a/okio/src/test/kotlin/okio/ByteStringTest.kt
+++ b/okio/src/test/kotlin/okio/ByteStringTest.kt
@@ -16,21 +16,67 @@
 
 package okio
 
+import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.decodeHex
+import okio.ByteString.Companion.encodeUtf8
+import okio.internal.commonAsUtf8ToByteArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
-class ByteStringTest {
+class CommonByteStringTest {
+  class Platform : AbstractByteStringTest(ByteStringFactory.PLATFORM)
+  class Okio : AbstractByteStringTest(ByteStringFactory.OKIO)
+}
+
+interface ByteStringFactory {
+  fun decodeHex(hex: String): ByteString
+  fun encodeUtf8(s: String): ByteString
+
+  companion object {
+    val PLATFORM: ByteStringFactory = object : ByteStringFactory {
+      override fun decodeHex(hex: String) = hex.decodeHex()
+      override fun encodeUtf8(s: String) = s.encodeUtf8()
+    }
+    val OKIO: ByteStringFactory = object : ByteStringFactory {
+      override fun decodeHex(hex: String) = hex.decodeHex()
+      override fun encodeUtf8(s: String) = ByteString.of(*s.commonAsUtf8ToByteArray())
+    }
+  }
+}
+
+abstract class AbstractByteStringTest(
+  private val factory: ByteStringFactory
+) {
+  @Test fun get() {
+    val actual = factory.encodeUtf8("abc")
+    assertEquals(actual[0], 'a'.toByte())
+    assertEquals(actual[1], 'b'.toByte())
+    assertEquals(actual[2], 'c'.toByte())
+    try {
+      actual[-1]
+      fail("no index out of bounds: -1")
+    } catch (expected: IndexOutOfBoundsException) {
+    }
+    try {
+      actual[3]
+      fail("no index out of bounds: 3")
+    } catch (expected: IndexOutOfBoundsException) {
+    }
+  }
+
   @Test fun getByte() {
-    val byteString = "ab12".decodeHex()
+    val byteString = factory.decodeHex("ab12")
     assertEquals(-85, byteString[0].toLong())
     assertEquals(18, byteString[1].toLong())
   }
 
   @Test fun startsWithByteString() {
-    val byteString = "112233".decodeHex()
+    val byteString = factory.decodeHex("112233")
     assertTrue(byteString.startsWith("".decodeHex()))
     assertTrue(byteString.startsWith("11".decodeHex()))
     assertTrue(byteString.startsWith("1122".decodeHex()))
@@ -41,7 +87,7 @@ class ByteStringTest {
   }
 
   @Test fun endsWithByteString() {
-    val byteString = "112233".decodeHex()
+    val byteString = factory.decodeHex("112233")
     assertTrue(byteString.endsWith("".decodeHex()))
     assertTrue(byteString.endsWith("33".decodeHex()))
     assertTrue(byteString.endsWith("2233".decodeHex()))
@@ -52,7 +98,7 @@ class ByteStringTest {
   }
 
   @Test fun startsWithByteArray() {
-    val byteString = "112233".decodeHex()
+    val byteString = factory.decodeHex("112233")
     assertTrue(byteString.startsWith("".decodeHex().toByteArray()))
     assertTrue(byteString.startsWith("11".decodeHex().toByteArray()))
     assertTrue(byteString.startsWith("1122".decodeHex().toByteArray()))
@@ -63,7 +109,7 @@ class ByteStringTest {
   }
 
   @Test fun endsWithByteArray() {
-    val byteString = "112233".decodeHex()
+    val byteString = factory.decodeHex("112233")
     assertTrue(byteString.endsWith("".decodeHex().toByteArray()))
     assertTrue(byteString.endsWith("33".decodeHex().toByteArray()))
     assertTrue(byteString.endsWith("2233".decodeHex().toByteArray()))
@@ -74,7 +120,7 @@ class ByteStringTest {
   }
 
   @Test fun indexOfByteString() {
-    val byteString = "112233".decodeHex()
+    val byteString = factory.decodeHex("112233")
     assertEquals(0, byteString.indexOf("112233".decodeHex()).toLong())
     assertEquals(0, byteString.indexOf("1122".decodeHex()).toLong())
     assertEquals(0, byteString.indexOf("11".decodeHex()).toLong())
@@ -100,7 +146,7 @@ class ByteStringTest {
   }
 
   @Test fun indexOfWithOffset() {
-    val byteString = "112233112233".decodeHex()
+    val byteString = factory.decodeHex("112233112233")
     assertEquals(0, byteString.indexOf("112233".decodeHex(), -1).toLong())
     assertEquals(0, byteString.indexOf("112233".decodeHex(), 0).toLong())
     assertEquals(0, byteString.indexOf("112233".decodeHex()).toLong())
@@ -111,10 +157,246 @@ class ByteStringTest {
   }
 
   @Test fun indexOfByteArray() {
-    val byteString = "112233".decodeHex()
+    val byteString = factory.decodeHex("112233")
     assertEquals(0, byteString.indexOf("112233".decodeHex().toByteArray()).toLong())
     assertEquals(1, byteString.indexOf("2233".decodeHex().toByteArray()).toLong())
     assertEquals(2, byteString.indexOf("33".decodeHex().toByteArray()).toLong())
     assertEquals(-1, byteString.indexOf("112244".decodeHex().toByteArray()).toLong())
+  }
+
+  // TODO Kotlin/Native and Kotlin/JS have a null ByteString.EMPTY
+  @Test fun equalsTest() {
+    val byteString = factory.decodeHex("000102")
+    assertEquals(byteString, byteString)
+    assertEquals(byteString, "000102".decodeHex())
+    // assertEquals(factory.decodeHex(""), ByteString.EMPTY)
+    assertEquals(factory.decodeHex(""), ByteString.of())
+    // assertEquals(ByteString.EMPTY, factory.decodeHex(""))
+    assertEquals(ByteString.of(), factory.decodeHex(""))
+    assertNotEquals(byteString, Any())
+    assertNotEquals(byteString, "000201".decodeHex())
+  }
+
+  private val bronzeHorseman = "На берегу пустынных волн"
+
+  @Test fun utf8() {
+    val byteString = factory.encodeUtf8(bronzeHorseman)
+    assertEquals(byteString.toByteArray().toList(), bronzeHorseman.commonAsUtf8ToByteArray().toList())
+    assertTrue(byteString == ByteString.of(*bronzeHorseman.commonAsUtf8ToByteArray()))
+    assertEquals(byteString, ("d09dd0b020d0b1d0b5d180d0b5d0b3d18320d0bfd183d181" +
+      "d182d18bd0bdd0bdd18bd18520d0b2d0bed0bbd0bd").decodeHex())
+    assertEquals(byteString.utf8(), bronzeHorseman)
+  }
+
+  @Test fun testHashCode() {
+    val byteString = factory.decodeHex("0102")
+    assertEquals(byteString.hashCode().toLong(), byteString.hashCode().toLong())
+    assertEquals(byteString.hashCode().toLong(), "0102".decodeHex().hashCode().toLong())
+  }
+
+  @Test fun toAsciiLowerCaseNoUppercase() {
+    val s = factory.encodeUtf8("a1_+")
+    assertEquals(s, s.toAsciiLowercase())
+    if (factory === ByteStringFactory.PLATFORM) {
+      assertSame(s, s.toAsciiLowercase())
+    }
+  }
+
+  @Test fun toAsciiAllUppercase() {
+    assertEquals("ab".encodeUtf8(), factory.encodeUtf8("AB").toAsciiLowercase())
+  }
+
+  @Test fun toAsciiStartsLowercaseEndsUppercase() {
+    assertEquals("abcd".encodeUtf8(), factory.encodeUtf8("abCD").toAsciiLowercase())
+  }
+
+  @Test fun toAsciiStartsUppercaseEndsLowercase() {
+    assertEquals("ABCD".encodeUtf8(), factory.encodeUtf8("ABcd").toAsciiUppercase())
+  }
+
+  @Test fun encodeBase64() {
+    assertEquals("", factory.encodeUtf8("").base64())
+    assertEquals("AA==", factory.encodeUtf8("\u0000").base64())
+    assertEquals("AAA=", factory.encodeUtf8("\u0000\u0000").base64())
+    assertEquals("AAAA", factory.encodeUtf8("\u0000\u0000\u0000").base64())
+    assertEquals("SG93IG1hbnkgbGluZXMgb2YgY29kZSBhcmUgdGhlcmU/ICdib3V0IDIgbWlsbGlvbi4=",
+      factory.encodeUtf8("How many lines of code are there? 'bout 2 million.").base64())
+  }
+
+  @Test fun encodeBase64Url() {
+    assertEquals("", factory.encodeUtf8("").base64Url())
+    assertEquals("AA==", factory.encodeUtf8("\u0000").base64Url())
+    assertEquals("AAA=", factory.encodeUtf8("\u0000\u0000").base64Url())
+    assertEquals("AAAA", factory.encodeUtf8("\u0000\u0000\u0000").base64Url())
+    assertEquals("SG93IG1hbnkgbGluZXMgb2YgY29kZSBhcmUgdGhlcmU_ICdib3V0IDIgbWlsbGlvbi4=",
+      factory.encodeUtf8("How many lines of code are there? 'bout 2 million.").base64Url())
+  }
+
+  @Test fun ignoreUnnecessaryPadding() {
+    assertEquals("", "====".decodeBase64()!!.utf8())
+    assertEquals("\u0000\u0000\u0000", "AAAA====".decodeBase64()!!.utf8())
+  }
+
+  @Test fun decodeBase64() {
+    assertEquals("", "".decodeBase64()!!.utf8())
+    assertEquals(null, "/===".decodeBase64()) // Can't do anything with 6 bits!
+    assertEquals("ff".decodeHex(), "//==".decodeBase64())
+    assertEquals("ff".decodeHex(), "__==".decodeBase64())
+    assertEquals("ffff".decodeHex(), "///=".decodeBase64())
+    assertEquals("ffff".decodeHex(), "___=".decodeBase64())
+    assertEquals("ffffff".decodeHex(), "////".decodeBase64())
+    assertEquals("ffffff".decodeHex(), "____".decodeBase64())
+    assertEquals("ffffffffffff".decodeHex(), "////////".decodeBase64())
+    assertEquals("ffffffffffff".decodeHex(), "________".decodeBase64())
+    assertEquals("What's to be scared about? It's just a little hiccup in the power...",
+      ("V2hhdCdzIHRvIGJlIHNjYXJlZCBhYm91dD8gSXQncyBqdXN0IGEgbGl0dGxlIGhpY2" +
+        "N1cCBpbiB0aGUgcG93ZXIuLi4=").decodeBase64()!!.utf8())
+    // Uses two encoding styles. Malformed, but supported as a side-effect.
+    assertEquals("ffffff".decodeHex(), "__//".decodeBase64())
+  }
+
+  @Test fun decodeBase64WithWhitespace() {
+    assertEquals("\u0000\u0000\u0000", " AA AA ".decodeBase64()!!.utf8())
+    assertEquals("\u0000\u0000\u0000", " AA A\r\nA ".decodeBase64()!!.utf8())
+    assertEquals("\u0000\u0000\u0000", "AA AA".decodeBase64()!!.utf8())
+    assertEquals("\u0000\u0000\u0000", " AA AA ".decodeBase64()!!.utf8())
+    assertEquals("\u0000\u0000\u0000", " AA A\r\nA ".decodeBase64()!!.utf8())
+    assertEquals("\u0000\u0000\u0000", "A    AAA".decodeBase64()!!.utf8())
+    assertEquals("", "    ".decodeBase64()!!.utf8())
+  }
+
+  @Test fun encodeHex() {
+    assertEquals("000102", ByteString.of(0x0, 0x1, 0x2).hex())
+  }
+
+  @Test fun decodeHex() {
+    val actual = "CAFEBABE".decodeHex()
+    val expected = ByteString.of(-54, -2, -70, -66)
+    assertEquals(expected, actual)
+  }
+
+  @Test fun decodeHexOddNumberOfChars() {
+    try {
+      "aaa".decodeHex()
+      fail()
+    } catch (expected: IllegalArgumentException) {
+    }
+  }
+
+  @Test fun decodeHexInvalidChar() {
+    try {
+      "a\u0000".decodeHex()
+      fail()
+    } catch (expected: IllegalArgumentException) {
+    }
+  }
+
+  @Test fun toStringOnEmpty() {
+    assertEquals("[size=0]", factory.decodeHex("").toString())
+  }
+
+  @Test fun toStringOnShortText() {
+    assertEquals("[text=Tyrannosaur]",
+      factory.encodeUtf8("Tyrannosaur").toString())
+    assertEquals("[text=təˈranəˌsôr]",
+      factory.decodeHex("74c999cb8872616ec999cb8c73c3b472").toString())
+  }
+
+  @Test fun toStringOnLongTextIsTruncated() {
+    val raw = ("Um, I'll tell you the problem with the scientific power that you're using here, " +
+      "it didn't require any discipline to attain it. You read what others had done and you " +
+      "took the next step. You didn't earn the knowledge for yourselves, so you don't take any " +
+      "responsibility for it. You stood on the shoulders of geniuses to accomplish something " +
+      "as fast as you could, and before you even knew what you had, you patented it, and " +
+      "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna " +
+      "sell it.")
+    assertEquals("[size=517 text=Um, I'll tell you the problem with the scientific power that " +
+      "you…]", factory.encodeUtf8(raw).toString())
+    val war = ("Սｍ, I'll 𝓽𝖾ll ᶌօ𝘂 ᴛℎ℮ 𝜚𝕣०ｂl𝖾ｍ ｗі𝕥𝒽 𝘵𝘩𝐞 𝓼𝙘𝐢𝔢𝓷𝗍𝜄𝚏𝑖ｃ 𝛠𝝾ｗ𝚎𝑟 𝕥ｈ⍺𝞃 𝛄𝓸𝘂'𝒓𝗲 υ𝖘𝓲𝗇ɡ 𝕙𝚎𝑟ｅ, " +
+      "𝛊𝓽 ⅆ𝕚𝐝𝝿'𝗍 𝔯𝙚𝙦ᴜ𝜾𝒓𝘦 𝔞𝘯𝐲 ԁ𝜄𝑠𝚌ι𝘱lι𝒏ｅ 𝑡𝜎 𝕒𝚝𝖙𝓪і𝞹 𝔦𝚝. 𝒀ο𝗎 𝔯𝑒⍺𝖉 ｗ𝐡𝝰𝔱 𝞂𝞽һ𝓮𝓇ƽ հ𝖺𝖉 ⅾ𝛐𝝅ⅇ 𝝰πԁ 𝔂ᴑᴜ 𝓉ﮨ၀𝚔 " +
+      "т𝒽𝑒 𝗇𝕖ⅹ𝚝 𝔰𝒕е𝓅. 𝘠ⲟ𝖚 𝖉ⅰԁ𝝕'τ 𝙚𝚊ｒ𝞹 𝘵Ꮒ𝖾 𝝒𝐧هｗl𝑒𝖉ƍ𝙚 𝓯૦ｒ 𝔂𝞼𝒖𝕣𝑠𝕖l𝙫𝖊𝓼, 𐑈о ｙ𝘰𝒖 ⅆە𝗇'ｔ 𝜏α𝒌𝕖 𝛂𝟉ℽ " +
+      "𝐫ⅇ𝗌ⲣ๐ϖ𝖘ꙇᖯ𝓲l𝓲𝒕𝘆 𝐟𝞼𝘳 𝚤𝑡. 𝛶𝛔𝔲 ｓ𝕥σσ𝐝 ﮩ𝕟 𝒕𝗁𝔢 𝘴𝐡𝜎ᴜlⅾ𝓮𝔯𝚜 𝛐𝙛 ᶃ𝚎ᴨᎥս𝚜𝘦𝓈 𝓽𝞸 ａ𝒄𝚌𝞸ｍρl𝛊ꜱ𝐡 𝓈𝚘ｍ𝚎𝞃𝔥⍳𝞹𝔤 𝐚𝗌 𝖋ａ𝐬𝒕 " +
+      "αｓ γ𝛐𝕦 𝔠ﻫ𝛖lԁ, 𝚊π𝑑 Ь𝑒𝙛૦𝓇𝘦 𝓎٥𝖚 ⅇｖℯ𝝅 𝜅ո𝒆ｗ ｗ𝗵𝒂𝘁 ᶌ੦𝗎 ｈ𝐚𝗱, 𝜸ﮨ𝒖 𝓹𝝰𝔱𝖾𝗇𝓽𝔢ⅆ і𝕥, 𝚊𝜛𝓭 𝓹𝖺ⅽϰ𝘢ℊеᏧ 𝑖𝞃, " +
+      "𝐚𝛑ꓒ 𝙨l𝔞р𝘱𝔢𝓭 ɩ𝗍 ہ𝛑 𝕒 ｐl𝛂ѕᴛ𝗂𝐜 l𝞄ℼ𝔠𝒽𝑏ﮪ⨯, 𝔞ϖ𝒹 ｎ𝛔ｗ 𝛾𝐨𝞄'𝗿𝔢 ꜱ℮ll𝙞ｎɡ ɩ𝘁, 𝙮𝕠𝛖 ｗ𝑎ℼ𝚗𝛂 𝕤𝓮ll 𝙞𝓉.")
+    assertEquals("[size=1496 text=Սｍ, I'll 𝓽𝖾ll ᶌօ𝘂 ᴛℎ℮ 𝜚𝕣०ｂl𝖾ｍ ｗі𝕥𝒽 𝘵𝘩𝐞 𝓼𝙘𝐢𝔢𝓷𝗍𝜄𝚏𝑖ｃ 𝛠𝝾ｗ𝚎𝑟 𝕥ｈ⍺𝞃 " +
+      "𝛄𝓸𝘂…]", factory.encodeUtf8(war).toString())
+  }
+
+  @Test fun toStringOnTextWithNewlines() {
+    // Instead of emitting a literal newline in the toString(), these are escaped as "\n".
+    assertEquals("[text=a\\r\\nb\\nc\\rd\\\\e]",
+      factory.encodeUtf8("a\r\nb\nc\rd\\e").toString())
+  }
+
+  @Test fun toStringOnData() {
+    val byteString = factory.decodeHex("" +
+      "60b420bb3851d9d47acb933dbe70399bf6c92da33af01d4fb770e98c0325f41d3ebaf8986da712c82bcd4d55" +
+      "4bf0b54023c29b624de9ef9c2f931efc580f9afb")
+    assertEquals("[hex=" +
+      "60b420bb3851d9d47acb933dbe70399bf6c92da33af01d4fb770e98c0325f41d3ebaf8986da712c82bcd4d55" +
+      "4bf0b54023c29b624de9ef9c2f931efc580f9afb]", byteString.toString())
+  }
+
+  @Test fun toStringOnLongDataIsTruncated() {
+    val byteString = factory.decodeHex("" +
+      "60b420bb3851d9d47acb933dbe70399bf6c92da33af01d4fb770e98c0325f41d3ebaf8986da712c82bcd4d55" +
+      "4bf0b54023c29b624de9ef9c2f931efc580f9afba1")
+    assertEquals("[size=65 hex=" +
+      "60b420bb3851d9d47acb933dbe70399bf6c92da33af01d4fb770e98c0325f41d3ebaf8986da712c82bcd4d55" +
+      "4bf0b54023c29b624de9ef9c2f931efc580f9afb…]", byteString.toString())
+  }
+
+  @Test fun compareToSingleBytes() {
+    val originalByteStrings = listOf(
+      factory.decodeHex("00"),
+      factory.decodeHex("01"),
+      factory.decodeHex("7e"),
+      factory.decodeHex("7f"),
+      factory.decodeHex("80"),
+      factory.decodeHex("81"),
+      factory.decodeHex("fe"),
+      factory.decodeHex("ff"))
+
+    val sortedByteStrings = originalByteStrings.toMutableList()
+    sortedByteStrings.shuffle() // TODO Constant random for repeatability
+    sortedByteStrings.sort()
+
+    assertEquals(originalByteStrings, sortedByteStrings)
+  }
+
+  @Test fun compareToMultipleBytes() {
+    val originalByteStrings = listOf(
+      factory.decodeHex(""),
+      factory.decodeHex("00"),
+      factory.decodeHex("0000"),
+      factory.decodeHex("000000"),
+      factory.decodeHex("00000000"),
+      factory.decodeHex("0000000000"),
+      factory.decodeHex("0000000001"),
+      factory.decodeHex("000001"),
+      factory.decodeHex("00007f"),
+      factory.decodeHex("0000ff"),
+      factory.decodeHex("000100"),
+      factory.decodeHex("000101"),
+      factory.decodeHex("007f00"),
+      factory.decodeHex("00ff00"),
+      factory.decodeHex("010000"),
+      factory.decodeHex("010001"),
+      factory.decodeHex("01007f"),
+      factory.decodeHex("0100ff"),
+      factory.decodeHex("010100"),
+      factory.decodeHex("01010000"),
+      factory.decodeHex("0101000000"),
+      factory.decodeHex("0101000001"),
+      factory.decodeHex("010101"),
+      factory.decodeHex("7f0000"),
+      factory.decodeHex("7f0000ffff"),
+      factory.decodeHex("ffffff"))
+
+    val sortedByteStrings = originalByteStrings.toMutableList()
+    sortedByteStrings.shuffle() // TODO Constant random for repeatability
+    sortedByteStrings.sort()
+
+    assertEquals(originalByteStrings, sortedByteStrings)
   }
 }

--- a/okio/src/test/kotlin/okio/Utf8KotlinTest.kt
+++ b/okio/src/test/kotlin/okio/Utf8KotlinTest.kt
@@ -16,15 +16,180 @@
 
 package okio
 
+import okio.ByteString.Companion.decodeHex
+import okio.internal.commonAsUtf8ToByteArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class Utf8KotlinTest {
-  @Test fun utf8Size() {
-    assertEquals(6, "a\uD83C\uDF69c".utf8Size())
+  @Test fun oneByteCharacters() {
+    assertEncoded("00", 0x00) // Smallest 1-byte character.
+    assertEncoded("20", ' '.toInt())
+    assertEncoded("7e", '~'.toInt())
+    assertEncoded("7f", 0x7f) // Largest 1-byte character.
   }
 
-  @Test fun utf8SizeSubstring() {
-    assertEquals(4, "a\uD83C\uDF69c".utf8Size(1, 3))
+  @Test fun twoByteCharacters() {
+    assertEncoded("c280", 0x0080) // Smallest 2-byte character.
+    assertEncoded("c3bf", 0x00ff)
+    assertEncoded("c480", 0x0100)
+    assertEncoded("dfbf", 0x07ff) // Largest 2-byte character.
+  }
+
+  @Test fun threeByteCharacters() {
+    assertEncoded("e0a080", 0x0800) // Smallest 3-byte character.
+    assertEncoded("e0bfbf", 0x0fff)
+    assertEncoded("e18080", 0x1000)
+    assertEncoded("e1bfbf", 0x1fff)
+    assertEncoded("ed8080", 0xd000)
+    assertEncoded("ed9fbf", 0xd7ff) // Largest character lower than the min surrogate.
+    assertEncoded("ee8080", 0xe000) // Smallest character greater than the max surrogate.
+    assertEncoded("eebfbf", 0xefff)
+    assertEncoded("ef8080", 0xf000)
+    assertEncoded("efbfbf", 0xffff) // Largest 3-byte character.
+  }
+
+  @Test fun fourByteCharacters() {
+    assertEncoded("f0908080", 0x010000) // Smallest surrogate pair.
+    assertEncoded("f48fbfbf", 0x10ffff) // Largest code point expressible by UTF-16.
+  }
+
+  @Test fun unknownBytes() {
+    assertCodePointDecoded("f8", REPLACEMENT_CODE_POINT) // Too large
+    assertCodePointDecoded("f0f8", REPLACEMENT_CODE_POINT, REPLACEMENT_CODE_POINT)
+    assertCodePointDecoded("ff", REPLACEMENT_CODE_POINT) // Largest
+    assertCodePointDecoded("f0ff", REPLACEMENT_CODE_POINT, REPLACEMENT_CODE_POINT)
+
+    // Lone continuation
+    assertCodePointDecoded("80", REPLACEMENT_CODE_POINT) // Smallest
+    assertCodePointDecoded("bf", REPLACEMENT_CODE_POINT) // Largest
+  }
+
+  @Test fun overlongSequences() {
+    // Overlong representation of the NUL character
+    assertCodePointDecoded("c080", REPLACEMENT_CODE_POINT)
+    assertCodePointDecoded("e08080", REPLACEMENT_CODE_POINT)
+    assertCodePointDecoded("f0808080", REPLACEMENT_CODE_POINT)
+
+    // Maximum overlong sequences
+    assertCodePointDecoded("c1bf", REPLACEMENT_CODE_POINT)
+    assertCodePointDecoded("e09fbf", REPLACEMENT_CODE_POINT)
+    assertCodePointDecoded("f08fbfbf", REPLACEMENT_CODE_POINT)
+  }
+
+  @Test fun danglingHighSurrogate() {
+    assertStringEncoded("3f", "\ud800") // "?"
+    assertCodePointDecoded("eda080", REPLACEMENT_CODE_POINT)
+  }
+
+  @Test fun lowSurrogateWithoutHighSurrogate() {
+    assertStringEncoded("3f", "\udc00") // "?"
+    assertCodePointDecoded("edb080", REPLACEMENT_CODE_POINT)
+  }
+
+  @Test fun highSurrogateFollowedByNonSurrogate() {
+    assertStringEncoded("3fee8080", "\ud800\ue000") // "?\ue000": Following character is too high.
+    assertCodePointDecoded("f090ee8080", REPLACEMENT_CODE_POINT, '\ue000'.toInt())
+
+    assertStringEncoded("3f61", "\ud800\u0061") // "?a": Following character is too low.
+    assertCodePointDecoded("f09061", REPLACEMENT_CODE_POINT, 'a'.toInt())
+  }
+
+  @Test fun doubleLowSurrogate() {
+    assertStringEncoded("3f3f", "\udc00\udc00") // "??"
+    assertCodePointDecoded("edb080edb080", REPLACEMENT_CODE_POINT, REPLACEMENT_CODE_POINT)
+  }
+
+  @Test fun doubleHighSurrogate() {
+    assertStringEncoded("3f3f", "\ud800\ud800") // "??"
+    assertCodePointDecoded("eda080eda080", REPLACEMENT_CODE_POINT, REPLACEMENT_CODE_POINT)
+  }
+
+  @Test fun lowSurrogateHighSurrogate() {
+    assertStringEncoded("3f3f", "\udc00\ud800") // "??"
+    assertCodePointDecoded("edb080eda080", REPLACEMENT_CODE_POINT, REPLACEMENT_CODE_POINT)
+  }
+
+  @Test fun writeSurrogateCodePoint() {
+    assertStringEncoded("ed9fbf", "\ud7ff") // Below lowest surrogate is okay.
+    assertCodePointDecoded("ed9fbf", '\ud7ff'.toInt())
+
+    assertStringEncoded("3f", "\ud800") // Lowest surrogate gets '?'.
+    assertCodePointDecoded("eda080", REPLACEMENT_CODE_POINT)
+
+    assertStringEncoded("3f", "\udfff") // Highest surrogate gets '?'.
+    assertCodePointDecoded("edbfbf", REPLACEMENT_CODE_POINT)
+
+    assertStringEncoded("ee8080", "\ue000") // Above highest surrogate is okay.
+    assertCodePointDecoded("ee8080", '\ue000'.toInt())
+  }
+
+  @Test fun size() {
+    assertEquals(0, "".utf8Size())
+    assertEquals(3, "abc".utf8Size())
+    assertEquals(16, "təˈranəˌsôr".utf8Size())
+  }
+
+  @Test fun sizeWithBounds() {
+    assertEquals(0, "".utf8Size(0, 0))
+    assertEquals(0, "abc".utf8Size(0, 0))
+    assertEquals(1, "abc".utf8Size(1, 2))
+    assertEquals(2, "abc".utf8Size(0, 2))
+    assertEquals(3, "abc".utf8Size(0, 3))
+    assertEquals(16, "təˈranəˌsôr".utf8Size(0, 11))
+    assertEquals(5, "təˈranəˌsôr".utf8Size(3, 7))
+  }
+
+  @Test fun sizeBoundsCheck() {
+    try {
+      "abc".utf8Size(-1, 2)
+      fail()
+    } catch (expected: IllegalArgumentException) {
+    }
+
+    try {
+      "abc".utf8Size(2, 1)
+      fail()
+    } catch (expected: IllegalArgumentException) {
+    }
+
+    try {
+      "abc".utf8Size(1, 4)
+      fail()
+    } catch (expected: IllegalArgumentException) {
+    }
+  }
+
+  private fun assertEncoded(hex: String, vararg codePoints: Int) {
+    assertCodePointDecoded(hex, *codePoints)
+  }
+
+  private fun assertCodePointDecoded(hex: String, vararg codePoints: Int) {
+    val bytes = hex.decodeHex().toByteArray()
+    var i = 0
+    bytes.processUtf8CodePoints(0, bytes.size) { codePoint ->
+      if (i < codePoints.size) assertEquals(codePoints[i], codePoint, "index=$i")
+      i++
+    }
+    assertEquals(i, codePoints.size) // Checked them all
+  }
+
+  private fun assertStringEncoded(hex: String, string: String) {
+    val expectedUtf8 = hex.decodeHex()
+
+    // Confirm our expectations are consistent with the platform.
+    val platformUtf8 = ByteString.of(*string.asUtf8ToByteArray())
+    assertEquals(expectedUtf8, platformUtf8)
+
+    // Confirm our implementations matches those expectations.
+    val actualUtf8 = ByteString.of(*string.commonAsUtf8ToByteArray())
+    assertEquals(expectedUtf8, actualUtf8)
+
+    // TODO Confirm we are consistent when writing one code point at a time.
+
+    // Confirm we are consistent when measuring lengths.
+    assertEquals(expectedUtf8.size.toLong(), string.utf8Size())
+    assertEquals(expectedUtf8.size.toLong(), string.utf8Size(0, string.length))
   }
 }


### PR DESCRIPTION
Kotlin/JS does not currently have a implementation for transforming a
UTF-8 encoded ByteArray into a String and vice versa. Create an
implementation using some of the logic which already exists within Okio.
While this implementation could be used for Kotlin/JVM and
Kotlin/Native, both of these platforms have their own implementation
which is faster.

Fixes #452

Since I was already working in this area because of #469, I made an attempt to implement UTF-8 encoding and decoding for Kotlin/JS. I decided on implementing this in Kotlin because there might be other places throughout the project we might want to use these inline functions.

For contrast, [kotlinx-io](https://github.com/Kotlin/kotlinx-io/) uses the `text-encoding` JS library. I would submit that implementing native in Okio keeps the number of dependencies of the project to just the Kotlin stdlib and also with Kotlin inline functions, a lot of common UTF-8 behavior could be centralized.