### PR TITLE
Various SegmentedByteString improvements

### DIFF
--- a/okio/js/src/main/kotlin/okio/ByteString.kt
+++ b/okio/js/src/main/kotlin/okio/ByteString.kt
@@ -30,6 +30,7 @@ import okio.internal.commonHashCode
 import okio.internal.commonHex
 import okio.internal.commonIndexOf
 import okio.internal.commonInternalArray
+import okio.internal.commonLastIndexOf
 import okio.internal.commonOf
 import okio.internal.commonRangeEquals
 import okio.internal.commonStartsWith
@@ -146,25 +147,15 @@ internal actual constructor(
 
   actual fun endsWith(suffix: ByteArray) = commonEndsWith(suffix)
 
-  actual fun indexOf(other: ByteString, fromIndex: Int) = indexOf(other.internalArray(), fromIndex)
+  actual fun indexOf(other: ByteString, fromIndex: Int) = commonIndexOf(other, fromIndex)
 
   actual open fun indexOf(other: ByteArray, fromIndex: Int) = commonIndexOf(other, fromIndex)
 
   // TODO move lastIndexOf() when https://youtrack.jetbrains.com/issue/KT-22818 is fixed
 
-  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = lastIndexOf(other.internalArray(),
-      fromIndex)
+  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
 
-  open fun lastIndexOf(other: ByteArray, fromIndex: Int = size): Int {
-    var fromIndex = fromIndex
-    fromIndex = minOf(fromIndex, data.size - other.size)
-    for (i in fromIndex downTo 0) {
-      if (arrayRangeEquals(data, i, other, 0, other.size)) {
-        return i
-      }
-    }
-    return -1
-  }
+  fun lastIndexOf(other: ByteArray, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
 
   actual override fun equals(other: Any?) = commonEquals(other)
 

--- a/okio/js/src/main/kotlin/okio/ByteString.kt
+++ b/okio/js/src/main/kotlin/okio/ByteString.kt
@@ -147,13 +147,13 @@ internal actual constructor(
 
   actual fun endsWith(suffix: ByteArray) = commonEndsWith(suffix)
 
-  actual fun indexOf(other: ByteString, fromIndex: Int) = commonIndexOf(other, fromIndex)
+  actual fun indexOf(other: ByteString, fromIndex: Int) = indexOf(other.internalArray(), fromIndex)
 
   actual open fun indexOf(other: ByteArray, fromIndex: Int) = commonIndexOf(other, fromIndex)
 
   // TODO move lastIndexOf() when https://youtrack.jetbrains.com/issue/KT-22818 is fixed
 
-  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
+  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = lastIndexOf(other.internalArray(), fromIndex)
 
   fun lastIndexOf(other: ByteArray, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
 

--- a/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/SegmentedByteStringBenchmark.java
+++ b/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/SegmentedByteStringBenchmark.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2018 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okio.benchmarks;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okio.Buffer;
+import okio.ByteString;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+@Fork(1)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class SegmentedByteStringBenchmark {
+
+  private static final ByteString UNKNOWN = ByteString.encodeUtf8("UNKNOWN");
+  private static final ByteString SEARCH = ByteString.encodeUtf8("tell");
+
+  @Param({"20", "2000", "200000"})
+  int length;
+
+  private ByteString byteString;
+
+  @Setup
+  public void setup() {
+    String part =
+        "Um, I'll tell you the problem with the scientific power that you're using here, "
+            + "it didn't require any discipline to attain it. You read what others had done and you "
+            + "took the next step. You didn't earn the knowledge for yourselves, so you don't take any "
+            + "responsibility for it. You stood on the shoulders of geniuses to accomplish something "
+            + "as fast as you could, and before you even knew what you had, you patented it, and "
+            + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
+            + "sell it.";
+
+    Buffer buffer = new Buffer();
+    while (buffer.size() < length) {
+      buffer.writeUtf8(part);
+    }
+    byteString = buffer.snapshot(length);
+  }
+
+  @Benchmark
+  public ByteString substring() {
+    return byteString.substring(1, byteString.size() - 1);
+  }
+
+  @Benchmark
+  public ByteString md5() {
+    return byteString.md5();
+  }
+
+  @Benchmark
+  public int indexOfUnknown() {
+    return byteString.indexOf(UNKNOWN);
+  }
+
+  @Benchmark
+  public int lastIndexOfUnknown() {
+    return byteString.lastIndexOf(UNKNOWN);
+  }
+
+  @Benchmark
+  public int indexOfEarly() {
+    return byteString.indexOf(SEARCH);
+  }
+
+  @Benchmark
+  public int lastIndexOfEarly() {
+    return byteString.lastIndexOf(SEARCH);
+  }
+
+  public static void main(String[] args) throws IOException, RunnerException {
+    Main.main(new String[] {SegmentedByteStringBenchmark.class.getName()});
+  }
+}

--- a/okio/jvm/src/main/java/okio/Buffer.kt
+++ b/okio/jvm/src/main/java/okio/Buffer.kt
@@ -1755,7 +1755,7 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
 
   /** Returns an immutable copy of the first `byteCount` bytes of this buffer as a byte string. */
   fun snapshot(byteCount: Int): ByteString {
-    return if (byteCount == 0) ByteString.EMPTY else SegmentedByteString(this, byteCount)
+    return if (byteCount == 0) ByteString.EMPTY else SegmentedByteString.of(this, byteCount)
   }
 
   @JvmOverloads fun readUnsafe(unsafeCursor: UnsafeCursor = UnsafeCursor()): UnsafeCursor {

--- a/okio/jvm/src/main/java/okio/Buffer.kt
+++ b/okio/jvm/src/main/java/okio/Buffer.kt
@@ -1470,7 +1470,8 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
 
       // Scan through the segments, searching for the lead byte. Each time that is found, delegate
       // to rangeEquals() to check for a complete match.
-      val b0 = bytes[0]
+      val targetByteArray = bytes.internalArray()
+      val b0 = targetByteArray[0]
       val bytesSize = bytes.size
       val resultLimit = size - bytesSize + 1L
       while (offset < resultLimit) {
@@ -1478,7 +1479,7 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
         val data = s.data
         val segmentLimit = minOf(s.limit, s.pos + resultLimit - offset).toInt()
         for (pos in (s.pos + fromIndex - offset).toInt() until segmentLimit) {
-          if (data[pos] == b0 && rangeEquals(s, pos + 1, bytes.internalArray(), 1, bytesSize)) {
+          if (data[pos] == b0 && rangeEquals(s, pos + 1, targetByteArray, 1, bytesSize)) {
             return pos - s.pos + offset
           }
         }

--- a/okio/jvm/src/main/java/okio/ByteString.kt
+++ b/okio/jvm/src/main/java/okio/ByteString.kt
@@ -219,7 +219,7 @@ internal actual constructor(
   // TODO move @JvmOverloads to common when https://youtrack.jetbrains.com/issue/KT-18882 lands
 
   @JvmOverloads
-  actual fun indexOf(other: ByteString, fromIndex: Int) = commonIndexOf(other, fromIndex)
+  actual fun indexOf(other: ByteString, fromIndex: Int) = indexOf(other.internalArray(), fromIndex)
 
   @JvmOverloads
   actual open fun indexOf(other: ByteArray, fromIndex: Int) = commonIndexOf(other, fromIndex)
@@ -227,7 +227,8 @@ internal actual constructor(
   // TODO move lastIndexOf() when https://youtrack.jetbrains.com/issue/KT-22818 is fixed
 
   @JvmOverloads
-  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
+  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = lastIndexOf(other.internalArray(),
+      fromIndex)
 
   @JvmOverloads
   open fun lastIndexOf(other: ByteArray, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)

--- a/okio/jvm/src/main/java/okio/ByteString.kt
+++ b/okio/jvm/src/main/java/okio/ByteString.kt
@@ -30,6 +30,7 @@ import okio.internal.commonHashCode
 import okio.internal.commonHex
 import okio.internal.commonIndexOf
 import okio.internal.commonInternalArray
+import okio.internal.commonLastIndexOf
 import okio.internal.commonOf
 import okio.internal.commonRangeEquals
 import okio.internal.commonStartsWith
@@ -218,7 +219,7 @@ internal actual constructor(
   // TODO move @JvmOverloads to common when https://youtrack.jetbrains.com/issue/KT-18882 lands
 
   @JvmOverloads
-  actual fun indexOf(other: ByteString, fromIndex: Int) = indexOf(other.internalArray(), fromIndex)
+  actual fun indexOf(other: ByteString, fromIndex: Int) = commonIndexOf(other, fromIndex)
 
   @JvmOverloads
   actual open fun indexOf(other: ByteArray, fromIndex: Int) = commonIndexOf(other, fromIndex)
@@ -226,20 +227,10 @@ internal actual constructor(
   // TODO move lastIndexOf() when https://youtrack.jetbrains.com/issue/KT-22818 is fixed
 
   @JvmOverloads
-  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = lastIndexOf(other.internalArray(),
-      fromIndex)
+  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
 
   @JvmOverloads
-  open fun lastIndexOf(other: ByteArray, fromIndex: Int = size): Int {
-    var fromIndex = fromIndex
-    fromIndex = minOf(fromIndex, data.size - other.size)
-    for (i in fromIndex downTo 0) {
-      if (arrayRangeEquals(data, i, other, 0, other.size)) {
-        return i
-      }
-    }
-    return -1
-  }
+  open fun lastIndexOf(other: ByteArray, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
 
   actual override fun equals(other: Any?) = commonEquals(other)
 

--- a/okio/jvm/src/main/java/okio/ByteString.kt
+++ b/okio/jvm/src/main/java/okio/ByteString.kt
@@ -98,7 +98,7 @@ internal actual constructor(
   /** Returns the 512-bit SHA-512 hash of this byte string.  */
   open fun sha512() = digest("SHA-512")
 
-  private fun digest(algorithm: String) =
+  internal open fun digest(algorithm: String) =
       ByteString(MessageDigest.getInstance(algorithm).digest(data))
 
   /** Returns the 160-bit SHA-1 HMAC of this byte string.  */
@@ -110,7 +110,7 @@ internal actual constructor(
   /** Returns the 512-bit SHA-512 HMAC of this byte string.  */
   open fun hmacSha512(key: ByteString) = hmac("HmacSHA512", key)
 
-  private fun hmac(algorithm: String, key: ByteString): ByteString {
+  internal open fun hmac(algorithm: String, key: ByteString): ByteString {
     try {
       val mac = Mac.getInstance(algorithm)
       mac.init(SecretKeySpec(key.toByteArray(), algorithm))

--- a/okio/jvm/src/main/java/okio/SegmentedByteString.kt
+++ b/okio/jvm/src/main/java/okio/SegmentedByteString.kt
@@ -87,8 +87,6 @@ internal class SegmentedByteString(buffer: Buffer, byteCount: Int) : ByteString(
     this.segments = segments as Array<ByteArray>
   }
 
-  override fun utf8() = toByteString().utf8()
-
   override fun string(charset: Charset) = toByteString().string(charset)
 
   override fun base64() = toByteString().base64()

--- a/okio/jvm/src/main/java/okio/SegmentedByteString.kt
+++ b/okio/jvm/src/main/java/okio/SegmentedByteString.kt
@@ -239,11 +239,6 @@ internal class SegmentedByteString private constructor(
     return true
   }
 
-  override fun indexOf(other: ByteArray, fromIndex: Int) = toByteString().indexOf(other, fromIndex)
-
-  override fun lastIndexOf(other: ByteArray, fromIndex: Int) = toByteString().lastIndexOf(other,
-      fromIndex)
-
   /** Returns a copy as a non-segmented byte string.  */
   private fun toByteString() = ByteString(toByteArray())
 

--- a/okio/jvm/src/main/java/okio/SegmentedByteString.kt
+++ b/okio/jvm/src/main/java/okio/SegmentedByteString.kt
@@ -240,6 +240,11 @@ internal class SegmentedByteString private constructor(
     return true
   }
 
+  override fun indexOf(other: ByteArray, fromIndex: Int) = toByteString().indexOf(other, fromIndex)
+
+  override fun lastIndexOf(other: ByteArray, fromIndex: Int) = toByteString().lastIndexOf(other,
+      fromIndex)
+
   /** Returns a copy as a non-segmented byte string.  */
   private fun toByteString() = ByteString(toByteArray())
 

--- a/okio/native/src/main/kotlin/okio/ByteString.kt
+++ b/okio/native/src/main/kotlin/okio/ByteString.kt
@@ -145,13 +145,13 @@ internal actual constructor(
 
   actual fun endsWith(suffix: ByteArray) = commonEndsWith(suffix)
 
-  actual fun indexOf(other: ByteString, fromIndex: Int) = commonIndexOf(other, fromIndex)
+  actual fun indexOf(other: ByteString, fromIndex: Int) = indexOf(other.internalArray(), fromIndex)
 
   actual open fun indexOf(other: ByteArray, fromIndex: Int) = commonIndexOf(other, fromIndex)
 
   // TODO move lastIndexOf() when https://youtrack.jetbrains.com/issue/KT-22818 is fixed
 
-  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
+  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = lastIndexOf(other.internalArray(), fromIndex)
 
   fun lastIndexOf(other: ByteArray, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
 

--- a/okio/native/src/main/kotlin/okio/ByteString.kt
+++ b/okio/native/src/main/kotlin/okio/ByteString.kt
@@ -31,6 +31,7 @@ import okio.internal.commonHashCode
 import okio.internal.commonHex
 import okio.internal.commonIndexOf
 import okio.internal.commonInternalArray
+import okio.internal.commonLastIndexOf
 import okio.internal.commonOf
 import okio.internal.commonRangeEquals
 import okio.internal.commonStartsWith
@@ -144,25 +145,15 @@ internal actual constructor(
 
   actual fun endsWith(suffix: ByteArray) = commonEndsWith(suffix)
 
-  actual fun indexOf(other: ByteString, fromIndex: Int) = indexOf(other.internalArray(), fromIndex)
+  actual fun indexOf(other: ByteString, fromIndex: Int) = commonIndexOf(other, fromIndex)
 
   actual open fun indexOf(other: ByteArray, fromIndex: Int) = commonIndexOf(other, fromIndex)
 
   // TODO move lastIndexOf() when https://youtrack.jetbrains.com/issue/KT-22818 is fixed
 
-  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = lastIndexOf(other.internalArray(),
-    fromIndex)
+  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
 
-  open fun lastIndexOf(other: ByteArray, fromIndex: Int = size): Int {
-    var fromIndex = fromIndex
-    fromIndex = minOf(fromIndex, data.size - other.size)
-    for (i in fromIndex downTo 0) {
-      if (arrayRangeEquals(data, i, other, 0, other.size)) {
-        return i
-      }
-    }
-    return -1
-  }
+  fun lastIndexOf(other: ByteArray, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
 
   actual override fun equals(other: Any?) = commonEquals(other)
 

--- a/okio/src/main/kotlin/okio/internal/ByteString.kt
+++ b/okio/src/main/kotlin/okio/internal/ByteString.kt
@@ -168,10 +168,42 @@ internal fun ByteString.commonEndsWith(suffix: ByteString) =
 internal fun ByteString.commonEndsWith(suffix: ByteArray) =
     rangeEquals(size - suffix.size, suffix, 0, suffix.size)
 
-internal fun ByteString.commonIndexOf(other: ByteArray, fromIndex: Int): Int {
-  val limit = data.size - other.size
+internal fun ByteString.commonIndexOf(other: ByteString, fromIndex: Int): Int {
+  val limit = size - other.size
   for (i in maxOf(fromIndex, 0)..limit) {
-    if (arrayRangeEquals(data, i, other, 0, other.size)) {
+    if (rangeEquals(i, other, 0, other.size)) {
+      return i
+    }
+  }
+  return -1
+}
+
+internal fun ByteString.commonIndexOf(other: ByteArray, fromIndex: Int): Int {
+  val limit = size - other.size
+  for (i in maxOf(fromIndex, 0)..limit) {
+    if (rangeEquals(i, other, 0, other.size)) {
+      return i
+    }
+  }
+  return -1
+}
+
+internal fun ByteString.commonLastIndexOf(other: ByteString, fromIndex: Int): Int {
+  var fromIndex = fromIndex
+  fromIndex = minOf(fromIndex, size - other.size)
+  for (i in fromIndex downTo 0) {
+    if (rangeEquals(i, other, 0, other.size)) {
+      return i
+    }
+  }
+  return -1
+}
+
+internal fun ByteString.commonLastIndexOf(other: ByteArray, fromIndex: Int): Int {
+  var fromIndex = fromIndex
+  fromIndex = minOf(fromIndex, size - other.size)
+  for (i in fromIndex downTo 0) {
+    if (rangeEquals(i, other, 0, other.size)) {
       return i
     }
   }

--- a/okio/src/main/kotlin/okio/internal/ByteString.kt
+++ b/okio/src/main/kotlin/okio/internal/ByteString.kt
@@ -168,30 +168,10 @@ internal fun ByteString.commonEndsWith(suffix: ByteString) =
 internal fun ByteString.commonEndsWith(suffix: ByteArray) =
     rangeEquals(size - suffix.size, suffix, 0, suffix.size)
 
-internal fun ByteString.commonIndexOf(other: ByteString, fromIndex: Int): Int {
-  val limit = size - other.size
-  for (i in maxOf(fromIndex, 0)..limit) {
-    if (rangeEquals(i, other, 0, other.size)) {
-      return i
-    }
-  }
-  return -1
-}
-
 internal fun ByteString.commonIndexOf(other: ByteArray, fromIndex: Int): Int {
-  val limit = size - other.size
+  val limit = data.size - other.size
   for (i in maxOf(fromIndex, 0)..limit) {
-    if (rangeEquals(i, other, 0, other.size)) {
-      return i
-    }
-  }
-  return -1
-}
-
-internal fun ByteString.commonLastIndexOf(other: ByteString, fromIndex: Int): Int {
-  val limit = size - other.size
-  for (i in minOf(fromIndex, limit) downTo 0) {
-    if (rangeEquals(i, other, 0, other.size)) {
+    if (arrayRangeEquals(data, i, other, 0, other.size)) {
       return i
     }
   }
@@ -199,9 +179,9 @@ internal fun ByteString.commonLastIndexOf(other: ByteString, fromIndex: Int): In
 }
 
 internal fun ByteString.commonLastIndexOf(other: ByteArray, fromIndex: Int): Int {
-  val limit = size - other.size
+  val limit = data.size - other.size
   for (i in minOf(fromIndex, limit) downTo 0) {
-    if (rangeEquals(i, other, 0, other.size)) {
+    if (arrayRangeEquals(data, i, other, 0, other.size)) {
       return i
     }
   }

--- a/okio/src/main/kotlin/okio/internal/ByteString.kt
+++ b/okio/src/main/kotlin/okio/internal/ByteString.kt
@@ -37,7 +37,7 @@ internal fun ByteString.commonUtf8(): String {
   var result = utf8
   if (result == null) {
     // We don't care if we double-allocate in racy code.
-    result = data.toUtf8String()
+    result = internalArray().toUtf8String()
     utf8 = result
   }
   return result

--- a/okio/src/main/kotlin/okio/internal/ByteString.kt
+++ b/okio/src/main/kotlin/okio/internal/ByteString.kt
@@ -189,9 +189,8 @@ internal fun ByteString.commonIndexOf(other: ByteArray, fromIndex: Int): Int {
 }
 
 internal fun ByteString.commonLastIndexOf(other: ByteString, fromIndex: Int): Int {
-  var fromIndex = fromIndex
-  fromIndex = minOf(fromIndex, size - other.size)
-  for (i in fromIndex downTo 0) {
+  val limit = size - other.size
+  for (i in minOf(fromIndex, limit) downTo 0) {
     if (rangeEquals(i, other, 0, other.size)) {
       return i
     }
@@ -200,9 +199,8 @@ internal fun ByteString.commonLastIndexOf(other: ByteString, fromIndex: Int): In
 }
 
 internal fun ByteString.commonLastIndexOf(other: ByteArray, fromIndex: Int): Int {
-  var fromIndex = fromIndex
-  fromIndex = minOf(fromIndex, size - other.size)
-  for (i in fromIndex downTo 0) {
+  val limit = size - other.size
+  for (i in minOf(fromIndex, limit) downTo 0) {
     if (rangeEquals(i, other, 0, other.size)) {
       return i
     }


### PR DESCRIPTION
Inspired after #514, I started taking a look at creating a substring for SegmentedByteString that shared segments and didn't convert to a normal first ByteString. This lead me down a road of a bunch of different optimizations that could be made to SegmentedByteString to simplify and reduce the amount of converting to a single ByteArray.

I've included each improvement as a separate commit to hopefully make reviewing it in isolation easier. I also did this in case you didn't want to include any of them, it should be pretty easy to just rebase out the commit.