### PR TITLE
Long division in Throttler can cause infinite wait

### DIFF
--- a/okio/jvm/src/test/java/okio/ThrottlerTest.kt
+++ b/okio/jvm/src/test/java/okio/ThrottlerTest.kt
@@ -21,6 +21,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 
 class ThrottlerTest {
@@ -267,5 +268,16 @@ class ThrottlerTest {
       future.get()
     }
     stopwatch.assertElapsed(1.0)
+  }
+
+  @Test fun infiniteWait() {
+    val throttlerLocal = Throttler()
+    throttlerLocal.bytesPerSecond(size - 1, maxByteCount = 8192)
+    val future =
+      executorService.submit {
+        val source = randomSource(size)
+        source.buffer().readAll(throttlerLocal.sink(blackholeSink()))
+      }
+    future.get(2, TimeUnit.SECONDS)
   }
 }


### PR DESCRIPTION
Found this issue when messing around with the Throttler. Creating a failing unit test and pull request to discuss the best possible fix.

Preconditions:
- Completely idle Thorttler
- `waitByteCount` and `maxByteCount` are equal
- `bytesPerSecond` not an even divisor of `maxByteCount` and `1e9`

Basically we are trying to induce integer truncation in the `nanosForMaxByteCount` calculation. This will find its way to the `take()` method when calculating `immediateBytes` which will be inaccurate because of the truncation and result in having to wait. The problem comes when the `byteCountNanos` for waiting is calculated, it will have the same value as `usableNanos` because the Throttler is idle (`idleInNanos=0`) and result in a wait of `0`. Thus infinite waiting.

Possible solutions:
1. I had success converting `nanosForMaxByteCount` to a Double.
2. Disallow `maxByteCount` to be equal to `waitByteCount`. I've found a few vary large `bytesPerSecond` values (like `3e9+1`) that still don't work with this solution though.
3. ?
