### PR TITLE
Rename common artifact to 'okio-multiplatform' to avoid name clash

### DIFF
--- a/gradle/gradle-mvn-mpp-push.gradle
+++ b/gradle/gradle-mvn-mpp-push.gradle
@@ -114,6 +114,9 @@ publishing {
   
   // Use default artifact name for the JVM target
   publications {
+    kotlinMultiplatform {
+      artifactId = 'okio-multiplatform'
+    }
     jvm {
       artifactId = 'okio'
     }


### PR DESCRIPTION
With current setup JVM artifact gets published on top of the common one, which makes it impossible to consume the library from a multiplatform project. Removing artifact name override for the JVM module will change it to `okio-jvm`, which will break existing library users (more precisely, existing users that don't use Gradle, whoever is consuming Okio through Gradle is fine thanks to metadata). I suggest overriding the common artifact name to `okio-multiplatform`, probably until 3.0.