### PR TITLE
Change BufferedSource.buffer() to be a val in Kotlin.

### DIFF
--- a/okio/jvm/src/main/java/okio/Buffer.kt
+++ b/okio/jvm/src/main/java/okio/Buffer.kt
@@ -50,6 +50,8 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
 
   override fun buffer() = this
 
+  override val buffer get() = this
+
   override fun outputStream(): OutputStream {
     return object : OutputStream() {
       override fun write(b: Int) {

--- a/okio/jvm/src/main/java/okio/BufferedSink.kt
+++ b/okio/jvm/src/main/java/okio/BufferedSink.kt
@@ -26,7 +26,14 @@ import java.nio.charset.Charset
  */
 interface BufferedSink : Sink, WritableByteChannel {
   /** Returns this sink's internal buffer. */
+  @Deprecated(
+    message = "moved to val: use getBuffer() instead",
+    replaceWith = ReplaceWith(expression = "buffer"),
+    level = DeprecationLevel.WARNING)
   fun buffer(): Buffer
+
+  /** This sink's internal buffer. */
+  val buffer: Buffer
 
   @Throws(IOException::class)
   fun write(byteString: ByteString): BufferedSink

--- a/okio/jvm/src/main/java/okio/BufferedSource.kt
+++ b/okio/jvm/src/main/java/okio/BufferedSource.kt
@@ -27,7 +27,14 @@ import java.nio.charset.Charset
  */
 interface BufferedSource : Source, ReadableByteChannel {
   /** Returns this source's internal buffer. */
+  @Deprecated(
+    message = "moved to val: use getBuffer() instead",
+    replaceWith = ReplaceWith(expression = "buffer"),
+    level = DeprecationLevel.WARNING)
   fun buffer(): Buffer
+
+  /** This source's internal buffer. */
+  val buffer: Buffer
 
   /**
    * Returns true if there are no more bytes in this source. This will block until there are bytes

--- a/okio/jvm/src/main/java/okio/DeflaterSink.kt
+++ b/okio/jvm/src/main/java/okio/DeflaterSink.kt
@@ -77,7 +77,7 @@ internal constructor(private val sink: BufferedSink, private val deflater: Defla
 
   @IgnoreJRERequirement
   private fun deflate(syncFlush: Boolean) {
-    val buffer = sink.buffer()
+    val buffer = sink.buffer
     while (true) {
       val s = buffer.writableSegment(1)
 

--- a/okio/jvm/src/main/java/okio/GzipSink.kt
+++ b/okio/jvm/src/main/java/okio/GzipSink.kt
@@ -61,7 +61,7 @@ class GzipSink(sink: Sink) : Sink {
 
   init {
     // Write the Gzip header directly into the buffer for the sink to avoid handling IOException.
-    this.sink.buffer().apply {
+    this.sink.buffer.apply {
       writeShort(0x1f8b) // Two-byte Gzip ID.
       writeByte(0x08) // 8 == Deflate compression method.
       writeByte(0x00) // No flags.

--- a/okio/jvm/src/main/java/okio/GzipSource.kt
+++ b/okio/jvm/src/main/java/okio/GzipSource.kt
@@ -102,9 +102,9 @@ class GzipSource(source: Source) : Source {
     // |ID1|ID2|CM |FLG|     MTIME     |XFL|OS | (more-->)
     // +---+---+---+---+---+---+---+---+---+---+
     source.require(10)
-    val flags = source.buffer()[3].toInt()
+    val flags = source.buffer[3].toInt()
     val fhcrc = flags.getBit(FHCRC)
-    if (fhcrc) updateCrc(source.buffer(), 0, 10)
+    if (fhcrc) updateCrc(source.buffer, 0, 10)
 
     val id1id2 = source.readShort()
     checkEqual("ID1ID2", 0x1f8b, id1id2.toInt())
@@ -116,10 +116,10 @@ class GzipSource(source: Source) : Source {
     // +---+---+=================================+
     if (flags.getBit(FEXTRA)) {
       source.require(2)
-      if (fhcrc) updateCrc(source.buffer(), 0, 2)
-      val xlen = source.buffer().readShortLe().toLong()
+      if (fhcrc) updateCrc(source.buffer, 0, 2)
+      val xlen = source.buffer.readShortLe().toLong()
       source.require(xlen)
-      if (fhcrc) updateCrc(source.buffer(), 0, xlen)
+      if (fhcrc) updateCrc(source.buffer, 0, xlen)
       source.skip(xlen)
     }
 
@@ -130,7 +130,7 @@ class GzipSource(source: Source) : Source {
     if (flags.getBit(FNAME)) {
       val index = source.indexOf(0)
       if (index == -1L) throw EOFException()
-      if (fhcrc) updateCrc(source.buffer(), 0, index + 1)
+      if (fhcrc) updateCrc(source.buffer, 0, index + 1)
       source.skip(index + 1)
     }
 
@@ -141,7 +141,7 @@ class GzipSource(source: Source) : Source {
     if (flags.getBit(FCOMMENT)) {
       val index = source.indexOf(0)
       if (index == -1L) throw EOFException()
-      if (fhcrc) updateCrc(source.buffer(), 0, index + 1)
+      if (fhcrc) updateCrc(source.buffer, 0, index + 1)
       source.skip(index + 1)
     }
 

--- a/okio/jvm/src/main/java/okio/InflaterSource.kt
+++ b/okio/jvm/src/main/java/okio/InflaterSource.kt
@@ -94,7 +94,7 @@ internal constructor(private val source: BufferedSource, private val inflater: I
     if (source.exhausted()) return true
 
     // Assign buffer bytes to the inflater.
-    val head = source.buffer().head!!
+    val head = source.buffer.head!!
     bufferBytesHeldByInflater = head.limit - head.pos
     inflater.setInput(head.data, head.pos, bufferBytesHeldByInflater)
     return false

--- a/okio/jvm/src/main/java/okio/RealBufferedSink.kt
+++ b/okio/jvm/src/main/java/okio/RealBufferedSink.kt
@@ -24,10 +24,14 @@ import java.nio.charset.Charset
 internal class RealBufferedSink(
   @JvmField val sink: Sink
 ) : BufferedSink {
-  @JvmField val buffer = Buffer()
+  @JvmField var bufferField = Buffer()
   @JvmField var closed: Boolean = false
 
-  override fun buffer() = buffer
+  @Suppress("OVERRIDE_BY_INLINE") // Prevent internal code from calling the getter.
+  override val buffer: Buffer
+    inline get() = bufferField
+
+  override fun buffer() = bufferField
 
   override fun write(source: Buffer, byteCount: Long) {
     check(!closed) { "closed" }

--- a/okio/jvm/src/main/java/okio/RealBufferedSource.kt
+++ b/okio/jvm/src/main/java/okio/RealBufferedSource.kt
@@ -24,10 +24,14 @@ import java.nio.charset.Charset
 internal class RealBufferedSource(
   @JvmField val source: Source
 ) : BufferedSource {
+  @JvmField var bufferField = Buffer()
   @JvmField var closed: Boolean = false
-  @JvmField val buffer = Buffer()
 
-  override fun buffer() = buffer
+  @Suppress("OVERRIDE_BY_INLINE") // Prevent internal code from calling the getter.
+  override val buffer: Buffer
+    inline get() = bufferField
+
+  override fun buffer() = bufferField
 
   override fun read(sink: Buffer, byteCount: Long): Long {
     require(byteCount >= 0) { "byteCount < 0: $byteCount" }

--- a/okio/jvm/src/test/java/okio/BufferedSourceTest.java
+++ b/okio/jvm/src/test/java/okio/BufferedSourceTest.java
@@ -350,7 +350,7 @@ public final class BufferedSourceTest {
   }
 
   @Test public void readAll() throws IOException {
-    source.buffer().writeUtf8("abc");
+    source.getBuffer().writeUtf8("abc");
     sink.writeUtf8("def");
     sink.emit();
 
@@ -1254,7 +1254,7 @@ public final class BufferedSourceTest {
     sink.writeUtf8("A man, a plan, a canal. Panama.");
     sink.emit();
     assertFalse(source.rangeEquals(0, ByteString.encodeUtf8("A man.")));
-    assertEquals("A man,", source.buffer().readUtf8());
+    assertEquals("A man,", source.getBuffer().readUtf8());
   }
 
   @Test public void rangeEqualsArgumentValidation() throws IOException {
@@ -1313,9 +1313,9 @@ public final class BufferedSourceTest {
     sink.emit();
     source.require(3);
     if (factory.isOneByteAtATime()) {
-      assertEquals(Arrays.asList(1, 1, 1), TestUtil.segmentSizes(source.buffer()));
+      assertEquals(Arrays.asList(1, 1, 1), TestUtil.segmentSizes(source.getBuffer()));
     } else {
-      assertEquals(Collections.singletonList(3), TestUtil.segmentSizes(source.buffer()));
+      assertEquals(Collections.singletonList(3), TestUtil.segmentSizes(source.getBuffer()));
     }
   }
 }

--- a/okio/jvm/src/test/java/okio/RealBufferedSinkTest.java
+++ b/okio/jvm/src/test/java/okio/RealBufferedSinkTest.java
@@ -48,7 +48,7 @@ public final class RealBufferedSinkTest {
     assertEquals(0, sink.size());
     bufferedSink.writeByte(0);
     assertEquals(SEGMENT_SIZE, sink.size());
-    assertEquals(0, bufferedSink.buffer().size());
+    assertEquals(0, bufferedSink.getBuffer().size());
   }
 
   @Test public void bufferedSinkEmitMultipleSegments() throws IOException {
@@ -56,7 +56,7 @@ public final class RealBufferedSinkTest {
     BufferedSink bufferedSink = Okio.buffer((Sink) sink);
     bufferedSink.writeUtf8(repeat('a', SEGMENT_SIZE * 4 - 1));
     assertEquals(SEGMENT_SIZE * 3, sink.size());
-    assertEquals(SEGMENT_SIZE - 1, bufferedSink.buffer().size());
+    assertEquals(SEGMENT_SIZE - 1, bufferedSink.getBuffer().size());
   }
 
   @Test public void bufferedSinkFlush() throws IOException {
@@ -65,7 +65,7 @@ public final class RealBufferedSinkTest {
     bufferedSink.writeByte('a');
     assertEquals(0, sink.size());
     bufferedSink.flush();
-    assertEquals(0, bufferedSink.buffer().size());
+    assertEquals(0, bufferedSink.getBuffer().size());
     assertEquals(1, sink.size());
   }
 
@@ -206,11 +206,11 @@ public final class RealBufferedSinkTest {
     MockSink mockSink = new MockSink();
     BufferedSink bufferedSink = Okio.buffer(mockSink);
 
-    bufferedSink.buffer().writeUtf8("abc");
+    bufferedSink.getBuffer().writeUtf8("abc");
     assertEquals(3, bufferedSink.writeAll(new Buffer().writeUtf8("def")));
 
-    assertEquals(6, bufferedSink.buffer().size());
-    assertEquals("abcdef", bufferedSink.buffer().readUtf8(6));
+    assertEquals(6, bufferedSink.getBuffer().size());
+    assertEquals("abcdef", bufferedSink.getBuffer().readUtf8(6));
     mockSink.assertLog(); // No writes.
  }
 
@@ -219,7 +219,7 @@ public final class RealBufferedSinkTest {
     BufferedSink bufferedSink = Okio.buffer(mockSink);
 
     assertEquals(0, bufferedSink.writeAll(new Buffer()));
-    assertEquals(0, bufferedSink.buffer().size());
+    assertEquals(0, bufferedSink.getBuffer().size());
     mockSink.assertLog(); // No writes.
  }
 

--- a/okio/jvm/src/test/java/okio/RealBufferedSourceTest.java
+++ b/okio/jvm/src/test/java/okio/RealBufferedSourceTest.java
@@ -97,10 +97,10 @@ public final class RealBufferedSourceTest {
     source.writeUtf8("bb");
 
     BufferedSource bufferedSource = Okio.buffer((Source) source);
-    bufferedSource.buffer().writeUtf8("aa");
+    bufferedSource.getBuffer().writeUtf8("aa");
 
     bufferedSource.require(2);
-    assertEquals(2, bufferedSource.buffer().size());
+    assertEquals(2, bufferedSource.getBuffer().size());
     assertEquals(2, source.size());
   }
 
@@ -109,10 +109,10 @@ public final class RealBufferedSourceTest {
     source.writeUtf8("b");
 
     BufferedSource bufferedSource = Okio.buffer((Source) source);
-    bufferedSource.buffer().writeUtf8("a");
+    bufferedSource.getBuffer().writeUtf8("a");
 
     bufferedSource.require(2);
-    assertEquals("ab", bufferedSource.buffer().readUtf8(2));
+    assertEquals("ab", bufferedSource.getBuffer().readUtf8(2));
   }
 
   @Test public void requireInsufficientData() throws Exception {
@@ -137,7 +137,7 @@ public final class RealBufferedSourceTest {
 
     bufferedSource.require(2);
     assertEquals(SEGMENT_SIZE, source.size());
-    assertEquals(SEGMENT_SIZE, bufferedSource.buffer().size());
+    assertEquals(SEGMENT_SIZE, bufferedSource.getBuffer().size());
   }
 
   @Test public void skipReadsOneSegmentAtATime() throws Exception {
@@ -147,7 +147,7 @@ public final class RealBufferedSourceTest {
     BufferedSource bufferedSource = Okio.buffer((Source) source);
     bufferedSource.skip(2);
     assertEquals(SEGMENT_SIZE, source.size());
-    assertEquals(SEGMENT_SIZE - 2, bufferedSource.buffer().size());
+    assertEquals(SEGMENT_SIZE - 2, bufferedSource.getBuffer().size());
   }
 
   @Test public void skipTracksBufferFirst() throws Exception {
@@ -155,10 +155,10 @@ public final class RealBufferedSourceTest {
     source.writeUtf8("bb");
 
     BufferedSource bufferedSource = Okio.buffer((Source) source);
-    bufferedSource.buffer().writeUtf8("aa");
+    bufferedSource.getBuffer().writeUtf8("aa");
 
     bufferedSource.skip(2);
-    assertEquals(0, bufferedSource.buffer().size());
+    assertEquals(0, bufferedSource.getBuffer().size());
     assertEquals(2, source.size());
   }
 

--- a/samples/src/main/java/okio/samples/SourceMarker.java
+++ b/samples/src/main/java/okio/samples/SourceMarker.java
@@ -68,7 +68,7 @@ public final class SourceMarker {
     this.markSource = new MarkSource(source);
     this.markBuffer = new Buffer();
     this.userSource = Okio.buffer(markSource);
-    this.userBuffer = userSource.buffer();
+    this.userBuffer = userSource.getBuffer();
   }
 
   public BufferedSource source() {


### PR DESCRIPTION
Same for BufferedSink.buffer().

This is because for Kotlin callers these methods shadow the
Source.buffer() and Sink.buffer() methods that have different
behavior. Methods with different behavior shouldn't have the
same names!

One consequence of this is that it will nudge Java users to
change from BufferedSource.buffer() to BufferedSource.getBuffer()
which is slightly worse. I couldn't find a good workaround due
to the lack of support for @JvmName in Kotlin interfaces.

Most users will never need to use either method.