### PR TITLE
Proof of concept for de-duplicating some coroutines code.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 buildscript {
   ext.versions = [
-      'kotlin': '1.2.60',
-      'kotlinNative': '0.8.2',
+      'kotlin': '1.3.0',
+      'kotlinNative': '1.3.0',
+      'kotlinCoroutinesCore': '1.0.0',
       'jmhPlugin': '0.4.5',
       'animalSnifferPlugin': '1.4.3',
       'dokka': '0.9.16',
@@ -32,8 +33,11 @@ buildscript {
               'js': "org.jetbrains.kotlin:kotlin-test-js",
           ],
           'native': [
-              'gradlePlugin': "org.jetbrains.kotlin:kotlin-native-gradle-plugin:${versions.kotlinNative}",
+              'gradlePlugin': "org.jetbrains.kotlin:kotlin-native-gradle-plugin:${versions.kotlin}",
           ]
+      ],
+      'kotlinx': [
+          'coroutinesCore': "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutinesCore}",
       ],
       'jmh': [
           'gradlePlugin': "me.champeau.gradle:jmh-gradle-plugin:${versions.jmhPlugin}",

--- a/okio/jvm/build.gradle
+++ b/okio/jvm/build.gradle
@@ -10,8 +10,21 @@ apply plugin: 'me.champeau.gradle.jmh'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+compileKotlin {
+  kotlinOptions {
+    jvmTarget = "1.8"
+    freeCompilerArgs = ['-Xjvm-default=enable']
+  }
+}
+compileTestKotlin {
+  kotlinOptions {
+    jvmTarget = "1.8"
+    freeCompilerArgs = ['-Xjvm-default=enable']
+  }
+}
 
 jar {
   manifest {
@@ -51,6 +64,7 @@ dependencies {
   expectedBy project(':okio')
 
   implementation deps.kotlin.stdLib.jdk6
+  implementation deps.kotlinx.coroutinesCore
   compileOnly deps.animalSniffer.annotations
   testImplementation deps.test.junit
   testImplementation deps.test.assertj

--- a/okio/jvm/src/main/java/okio/BufferedSink.kt
+++ b/okio/jvm/src/main/java/okio/BufferedSink.kt
@@ -353,6 +353,8 @@ interface BufferedSink : Sink, WritableByteChannel {
   @Throws(IOException::class)
   fun emitCompleteSegments(): BufferedSink
 
+  suspend fun emitCompleteSegmentsAsync(): BufferedSink
+
   /** Returns an output stream that writes to this sink. */
   fun outputStream(): OutputStream
 }

--- a/okio/jvm/src/main/java/okio/BufferedSource.kt
+++ b/okio/jvm/src/main/java/okio/BufferedSource.kt
@@ -43,12 +43,16 @@ interface BufferedSource : Source, ReadableByteChannel {
   @Throws(IOException::class)
   fun exhausted(): Boolean
 
-  /**
+  suspend fun exhaustedAsync(): Boolean
+
+    /**
    * Returns when the buffer contains at least `byteCount` bytes. Throws an
    * [java.io.EOFException] if the source is exhausted before the required bytes can be read.
    */
   @Throws(IOException::class)
   fun require(byteCount: Long)
+
+  suspend fun requireAsync(byteCount: Long)
 
   /**
    * Returns true when the buffer contains at least `byteCount` bytes, expanding it as
@@ -56,6 +60,8 @@ interface BufferedSource : Source, ReadableByteChannel {
    */
   @Throws(IOException::class)
   fun request(byteCount: Long): Boolean
+
+  suspend fun requestAsync(byteCount: Long): Boolean
 
   /** Removes a byte from this source and returns it. */
   @Throws(IOException::class)
@@ -338,6 +344,9 @@ interface BufferedSource : Source, ReadableByteChannel {
    */
   @Throws(IOException::class)
   fun readAll(sink: Sink): Long
+
+  @Throws(IOException::class)
+  suspend fun readAllAsync(sink: Sink): Long
 
   /**
    * Removes all bytes from this, decodes them as UTF-8, and returns the string. Returns the empty

--- a/okio/jvm/src/main/java/okio/ForwardingSink.kt
+++ b/okio/jvm/src/main/java/okio/ForwardingSink.kt
@@ -29,12 +29,22 @@ abstract class ForwardingSink(
   override fun write(source: Buffer, byteCount: Long) = delegate.write(source, byteCount)
 
   @Throws(IOException::class)
+  override suspend fun writeAsync(source: Buffer, byteCount: Long) =
+    delegate.writeAsync(source, byteCount)
+
+  @Throws(IOException::class)
   override fun flush() = delegate.flush()
+
+  @Throws(IOException::class)
+  override suspend fun flushAsync() = delegate.flushAsync()
 
   override fun timeout() = delegate.timeout()
 
   @Throws(IOException::class)
   override fun close() = delegate.close()
+
+  @Throws(IOException::class)
+  override suspend fun closeAsync() = delegate.closeAsync()
 
   override fun toString() = "${javaClass.simpleName}($delegate)"
 

--- a/okio/jvm/src/main/java/okio/ForwardingSource.kt
+++ b/okio/jvm/src/main/java/okio/ForwardingSource.kt
@@ -28,10 +28,15 @@ abstract class ForwardingSource(
   @Throws(IOException::class)
   override fun read(sink: Buffer, byteCount: Long): Long = delegate.read(sink, byteCount)
 
+  override suspend fun readAsync(sink: Buffer, byteCount: Long) =
+    delegate.readAsync(sink, byteCount)
+
   override fun timeout() = delegate.timeout()
 
   @Throws(IOException::class)
   override fun close() = delegate.close()
+
+  override suspend fun closeAsync() = delegate.closeAsync()
 
   override fun toString() = "${javaClass.simpleName}($delegate)"
 

--- a/okio/jvm/src/main/java/okio/Okio.kt
+++ b/okio/jvm/src/main/java/okio/Okio.kt
@@ -123,9 +123,12 @@ fun blackholeSink(): Sink = BlackholeSink()
 
 private class BlackholeSink : Sink {
   override fun write(source: Buffer, byteCount: Long) = source.skip(byteCount)
+  override suspend fun writeAsync(source: Buffer, byteCount: Long) = write(source, byteCount)
   override fun flush() {}
+  override suspend fun flushAsync() {}
   override fun timeout() = Timeout.NONE
   override fun close() {}
+  override suspend fun closeAsync() {}
 }
 
 /**

--- a/okio/jvm/src/main/java/okio/Sink.kt
+++ b/okio/jvm/src/main/java/okio/Sink.kt
@@ -15,6 +15,8 @@
  */
 package okio
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.Closeable
 import java.io.Flushable
 import java.io.IOException
@@ -51,9 +53,23 @@ interface Sink : Closeable, Flushable {
   @Throws(IOException::class)
   fun write(source: Buffer, byteCount: Long)
 
+  /** Non-blocking variant of [write]. Uses the IO dispatcher if blocking is necessary. */
+  @Throws(IOException::class)
+  @JvmDefault
+  suspend fun writeAsync(source: Buffer, byteCount: Long) = withContext(Dispatchers.IO) {
+    write(source, byteCount)
+  }
+
   /** Pushes all buffered bytes to their final destination.  */
   @Throws(IOException::class)
   override fun flush()
+
+  /** Non-blocking variant of [flush]. Uses the IO dispatcher if blocking is necessary. */
+  @Throws(IOException::class)
+  @JvmDefault
+  suspend fun flushAsync() = withContext(Dispatchers.IO) {
+    flush()
+  }
 
   /** Returns the timeout for this sink.  */
   fun timeout(): Timeout
@@ -64,4 +80,11 @@ interface Sink : Closeable, Flushable {
    */
   @Throws(IOException::class)
   override fun close()
+
+  /** Non-blocking variant of [close]. Uses the IO dispatcher if blocking is necessary. */
+  @Throws(IOException::class)
+  @JvmDefault
+  suspend fun closeAsync() = withContext(Dispatchers.IO) {
+    close()
+  }
 }

--- a/okio/jvm/src/main/java/okio/Source.kt
+++ b/okio/jvm/src/main/java/okio/Source.kt
@@ -15,6 +15,8 @@
  */
 package okio
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.Closeable
 import java.io.IOException
 
@@ -61,6 +63,13 @@ interface Source : Closeable {
   @Throws(IOException::class)
   fun read(sink: Buffer, byteCount: Long): Long
 
+  /** Non-blocking variant of [read]. Uses the IO dispatcher if blocking is necessary. */
+  @Throws(IOException::class)
+  @JvmDefault
+  suspend fun readAsync(sink: Buffer, byteCount: Long): Long = withContext(Dispatchers.IO) {
+    read(sink, byteCount)
+  }
+
   /** Returns the timeout for this source.  */
   fun timeout(): Timeout
 
@@ -70,4 +79,11 @@ interface Source : Closeable {
    */
   @Throws(IOException::class)
   override fun close()
+
+  /** Non-blocking variant of [close]. Uses the IO dispatcher if blocking is necessary. */
+  @Throws(IOException::class)
+  @JvmDefault
+  suspend fun closeAsync() = withContext(Dispatchers.IO) {
+    close()
+  }
 }

--- a/okio/jvm/src/test/java/okio/TestUtil.kt
+++ b/okio/jvm/src/test/java/okio/TestUtil.kt
@@ -93,12 +93,16 @@ object TestUtil {
         }
       }
 
+      override suspend fun readAsync(sink: Buffer, byteCount: Long) = read(sink, byteCount)
+
       override fun timeout() = Timeout.NONE
 
       @Throws(IOException::class)
       override fun close() {
         closed = true
       }
+
+      override suspend fun closeAsync() = close()
     }
   }
 

--- a/okio/jvm/src/test/java/okio/ThrottlerTest.kt
+++ b/okio/jvm/src/test/java/okio/ThrottlerTest.kt
@@ -15,6 +15,7 @@
  */
 package okio
 
+import kotlinx.coroutines.runBlocking
 import okio.TestUtil.randomSource
 import org.junit.After
 import org.junit.Before
@@ -155,5 +156,15 @@ class ThrottlerTest {
       future.get()
     }
     stopwatch.assertElapsed(1.0)
+  }
+
+  @Test fun asyncSource() = runBlocking {
+    throttler.source(source).buffer().readAllAsync(blackholeSink())
+    stopwatch.assertElapsed(0.25)
+  }
+
+  @Test fun asyncSink() = runBlocking {
+    source.buffer().readAllAsync(throttler.sink(blackholeSink()))
+    stopwatch.assertElapsed(0.25)
   }
 }


### PR DESCRIPTION
This pulls the common code from the `read` and `readAsync` methods out into an inline method that takes a function parameter for the actual read call. Inline functions can take suspending lambdas when called from suspend functions, so this is re-useable from both sync and async methods. This pattern could be copied for all the other methods.