### PR TITLE
Update japicmp plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ buildscript {
           'gradlePlugin': "ru.vyarus:gradle-animalsniffer-plugin:${versions.animalSnifferPlugin}",
           'annotations': "org.codehaus.mojo:animal-sniffer-annotations:${versions.animalSniffer}",
       ],
-      'japicmp': 'me.champeau.gradle:japicmp-gradle-plugin:0.2.6',
+      'japicmp': 'me.champeau.gradle:japicmp-gradle-plugin:0.2.8',
       'dokka': "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
       'shadow': "com.github.jengelman.gradle.plugins:shadow:${versions.shadowPlugin}",
       'node': "com.moowork.gradle:gradle-node-plugin:${versions.nodePlugin}",

--- a/okio/jvm/japicmp/build.gradle
+++ b/okio/jvm/japicmp/build.gradle
@@ -25,16 +25,14 @@ task japicmp(type: JapicmpTask, dependsOn: 'jar') {
   ignoreMissingClasses = true
   includeSynthetic = true
   classExcludes = [
+      'okio.RealBufferedSink', // Internal.
+      'okio.RealBufferedSource', // Internal.
       'okio.SegmentedByteString', // Internal.
       'okio.Util', // Internal.
   ]
   methodExcludes = [
       'okio.ByteString#getByte(int)', // Became 'final' in 1.15.0.
       'okio.ByteString#size()', // Became 'final' in 1.15.0.
-  ]
-  fieldExcludes = [
-      'okio.RealBufferedSink#buffer', // Became 'bufferField' in 2.1.0.
-      'okio.RealBufferedSource#buffer', // Became 'bufferField' in 2.1.0.
   ]
 }
 check.dependsOn japicmp


### PR DESCRIPTION
This bumps japicmp to 0.13.1 which still doesn't contain the effectively-final fix, but at least provides compatibility with newer japicmp versions so that we can upgrade once that change is released.