### PR TITLE
Update to Kotlin 1.2.70

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.versions = [
-      'kotlin': '1.2.60',
-      'kotlinNative': '0.8.2',
+      'kotlin': '1.2.70',
+      'kotlinNative': '0.9.1',
       'jmhPlugin': '0.4.5',
       'animalSnifferPlugin': '1.4.3',
       'dokka': '0.9.16',

--- a/okio/js/src/main/kotlin/okio/-Platform.kt
+++ b/okio/js/src/main/kotlin/okio/-Platform.kt
@@ -18,23 +18,6 @@ package okio
 
 import okio.internal.commonAsUtf8ToByteArray
 import okio.internal.commonToUtf8String
-import kotlin.annotation.AnnotationTarget.FIELD
-import kotlin.annotation.AnnotationTarget.FILE
-import kotlin.annotation.AnnotationTarget.FUNCTION
-import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
-import kotlin.annotation.AnnotationTarget.PROPERTY_SETTER
-
-@Target(FUNCTION)
-actual annotation class JvmOverloads
-
-@Target(FIELD)
-actual annotation class JvmField
-
-@Target(FUNCTION)
-actual annotation class JvmStatic
-
-@Target(FILE, FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER)
-actual annotation class JvmName(actual val name: String)
 
 internal actual fun arraycopy(
   src: ByteArray,

--- a/okio/jvm/src/main/java/okio/-Platform.kt
+++ b/okio/jvm/src/main/java/okio/-Platform.kt
@@ -17,11 +17,6 @@
 @file:JvmName("-Platform")
 package okio
 
-actual typealias JvmOverloads = kotlin.jvm.JvmOverloads
-actual typealias JvmField = kotlin.jvm.JvmField
-actual typealias JvmStatic = kotlin.jvm.JvmStatic
-actual typealias JvmName = kotlin.jvm.JvmName
-
 internal actual fun arraycopy(
   src: ByteArray,
   srcPos: Int,

--- a/okio/native/src/main/kotlin/okio/-Platform.kt
+++ b/okio/native/src/main/kotlin/okio/-Platform.kt
@@ -17,23 +17,6 @@
 package okio
 
 import okio.internal.commonAsUtf8ToByteArray
-import kotlin.annotation.AnnotationTarget.FIELD
-import kotlin.annotation.AnnotationTarget.FILE
-import kotlin.annotation.AnnotationTarget.FUNCTION
-import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
-import kotlin.annotation.AnnotationTarget.PROPERTY_SETTER
-
-@Target(FUNCTION)
-actual annotation class JvmOverloads
-
-@Target(FIELD)
-actual annotation class JvmField
-
-@Target(FUNCTION)
-actual annotation class JvmStatic
-
-@Target(FILE, FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER)
-actual annotation class JvmName(actual val name: String)
 
 internal actual fun arraycopy(
   src: ByteArray,

--- a/okio/src/main/kotlin/okio/-Base64.kt
+++ b/okio/src/main/kotlin/okio/-Base64.kt
@@ -19,6 +19,7 @@
 package okio
 
 import okio.ByteString.Companion.encodeUtf8
+import kotlin.jvm.JvmName
 
 /** @author Alexander Y. Kleymenov */
 

--- a/okio/src/main/kotlin/okio/-Platform.kt
+++ b/okio/src/main/kotlin/okio/-Platform.kt
@@ -16,28 +16,6 @@
 
 package okio
 
-import kotlin.annotation.AnnotationTarget.FIELD
-import kotlin.annotation.AnnotationTarget.FILE
-import kotlin.annotation.AnnotationTarget.FUNCTION
-import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
-import kotlin.annotation.AnnotationTarget.PROPERTY_SETTER
-
-// TODO remove after https://youtrack.jetbrains.com/issue/KT-24478
-@Target(FUNCTION)
-expect annotation class JvmOverloads()
-
-// TODO remove after https://youtrack.jetbrains.com/issue/KT-24478
-@Target(FIELD)
-expect annotation class JvmField()
-
-// TODO remove after https://youtrack.jetbrains.com/issue/KT-24478
-@Target(FUNCTION)
-expect annotation class JvmStatic()
-
-// TODO remove after https://youtrack.jetbrains.com/issue/KT-24478
-@Target(FILE, FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER)
-expect annotation class JvmName(val name: String)
-
 internal expect fun arraycopy(
   src: ByteArray,
   srcPos: Int,

--- a/okio/src/main/kotlin/okio/-Util.kt
+++ b/okio/src/main/kotlin/okio/-Util.kt
@@ -18,6 +18,8 @@
 
 package okio
 
+import kotlin.jvm.JvmName
+
 internal fun checkOffsetAndCount(size: Long, offset: Long, byteCount: Long) {
   if (offset or byteCount < 0 || offset > size || size - offset < byteCount) {
     throw ArrayIndexOutOfBoundsException("size=$size offset=$offset byteCount=$byteCount")

--- a/okio/src/main/kotlin/okio/ByteString.kt
+++ b/okio/src/main/kotlin/okio/ByteString.kt
@@ -16,6 +16,10 @@
 
 package okio
 
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmStatic
+
 /**
  * An immutable sequence of bytes.
  *

--- a/okio/src/main/kotlin/okio/Segment.kt
+++ b/okio/src/main/kotlin/okio/Segment.kt
@@ -15,6 +15,8 @@
  */
 package okio
 
+import kotlin.jvm.JvmField
+
 /**
  * A segment of a buffer.
  *

--- a/okio/src/main/kotlin/okio/SegmentPool.kt
+++ b/okio/src/main/kotlin/okio/SegmentPool.kt
@@ -15,6 +15,9 @@
  */
 package okio
 
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmStatic
+
 /**
  * A collection of unused segments, necessary to avoid GC churn and zero-fill.
  * This pool is a thread-safe static singleton.

--- a/okio/src/main/kotlin/okio/Utf8.kt
+++ b/okio/src/main/kotlin/okio/Utf8.kt
@@ -65,6 +65,9 @@
 
 package okio
 
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmOverloads
+
 /**
  * Returns the number of bytes used to encode the slice of `string` as UTF-8 when using
  * [BufferedSink.writeUtf8].


### PR DESCRIPTION
This allows using the built-in platform-specific annotations instead of our own aliases.

Blocked by a new Kotlin Native release.