### PR TITLE
Configure Travis to run builds on OSX and publish artifacts for all platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
+os:
+  - osx
+
+osx_image: xcode9.3
+
 language: java
 
 jdk:
   - oraclejdk8
-
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer # Updates JDK 8 to the latest available.
 
 script:
   - ./gradlew clean build

--- a/gradle/gradle-mvn-mpp-push.gradle
+++ b/gradle/gradle-mvn-mpp-push.gradle
@@ -112,8 +112,7 @@ publishing {
     }
   }
   
-  // Use default artifact name for the JVM target until we start publishing artifacts for all
-  // platforms
+  // Use default artifact name for the JVM target
   publications {
     jvm {
       artifactId = 'okio'


### PR DESCRIPTION
Still figuring this out:
- ~Publishing doesn't seem to work without enabling `GRADLE_METADATA`, do we really need it?~
- ~Right now the JVM artifact gets published under the `okio` ID, which as I understand in multiplatform world get taken by the metadata artifact. I've also seen that SQLDelight's metadata is under `runtime-metadata`. Is there special config needed to get `okio-metadata` to contain metadata, and `okio` to contain the JVM artifact?~