### PR TITLE
AsyncTimeout wrapped Source needs to timeout on long close

### DIFF
--- a/okio/jvm/src/main/java/okio/AsyncTimeout.kt
+++ b/okio/jvm/src/main/java/okio/AsyncTimeout.kt
@@ -168,6 +168,7 @@ open class AsyncTimeout : Timeout() {
 
       override fun close() {
         var throwOnTimeout = false
+        enter()
         try {
           source.close()
           throwOnTimeout = true

--- a/okio/jvm/src/test/java/okio/AsyncTimeoutTest.java
+++ b/okio/jvm/src/test/java/okio/AsyncTimeoutTest.java
@@ -202,6 +202,46 @@ public final class AsyncTimeoutTest {
     }
   }
 
+  @Test public void wrappedSinkFlushTimesOut() throws Exception {
+    Sink sink = new ForwardingSink(new Buffer()) {
+      @Override public void flush() throws IOException {
+        try {
+          Thread.sleep(500);
+        } catch (InterruptedException e) {
+          throw new AssertionError();
+        }
+      }
+    };
+    AsyncTimeout timeout = new AsyncTimeout();
+    timeout.timeout(250, TimeUnit.MILLISECONDS);
+    Sink timeoutSink = timeout.sink(sink);
+    try {
+      timeoutSink.flush();
+      fail();
+    } catch (InterruptedIOException expected) {
+    }
+  }
+
+  @Test public void wrappedSinkCloseTimesOut() throws Exception {
+    Sink sink = new ForwardingSink(new Buffer()) {
+      @Override public void close() throws IOException {
+        try {
+          Thread.sleep(500);
+        } catch (InterruptedException e) {
+          throw new AssertionError();
+        }
+      }
+    };
+    AsyncTimeout timeout = new AsyncTimeout();
+    timeout.timeout(250, TimeUnit.MILLISECONDS);
+    Sink timeoutSink = timeout.sink(sink);
+    try {
+      timeoutSink.close();
+      fail();
+    } catch (InterruptedIOException expected) {
+    }
+  }
+
   @Test public void wrappedSourceTimesOut() throws Exception {
     Source source = new ForwardingSource(new Buffer()) {
       @Override public long read(Buffer sink, long byteCount) throws IOException {
@@ -218,6 +258,26 @@ public final class AsyncTimeoutTest {
     Source timeoutSource = timeout.source(source);
     try {
       timeoutSource.read(new Buffer(), 0);
+      fail();
+    } catch (InterruptedIOException expected) {
+    }
+  }
+
+  @Test public void wrappedSourceCloseTimesOut() throws Exception {
+    Source source = new ForwardingSource(new Buffer()) {
+      @Override public void close() throws IOException {
+        try {
+          Thread.sleep(500);
+        } catch (InterruptedException e) {
+          throw new AssertionError();
+        }
+      }
+    };
+    AsyncTimeout timeout = new AsyncTimeout();
+    timeout.timeout(250, TimeUnit.MILLISECONDS);
+    Source timeoutSource = timeout.source(source);
+    try {
+      timeoutSource.close();
       fail();
     } catch (InterruptedIOException expected) {
     }


### PR DESCRIPTION
The wrapping Source for an AsyncTimeout was missing a call to enter() in
close(). This means a timeout would never occur if closing the Source
took longer than then the current timeout.

Added some unit tests to cover this case as well for both Source and
Sink and close() and flush().