### PR TITLE
Create a Throttler sample

### DIFF
--- a/okio/jvm/src/main/java/okio/Throttler.kt
+++ b/okio/jvm/src/main/java/okio/Throttler.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import java.io.IOException
+import java.io.InterruptedIOException
+
+/**
+ * Enables limiting of Source and Sink throughput. Attach to this throttler via [.source] and
+ * [.sink] and set the desired throughput via [.bytesPerSecond]. Multiple Sources and Sinks can be
+ * attached to a single Throttler and they will be throttled as a group, where their combined
+ * throughput will not exceed the desired throughput. The same Source or Sink can be attached to
+ * multiple Throttlers and its throughput will not exceed the desired throughput of any of the
+ * Throttlers.
+ *
+ * This class has these tuning parameters:
+ *
+ *  * `bytesPerSecond`: Maximum sustained throughput. Use 0 for no limit.
+ *  * `waitByteCount`: When the requested byte count is greater than this many bytes and isn't
+ *    immediately available, only wait until we can allocate at least this many bytes. Use this to
+ *    set the ideal byte count during sustained throughput.
+ *  * `maxByteCount`: Maximum number of bytes to allocate on any call. This is also the number of
+ *    bytes that will be returned before any waiting.
+ */
+class Throttler {
+  private var bytesPerSecond: Long = 0L
+  private var waitByteCount: Long = 8 * 1024 // 8 KiB.
+  private var maxByteCount: Long = 256 * 1024 // 256 KiB.
+  private var nanosForMaxByteCount: Long = -1L
+
+  /**
+   * The nanoTime that we've consumed all bytes through. This is never greater than the current
+   * nanoTime plus nanosForMaxByteCount.
+   */
+  private var allocatedUntil: Long = System.nanoTime()
+
+  /** Sets the rate at which bytes will be allocated. Use 0 for no limit. */
+  @JvmOverloads
+  fun bytesPerSecond(
+    bytesPerSecond: Long,
+    waitByteCount: Long = this.waitByteCount,
+    maxByteCount: Long = this.maxByteCount
+  ) {
+    synchronized(this) {
+      require(bytesPerSecond >= 0)
+      require(waitByteCount > 0)
+      require(maxByteCount >= waitByteCount)
+
+      this.bytesPerSecond = bytesPerSecond
+      this.waitByteCount = waitByteCount
+      this.maxByteCount = maxByteCount
+      this.nanosForMaxByteCount = when {
+        bytesPerSecond != 0L -> maxByteCount * 1_000_000_000L / bytesPerSecond
+        else -> -1L
+      }
+
+      (this as Object).notifyAll()
+    }
+  }
+
+  /**
+   * Take up to `byteCount` bytes, waiting if necessary. Returns the number of bytes that were
+   * taken.
+   */
+  internal fun take(byteCount: Long): Long {
+    require(byteCount > 0)
+
+    synchronized(this) {
+      while (true) {
+        if (bytesPerSecond == 0L) return byteCount // No limits.
+
+        val now = System.nanoTime()
+        val idleInNanos = maxOf(allocatedUntil - now, 0L)
+        val usableNanos = nanosForMaxByteCount - idleInNanos
+        val immediateBytes = bytesPerSecond * usableNanos / 1_000_000_000L
+
+        // Fulfill the entire request without waiting.
+        if (immediateBytes >= byteCount) {
+          val byteCountNanos = byteCount * 1_000_000_000L / bytesPerSecond
+          allocatedUntil = now + idleInNanos + byteCountNanos
+          return byteCount
+        }
+
+        // Fulfill a big-enough block without waiting.
+        if (immediateBytes >= waitByteCount) {
+          allocatedUntil = now + idleInNanos + usableNanos
+          return immediateBytes
+        }
+
+        // Wait until we can write some bytes.
+        val byteCountNanos = minOf(waitByteCount, byteCount) * 1_000_000_000L / bytesPerSecond
+        waitNanos(byteCountNanos - usableNanos)
+      }
+    }
+    throw AssertionError() // Unreachable, but synchronized() doesn't know that.
+  }
+
+  private fun waitNanos(nanosToWait: Long) {
+    val millisToWait = nanosToWait / 1_000_000L
+    val remainderNanos = nanosToWait - (millisToWait * 1_000_000L)
+    (this as Object).wait(millisToWait, remainderNanos.toInt())
+  }
+
+  /** Create a Source which honors this Throttler.  */
+  fun source(source: Source): Source {
+    return object : ForwardingSource(source) {
+      override fun read(sink: Buffer, byteCount: Long): Long {
+        try {
+          val toRead = take(byteCount)
+          return super.read(sink, toRead)
+        } catch (e: InterruptedException) {
+          Thread.currentThread().interrupt()
+          throw InterruptedIOException("interrupted")
+        }
+      }
+    }
+  }
+
+  /** Create a Sink which honors this Throttler.  */
+  fun sink(sink: Sink): Sink {
+    return object : ForwardingSink(sink) {
+      @Throws(IOException::class)
+      override fun write(source: Buffer, byteCount: Long) {
+        try {
+          var remaining = byteCount
+          while (remaining > 0L) {
+            val toWrite = take(remaining)
+            super.write(source, toWrite)
+            remaining -= toWrite
+          }
+        } catch (e: InterruptedException) {
+          Thread.currentThread().interrupt()
+          throw InterruptedIOException("interrupted")
+        }
+      }
+    }
+  }
+}

--- a/okio/jvm/src/test/java/okio/Stopwatch.kt
+++ b/okio/jvm/src/test/java/okio/Stopwatch.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+
+/** Stopwatch for asserting elapsed time during unit tests. */
+internal class Stopwatch {
+  private val start = System.nanoTime() / 1e9
+  private var offset = 0.0
+
+  /**
+   * Fails the test unless the time from the last assertion until now is `elapsed`, accepting
+   * differences in -200..+200 milliseconds.
+   */
+  fun assertElapsed(elapsed: Double) {
+    offset += elapsed
+    assertThat(System.nanoTime() / 1e9 - start).isCloseTo(offset, within(0.2))
+  }
+}

--- a/okio/jvm/src/test/java/okio/ThrottlerTest.kt
+++ b/okio/jvm/src/test/java/okio/ThrottlerTest.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import okio.TestUtil.randomSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.Executors
+import kotlin.test.assertEquals
+
+class ThrottlerTest {
+  private val size = 1024L * 80L // 80 KiB
+  private val source = randomSource(size)
+
+  private val throttler = Throttler()
+  private val throttlerSlow = Throttler()
+
+  private val threads = 4
+  private val executorService = Executors.newFixedThreadPool(threads)
+  private var stopwatch = Stopwatch()
+
+  @Before fun setup() {
+    throttler.bytesPerSecond(4 * size, 4096, 8192)
+    throttlerSlow.bytesPerSecond(2 * size, 4096, 8192)
+    stopwatch = Stopwatch()
+  }
+
+  @After fun teardown() {
+    executorService.shutdown()
+  }
+
+  @Test fun sourceByteCount() {
+    throttler.bytesPerSecond(bytesPerSecond = 20, waitByteCount = 5, maxByteCount = 10)
+    val source = throttler.source(source)
+    val buffer = Buffer()
+
+    // We get the first 10 bytes immediately (that's maxByteCount).
+    assertThat(source.read(buffer, size)).isEqualTo(10)
+    stopwatch.assertElapsed(0.0)
+
+    // Wait a quarter second for each subsequent 5 bytes (that's waitByteCount).
+    assertThat(source.read(buffer, size)).isEqualTo(5)
+    stopwatch.assertElapsed(0.25)
+
+    assertThat(source.read(buffer, size)).isEqualTo(5)
+    stopwatch.assertElapsed(0.25)
+
+    // Wait three quarters of a second to build up 15 bytes of potential.
+    // Since maxByteCount = 10, there will only be 10 bytes of potential.
+    Thread.sleep(750)
+    stopwatch.assertElapsed(0.75)
+
+    // We get 10 bytes immediately (that's maxByteCount again).
+    assertThat(source.read(buffer, size)).isEqualTo(10)
+    stopwatch.assertElapsed(0.0)
+
+    // Wait a quarter second for each subsequent 5 bytes (that's waitByteCount again).
+    assertThat(source.read(buffer, size)).isEqualTo(5)
+    stopwatch.assertElapsed(0.25)
+  }
+
+  @Test fun sinkByteCount() {
+    throttler.bytesPerSecond(bytesPerSecond = 20, waitByteCount = 5, maxByteCount = 10)
+    val sinkBuffer = Buffer()
+    val sourceBuffer = Buffer().apply { writeAll(source) }
+    val sink = throttler.sink(sinkBuffer)
+    var written = 0L
+
+    // We write the first 10 bytes immediately (that's maxByteCount again).
+    sink.write(sourceBuffer, 10)
+    written += 10
+    assertEquals(written, size - sourceBuffer.size)
+    stopwatch.assertElapsed(0.0)
+
+    // Wait a quarter second for each subsequent 5 bytes (that's waitByteCount).
+    sink.write(sourceBuffer, 5)
+    written += 5
+    assertEquals(written, size - sourceBuffer.size)
+    stopwatch.assertElapsed(0.25)
+
+    // Wait a half second for 10 bytes.
+    sink.write(sourceBuffer, 10)
+    written += 10
+    assertEquals(written, size - sourceBuffer.size)
+    stopwatch.assertElapsed(0.5)
+
+    // Wait a three quarters of a second to build up 15 bytes of potential.
+    // Since maxByteCount = 10, there will only be 10 bytes of potential.
+    Thread.sleep(750)
+    stopwatch.assertElapsed(0.75)
+
+    // We write the first 10 bytes immediately (that's maxByteCount again).
+    // Wait a quarter second for each subsequent 5 bytes (that's waitByteCount again).
+    sink.write(sourceBuffer, 15)
+    written += 15
+    assertEquals(written, size - sourceBuffer.size)
+    stopwatch.assertElapsed(0.25)
+  }
+
+  @Test fun source() {
+    throttler.source(source).buffer().readAll(blackholeSink())
+    stopwatch.assertElapsed(0.25)
+  }
+
+  @Test fun sink() {
+    source.buffer().readAll(throttler.sink(blackholeSink()))
+    stopwatch.assertElapsed(0.25)
+  }
+
+  @Test fun sourceAfterClear() {
+    throttler.bytesPerSecond(0)
+    throttler.source(source).buffer().readAll(blackholeSink())
+    stopwatch.assertElapsed(0.0)
+  }
+
+  @Test fun sinkAfterClear() {
+    throttler.bytesPerSecond(0)
+    source.buffer().readAll(throttler.sink(blackholeSink()))
+    stopwatch.assertElapsed(0.0)
+  }
+
+  @Test fun doubleSourceThrottle() {
+    throttler.source(throttler.source(source)).buffer().readAll(blackholeSink())
+    stopwatch.assertElapsed(0.5)
+  }
+
+  @Test fun doubleSinkThrottle() {
+    source.buffer().readAll(throttler.sink(throttler.sink(blackholeSink())))
+    stopwatch.assertElapsed(0.5)
+  }
+
+  @Test fun singleSourceMultiThrottleSlowerThenSlow() {
+    source.buffer().readAll(throttler.sink(throttlerSlow.sink(blackholeSink())))
+    stopwatch.assertElapsed(0.5)
+  }
+
+  @Test fun singleSourceMultiThrottleSlowThenSlower() {
+    source.buffer().readAll(throttlerSlow.sink(throttler.sink(blackholeSink())))
+    stopwatch.assertElapsed(0.5)
+  }
+
+  @Test fun slowSourceSlowerSink() {
+    throttler.source(source).buffer().readAll(throttlerSlow.sink(blackholeSink()))
+    stopwatch.assertElapsed(0.5)
+  }
+
+  @Test fun slowSinkSlowerSource() {
+    throttlerSlow.source(source).buffer().readAll(throttler.sink(blackholeSink()))
+    stopwatch.assertElapsed(0.5)
+  }
+
+  @Test fun parallel() {
+    val futures = List(threads) {
+      executorService.submit {
+        val source = randomSource(size)
+        source.buffer().readAll(throttler.sink(blackholeSink()))
+      }
+    }
+    for (future in futures) {
+      future.get()
+    }
+    stopwatch.assertElapsed(1.0)
+  }
+
+  @Test fun parallelAfterClear() {
+    throttler.bytesPerSecond(0)
+
+    val futures = List(threads) {
+      executorService.submit {
+        val source = randomSource(size)
+        source.buffer().readAll(throttler.sink(blackholeSink()))
+      }
+    }
+    for (future in futures) {
+      future.get()
+    }
+    stopwatch.assertElapsed(0.0)
+  }
+
+  @Test fun parallelWithClear() {
+    val futures = List(threads) {
+      executorService.submit {
+        val source = randomSource(size)
+        source.buffer().readAll(throttler.sink(blackholeSink()))
+      }
+    }
+    Thread.sleep(500)
+    throttler.bytesPerSecond(0)
+    for (future in futures) {
+      future.get()
+    }
+    stopwatch.assertElapsed(0.5)
+  }
+
+  @Test fun parallelFastThenSlower() {
+    val futures = List(threads) {
+      executorService.submit {
+        val source = randomSource(size)
+        source.buffer().readAll(throttler.sink(blackholeSink()))
+      }
+    }
+    Thread.sleep(500)
+    throttler.bytesPerSecond(2 * size)
+    for (future in futures) {
+      future.get()
+    }
+    stopwatch.assertElapsed(1.5)
+  }
+
+  @Test fun parallelSlowThenFaster() {
+    val futures = List(threads) {
+      executorService.submit {
+        val source = randomSource(size)
+        source.buffer().readAll(throttlerSlow.sink(blackholeSink()))
+      }
+    }
+    Thread.sleep(1_000)
+    throttlerSlow.bytesPerSecond(4 * size)
+    for (future in futures) {
+      future.get()
+    }
+    stopwatch.assertElapsed(1.5)
+  }
+
+  @Test fun parallelIndividualThrottle() {
+    val futures = List(threads) {
+      executorService.submit {
+        val throttlerLocal = Throttler()
+        throttlerLocal.bytesPerSecond(4 * size, maxByteCount = 8192)
+
+        val source = randomSource(size)
+        source.buffer().readAll(throttlerLocal.sink(blackholeSink()))
+      }
+    }
+    for (future in futures) {
+      future.get()
+    }
+    stopwatch.assertElapsed(0.25)
+  }
+
+  @Test fun parallelGroupAndIndividualThrottle() {
+    val futures = List(threads) {
+      executorService.submit {
+        val throttlerLocal = Throttler()
+        throttlerLocal.bytesPerSecond(4 * size, maxByteCount = 8192)
+
+        val source = randomSource(size)
+        source.buffer().readAll(throttler.sink(throttlerLocal.sink(blackholeSink())))
+      }
+    }
+    for (future in futures) {
+      future.get()
+    }
+    stopwatch.assertElapsed(1.0)
+  }
+}


### PR DESCRIPTION
Closes #490 

Created a sample Throttler which can throttle Sources and Sinks to a
desired throughput. Multiple Sources and Sinks can be attached to the
same Throttler and their combined throughput will not exceed the desired
throughput. Multiple Throttlers can also be used on the same Source or
Sink and they will all be honored.

Added some basic unit tests to verify desired behavior.