### PR TITLE
Copy KDoc for common interfaces from JVM

### DIFF
--- a/okio/src/main/kotlin/okio/BufferedSink.kt
+++ b/okio/src/main/kotlin/okio/BufferedSink.kt
@@ -16,4 +16,8 @@
 
 package okio
 
+/**
+ * A sink that keeps a buffer internally so that callers can do small writes without a performance
+ * penalty.
+ */
 expect interface BufferedSink : Sink

--- a/okio/src/main/kotlin/okio/BufferedSource.kt
+++ b/okio/src/main/kotlin/okio/BufferedSource.kt
@@ -16,4 +16,9 @@
 
 package okio
 
+/**
+ * A source that keeps a buffer internally so that callers can do small reads without a performance
+ * penalty. It also allows clients to read ahead, buffering as much as necessary before consuming
+ * input.
+ */
 expect interface BufferedSource : Source

--- a/okio/src/main/kotlin/okio/Sink.kt
+++ b/okio/src/main/kotlin/okio/Sink.kt
@@ -16,4 +16,15 @@
 
 package okio
 
+/**
+ * Receives a stream of bytes. Use this interface to write data wherever it's needed: to the
+ * network, storage, or a buffer in memory. Sinks may be layered to transform received data, such as
+ * to compress, encrypt, throttle, or add protocol framing.
+ *
+ * Most application code shouldn't operate on a sink directly, but rather on a [BufferedSink] which
+ * is both more efficient and more convenient. Use [buffer] to wrap any sink with a buffer.
+ *
+ * Sinks are easy to test: just use a [Buffer] in your tests, and read from it to confirm it
+ * received the data that was expected.
+ */
 expect interface Sink

--- a/okio/src/main/kotlin/okio/Source.kt
+++ b/okio/src/main/kotlin/okio/Source.kt
@@ -16,4 +16,15 @@
 
 package okio
 
+/**
+ * Supplies a stream of bytes. Use this interface to read data from wherever it's located: from the
+ * network, storage, or a buffer in memory. Sources may be layered to transform supplied data, such
+ * as to decompress, decrypt, or remove protocol framing.
+ *
+ * Most applications shouldn't operate on a source directly, but rather on a [BufferedSource] which
+ * is both more efficient and more convenient. Use [buffer] to wrap any source with a buffer.
+ *
+ * Sources are easy to test: just use a [Buffer] in your tests, and fill it with the data your
+ * application is to read.
+ */
 expect interface Source


### PR DESCRIPTION
These are not rendered as of now but it should get fixed in the next Dokka release. Unclear what the KDoc merging strategy is going to be, hopefully they'll be merging common KDoc with platform-specific: `Source` and `Sink` have paragraphs on `InputStream` and `OutputStream` comparisons which should ideally live in the JVM module.