### PR TITLE
Add Buffer implementation to Kotlin/JS and Kotlin/Native

### DIFF
--- a/okio/src/commonMain/kotlin/okio/-Util.kt
+++ b/okio/src/commonMain/kotlin/okio/-Util.kt
@@ -18,6 +18,7 @@
 
 package okio
 
+import okio.internal.HEX_DIGITS
 import kotlin.jvm.JvmName
 
 internal fun checkOffsetAndCount(size: Long, offset: Long, byteCount: Long) {
@@ -87,4 +88,29 @@ internal fun arrayRangeEquals(
     if (a[i + aOffset] != b[i + bOffset]) return false
   }
   return true
+}
+
+internal fun Byte.toHexString(): String {
+  val result = CharArray(4)
+  result[0] = '0'
+  result[1] = 'x'
+  result[2] = HEX_DIGITS[this shr 4 and 0xf]
+  result[3] = HEX_DIGITS[this       and 0xf] // ktlint-disable no-multi-spaces
+  return String(result)
+}
+
+internal fun Int.toHexString(): String {
+  // Should this trim leading 0's?
+  val result = CharArray(10)
+  result[0] = '0'
+  result[1] = 'x'
+  result[2] = HEX_DIGITS[this shr 28 and 0xf]
+  result[3] = HEX_DIGITS[this shr 24 and 0xf]
+  result[4] = HEX_DIGITS[this shr 20 and 0xf]
+  result[5] = HEX_DIGITS[this shr 16 and 0xf]
+  result[6] = HEX_DIGITS[this shr 12 and 0xf]
+  result[7] = HEX_DIGITS[this shr 8  and 0xf] // ktlint-disable no-multi-spaces
+  result[8] = HEX_DIGITS[this shr 4  and 0xf] // ktlint-disable no-multi-spaces
+  result[9] = HEX_DIGITS[this        and 0xf] // ktlint-disable no-multi-spaces
+  return String(result)
 }

--- a/okio/src/commonMain/kotlin/okio/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/Buffer.kt
@@ -42,6 +42,9 @@ expect class Buffer() : BufferedSource, BufferedSink {
     offset: Long = 0L
   ): Buffer
 
+  /** Returns the byte at `pos`.  */
+  operator fun get(pos: Long): Byte
+
   fun clear()
 
   override fun skip(byteCount: Long)

--- a/okio/src/commonMain/kotlin/okio/BufferedSource.kt
+++ b/okio/src/commonMain/kotlin/okio/BufferedSource.kt
@@ -48,6 +48,8 @@ expect interface BufferedSource : Source {
 
   fun readByteString(byteCount: Long): ByteString
 
+  fun select(options: Options): Int
+
   fun readByteArray(): ByteArray
 
   fun readByteArray(byteCount: Long): ByteArray

--- a/okio/src/commonMain/kotlin/okio/SegmentPool.kt
+++ b/okio/src/commonMain/kotlin/okio/SegmentPool.kt
@@ -15,10 +15,13 @@
  */
 package okio
 
+import kotlin.native.concurrent.ThreadLocal
+
 /**
  * A collection of unused segments, necessary to avoid GC churn and zero-fill.
  * This pool is a thread-safe static singleton.
  */
+@ThreadLocal
 internal object SegmentPool {
   /** The maximum number of bytes to pool.  */
   // TODO: Is 64 KiB a good maximum size? Do we ever have that many idle segments?

--- a/okio/src/commonMain/kotlin/okio/internal/-Utf8.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/-Utf8.kt
@@ -23,11 +23,12 @@ import okio.processUtf16Chars
 // to everything else. Putting them in this file, `-Utf8.kt`, makes them invisible to
 // Java but still visible to Kotlin.
 
-fun ByteArray.commonToUtf8String(): String {
-  val chars = CharArray(size)
+fun ByteArray.commonToUtf8String(offset: Int = 0, byteCount: Int = size): String {
+  require(offset + byteCount <= size) { "offset=$offset byteCount=$byteCount size=$size" }
+  val chars = CharArray(byteCount)
 
   var length = 0
-  processUtf16Chars(0, size) { c ->
+  processUtf16Chars(offset, offset + byteCount) { c ->
     chars[length++] = c
   }
 

--- a/okio/src/commonMain/kotlin/okio/internal/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/Buffer.kt
@@ -13,15 +13,213 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// TODO move to Buffer class: https://youtrack.jetbrains.com/issue/KT-20427
+@file:Suppress("NOTHING_TO_INLINE")
+
 package okio.internal
 
 import okio.Buffer
 import okio.ByteString
 import okio.EOFException
+import okio.Options
+import okio.REPLACEMENT_CODE_POINT
 import okio.Segment
 import okio.SegmentPool
+import okio.Sink
+import okio.Source
+import okio.and
+import okio.asUtf8ToByteArray
 import okio.checkOffsetAndCount
+import okio.toHexString
 import okio.minOf
+
+private val DIGITS = "0123456789abcdef".asUtf8ToByteArray()
+
+/**
+ * Returns true if the range within this buffer starting at `segmentPos` in `segment` is equal to
+ * `bytes[bytesOffset..bytesLimit)`.
+ */
+internal fun rangeEquals(
+  segment: Segment,
+  segmentPos: Int,
+  bytes: ByteArray,
+  bytesOffset: Int,
+  bytesLimit: Int
+): Boolean {
+  var segment = segment
+  var segmentPos = segmentPos
+  var segmentLimit = segment.limit
+  var data = segment.data
+
+  var i = bytesOffset
+  while (i < bytesLimit) {
+    if (segmentPos == segmentLimit) {
+      segment = segment.next!!
+      data = segment.data
+      segmentPos = segment.pos
+      segmentLimit = segment.limit
+    }
+
+    if (data[segmentPos] != bytes[i]) {
+      return false
+    }
+
+    segmentPos++
+    i++
+  }
+
+  return true
+}
+
+internal inline fun Buffer.readUtf8Line(newline: Long): String {
+  return when {
+    newline > 0 && this[newline - 1] == '\r'.toByte() -> {
+      // Read everything until '\r\n', then skip the '\r\n'.
+      val result = readUtf8(newline - 1L)
+      skip(2L)
+      result
+    }
+    else -> {
+      // Read everything until '\n', then skip the '\n'.
+      val result = readUtf8(newline)
+      skip(1L)
+      result
+    }
+  }
+}
+
+/**
+ * Invoke `lambda` with the segment and offset at `fromIndex`. Searches from the front or the back
+ * depending on what's closer to `fromIndex`.
+ */
+internal inline fun <T> Buffer.seek(
+  fromIndex: Long,
+  lambda: (Segment?, Long) -> T
+): T {
+  var s: Segment = head ?: return lambda(null, -1L)
+
+  if (size - fromIndex < fromIndex) {
+    // We're scanning in the back half of this buffer. Find the segment starting at the back.
+    var offset = size
+    while (offset > fromIndex) {
+      s = s.prev!!
+      offset -= (s.limit - s.pos).toLong()
+    }
+    return lambda(s, offset)
+  } else {
+    // We're scanning in the front half of this buffer. Find the segment starting at the front.
+    var offset = 0L
+    while (true) {
+      val nextOffset = offset + (s.limit - s.pos)
+      if (nextOffset > fromIndex) break
+      s = s.next!!
+      offset = nextOffset
+    }
+    return lambda(s, offset)
+  }
+}
+
+/**
+ * Returns the index of a value in options that is a prefix of this buffer. Returns -1 if no value
+ * is found. This method does two simultaneous iterations: it iterates the trie and it iterates
+ * this buffer. It returns when it reaches a result in the trie, when it mismatches in the trie,
+ * and when the buffer is exhausted.
+ *
+ * @param selectTruncated true to return -2 if a possible result is present but truncated. For
+ *     example, this will return -2 if the buffer contains [ab] and the options are [abc, abd].
+ *     Note that this is made complicated by the fact that options are listed in preference order,
+ *     and one option may be a prefix of another. For example, this returns -2 if the buffer
+ *     contains [ab] and the options are [abc, a].
+ */
+internal fun Buffer.selectPrefix(options: Options, selectTruncated: Boolean = false): Int {
+  val head = head ?: return if (selectTruncated) -2 else -1
+
+  var s: Segment? = head
+  var data = head.data
+  var pos = head.pos
+  var limit = head.limit
+
+  val trie = options.trie
+  var triePos = 0
+
+  var prefixIndex = -1
+
+  navigateTrie@
+  while (true) {
+    val scanOrSelect = trie[triePos++]
+
+    val possiblePrefixIndex = trie[triePos++]
+    if (possiblePrefixIndex != -1) {
+      prefixIndex = possiblePrefixIndex
+    }
+
+    val nextStep: Int
+
+    if (s == null) {
+      break@navigateTrie
+    } else if (scanOrSelect < 0) {
+      // Scan: take multiple bytes from the buffer and the trie, looking for any mismatch.
+      val scanByteCount = -1 * scanOrSelect
+      val trieLimit = triePos + scanByteCount
+      while (true) {
+        val byte = data[pos++] and 0xff
+        if (byte != trie[triePos++]) return prefixIndex // Fail 'cause we found a mismatch.
+        val scanComplete = (triePos == trieLimit)
+
+        // Advance to the next buffer segment if this one is exhausted.
+        if (pos == limit) {
+          s = s!!.next!!
+          pos = s.pos
+          data = s.data
+          limit = s.limit
+          if (s === head) {
+            if (!scanComplete) break@navigateTrie // We were exhausted before the scan completed.
+            s = null // We were exhausted at the end of the scan.
+          }
+        }
+
+        if (scanComplete) {
+          nextStep = trie[triePos]
+          break
+        }
+      }
+    } else {
+      // Select: take one byte from the buffer and find a match in the trie.
+      val selectChoiceCount = scanOrSelect
+      val byte = data[pos++] and 0xff
+      val selectLimit = triePos + selectChoiceCount
+      while (true) {
+        if (triePos == selectLimit) return prefixIndex // Fail 'cause we didn't find a match.
+
+        if (byte == trie[triePos]) {
+          nextStep = trie[triePos + selectChoiceCount]
+          break
+        }
+
+        triePos++
+      }
+
+      // Advance to the next buffer segment if this one is exhausted.
+      if (pos == limit) {
+        s = s.next!!
+        pos = s.pos
+        data = s.data
+        limit = s.limit
+        if (s === head) {
+          s = null // No more segments! The next trie node will be our last.
+        }
+      }
+    }
+
+    if (nextStep >= 0) return nextStep // Found a matching option.
+    triePos = -nextStep // Found another node to continue the search.
+  }
+
+  // We break out of the loop above when we've exhausted the buffer without exhausting the trie.
+  if (selectTruncated) return -2 // The buffer is a prefix of at least one option.
+  return prefixIndex // Return any matches we encountered while searching for a deeper match.
+}
 
 // TODO Kotlin's expect classes can't have default implementations, so platform implementations
 // have to call these functions. Remove all this nonsense when expect class allow actual code.
@@ -86,41 +284,103 @@ internal fun Buffer.commonReadByte(): Byte {
   return b
 }
 
+internal inline fun Buffer.commonReadShort(): Short {
+  if (size < 2L) throw EOFException()
+
+  val segment = head!!
+  var pos = segment.pos
+  val limit = segment.limit
+
+  // If the short is split across multiple segments, delegate to readByte().
+  if (limit - pos < 2) {
+    val s = readByte() and 0xff shl 8 or (readByte() and 0xff)
+    return s.toShort()
+  }
+
+  val data = segment.data
+  val s = data[pos++] and 0xff shl 8 or (data[pos++] and 0xff)
+  size -= 2L
+
+  if (pos == limit) {
+    head = segment.pop()
+    SegmentPool.recycle(segment)
+  } else {
+    segment.pos = pos
+  }
+
+  return s.toShort()
+}
+
+internal inline fun Buffer.commonReadInt(): Int {
+  if (size < 4L) throw EOFException()
+
+  val segment = head!!
+  var pos = segment.pos
+  val limit = segment.limit
+
+  // If the int is split across multiple segments, delegate to readByte().
+  if (limit - pos < 4L) {
+    return (readByte() and 0xff shl 24
+      or (readByte() and 0xff shl 16)
+      or (readByte() and 0xff shl 8) // ktlint-disable no-multi-spaces
+      or (readByte() and 0xff))
+  }
+
+  val data = segment.data
+  val i = (data[pos++] and 0xff shl 24
+    or (data[pos++] and 0xff shl 16)
+    or (data[pos++] and 0xff shl 8)
+    or (data[pos++] and 0xff))
+  size -= 4L
+
+  if (pos == limit) {
+    head = segment.pop()
+    SegmentPool.recycle(segment)
+  } else {
+    segment.pos = pos
+  }
+
+  return i
+}
+
+internal inline fun Buffer.commonReadLong(): Long {
+  if (size < 8L) throw EOFException()
+
+  val segment = head!!
+  var pos = segment.pos
+  val limit = segment.limit
+
+  // If the long is split across multiple segments, delegate to readInt().
+  if (limit - pos < 8L) {
+    return (readInt() and 0xffffffffL shl 32
+      or (readInt() and 0xffffffffL))
+  }
+
+  val data = segment.data
+  val v = (data[pos++] and 0xffL shl 56
+    or (data[pos++] and 0xffL shl 48)
+    or (data[pos++] and 0xffL shl 40)
+    or (data[pos++] and 0xffL shl 32)
+    or (data[pos++] and 0xffL shl 24)
+    or (data[pos++] and 0xffL shl 16)
+    or (data[pos++] and 0xffL shl 8) // ktlint-disable no-multi-spaces
+    or (data[pos++] and 0xffL))
+  size -= 8L
+
+  if (pos == limit) {
+    head = segment.pop()
+    SegmentPool.recycle(segment)
+  } else {
+    segment.pos = pos
+  }
+
+  return v
+}
+
 internal fun Buffer.commonGet(pos: Long): Byte {
   checkOffsetAndCount(size, pos, 1L)
   seek(pos) { s, offset ->
     return s!!.data[(s.pos + pos - offset).toInt()]
-  }
-}
-
-/**
- * Invoke `lambda` with the segment and offset at `fromIndex`. Searches from the front or the back
- * depending on what's closer to `fromIndex`.
- */
-internal inline fun <T> Buffer.seek(
-  fromIndex: Long,
-  lambda: (Segment?, Long) -> T
-): T {
-  var s: Segment = head ?: return lambda(null, -1L)
-
-  if (size - fromIndex < fromIndex) {
-    // We're scanning in the back half of this buffer. Find the segment starting at the back.
-    var offset = size
-    while (offset > fromIndex) {
-      s = s.prev!!
-      offset -= (s.limit - s.pos).toLong()
-    }
-    return lambda(s, offset)
-  } else {
-    // We're scanning in the front half of this buffer. Find the segment starting at the front.
-    var offset = 0L
-    while (true) {
-      val nextOffset = offset + (s.limit - s.pos)
-      if (nextOffset > fromIndex) break
-      s = s.next!!
-      offset = nextOffset
-    }
-    return lambda(s, offset)
   }
 }
 
@@ -145,6 +405,72 @@ internal fun Buffer.commonSkip(byteCount: Long) {
 
 internal fun Buffer.commonWrite(byteString: ByteString): Buffer {
   byteString.write(this)
+  return this
+}
+
+internal inline fun Buffer.commonWriteDecimalLong(v: Long): Buffer {
+  var v = v
+  if (v == 0L) {
+    // Both a shortcut and required since the following code can't handle zero.
+    return writeByte('0'.toInt())
+  }
+
+  var negative = false
+  if (v < 0L) {
+    v = -v
+    if (v < 0L) { // Only true for Long.MIN_VALUE.
+      return writeUtf8("-9223372036854775808")
+    }
+    negative = true
+  }
+
+  // Binary search for character width which favors matching lower numbers.
+  var width =
+    if (v < 100000000L)
+      if (v < 10000L)
+        if (v < 100L)
+          if (v < 10L) 1
+          else 2
+        else if (v < 1000L) 3
+        else 4
+      else if (v < 1000000L)
+        if (v < 100000L) 5
+        else 6
+      else if (v < 10000000L) 7
+      else 8
+    else if (v < 1000000000000L)
+      if (v < 10000000000L)
+        if (v < 1000000000L) 9
+        else 10
+      else if (v < 100000000000L) 11
+      else 12
+    else if (v < 1000000000000000L)
+      if (v < 10000000000000L) 13
+      else if (v < 100000000000000L) 14
+      else 15
+    else if (v < 100000000000000000L)
+      if (v < 10000000000000000L) 16
+      else 17
+    else if (v < 1000000000000000000L) 18
+    else 19
+  if (negative) {
+    ++width
+  }
+
+  val tail = writableSegment(width)
+  val data = tail.data
+  var pos = tail.limit + width // We write backwards from right to left.
+  while (v != 0L) {
+    val digit = (v % 10).toInt()
+    data[--pos] = DIGITS[digit]
+    v /= 10
+  }
+  if (negative) {
+    data[--pos] = '-'.toByte()
+  }
+
+  tail.limit += width
+  this.size += width.toLong()
   return this
 }
 
@@ -242,3 +568,667 @@ internal fun Buffer.commonRead(sink: ByteArray, offset: Int, byteCount: Int): In
 internal fun Buffer.commonReadByteString(): ByteString = ByteString(readByteArray())
 
 internal fun Buffer.commonReadByteString(byteCount: Long) = ByteString(readByteArray(byteCount))
+
+internal inline fun Buffer.commonSelect(options: Options): Int {
+  val index = selectPrefix(options)
+  if (index == -1) return -1
+
+  // If the prefix match actually matched a full byte string, consume it and return it.
+  val selectedSize = options.byteStrings[index].size
+  skip(selectedSize.toLong())
+  return index
+}
+
+internal inline fun Buffer.commonReadFully(sink: Buffer, byteCount: Long) {
+  if (size < byteCount) {
+    sink.write(this, size) // Exhaust ourselves.
+    throw EOFException()
+  }
+  sink.write(this, byteCount)
+}
+
+internal inline fun Buffer.commonReadAll(sink: Sink): Long {
+  val byteCount = size
+  if (byteCount > 0L) {
+    sink.write(this, byteCount)
+  }
+  return byteCount
+}
+
+
+internal inline fun Buffer.commonReadUtf8(byteCount: Long): String {
+  require(byteCount >= 0 && byteCount <= Int.MAX_VALUE) { "byteCount: $byteCount" }
+  if (size < byteCount) throw EOFException()
+  if (byteCount == 0L) return ""
+
+  val s = head!!
+  if (s.pos + byteCount > s.limit) {
+    // If the string spans multiple segments, delegate to readBytes().
+
+    return readByteArray(byteCount).commonToUtf8String()
+  }
+
+
+  val result = s.data.commonToUtf8String(s.pos, byteCount.toInt())
+  s.pos += byteCount.toInt()
+  size -= byteCount
+
+  if (s.pos == s.limit) {
+    head = s.pop()
+    SegmentPool.recycle(s)
+  }
+
+  return result
+}
+
+internal inline fun Buffer.commonReadUtf8Line(): String? {
+  val newline = indexOf('\n'.toByte())
+
+  return when {
+    newline != -1L -> readUtf8Line(newline)
+    size != 0L -> readUtf8(size)
+    else -> null
+  }
+}
+
+internal inline fun Buffer.commonReadUtf8LineStrict(limit: Long): String {
+  require(limit >= 0L) { "limit < 0: $limit" }
+  val scanLength = if (limit == Long.MAX_VALUE) Long.MAX_VALUE else limit + 1L
+  val newline = indexOf('\n'.toByte(), 0L, scanLength)
+  if (newline != -1L) return readUtf8Line(newline)
+  if (scanLength < size &&
+    this[scanLength - 1] == '\r'.toByte() &&
+    this[scanLength] == '\n'.toByte()) {
+    return readUtf8Line(scanLength) // The line was 'limit' UTF-8 bytes followed by \r\n.
+  }
+  val data = Buffer()
+  copyTo(data, 0, okio.minOf(32, size))
+  throw EOFException("\\n not found: limit=${minOf(size,
+    limit)} content=${data.readByteString().hex()}${'…'}")
+}
+
+internal inline fun Buffer.commonReadUtf8CodePoint(): Int {
+  if (size == 0L) throw EOFException()
+
+  val b0 = this[0]
+  var codePoint: Int
+  val byteCount: Int
+  val min: Int
+
+  when {
+    b0 and 0x80 == 0 -> {
+      // 0xxxxxxx.
+      codePoint = b0 and 0x7f
+      byteCount = 1 // 7 bits (ASCII).
+      min = 0x0
+    }
+    b0 and 0xe0 == 0xc0 -> {
+      // 0x110xxxxx
+      codePoint = b0 and 0x1f
+      byteCount = 2 // 11 bits (5 + 6).
+      min = 0x80
+    }
+    b0 and 0xf0 == 0xe0 -> {
+      // 0x1110xxxx
+      codePoint = b0 and 0x0f
+      byteCount = 3 // 16 bits (4 + 6 + 6).
+      min = 0x800
+    }
+    b0 and 0xf8 == 0xf0 -> {
+      // 0x11110xxx
+      codePoint = b0 and 0x07
+      byteCount = 4 // 21 bits (3 + 6 + 6 + 6).
+      min = 0x10000
+    }
+    else -> {
+      // We expected the first byte of a code point but got something else.
+      skip(1)
+      return REPLACEMENT_CODE_POINT
+    }
+  }
+
+  if (size < byteCount) {
+    throw EOFException("size < $byteCount: $size (to read code point prefixed 0x${b0.toHexString()})")
+  }
+
+  // Read the continuation bytes. If we encounter a non-continuation byte, the sequence consumed
+  // thus far is truncated and is decoded as the replacement character. That non-continuation byte
+  // is left in the stream for processing by the next call to readUtf8CodePoint().
+  for (i in 1 until byteCount) {
+    val b = this[i.toLong()]
+    if (b and 0xc0 == 0x80) {
+      // 0x10xxxxxx
+      codePoint = codePoint shl 6
+      codePoint = codePoint or (b and 0x3f)
+    } else {
+      skip(i.toLong())
+      return REPLACEMENT_CODE_POINT
+    }
+  }
+
+  skip(byteCount.toLong())
+
+  return when {
+    codePoint > 0x10ffff -> {
+      REPLACEMENT_CODE_POINT // Reject code points larger than the Unicode maximum.
+    }
+    codePoint in 0xd800..0xdfff -> {
+      REPLACEMENT_CODE_POINT // Reject partial surrogates.
+    }
+    codePoint < min -> {
+      REPLACEMENT_CODE_POINT // Reject overlong code points.
+    }
+    else -> codePoint
+  }
+}
+
+internal inline fun Buffer.commonWriteUtf8(string: String, beginIndex: Int, endIndex: Int): Buffer {
+  require(beginIndex >= 0) { "beginIndex < 0: $beginIndex" }
+  require(endIndex >= beginIndex) { "endIndex < beginIndex: $endIndex < $beginIndex" }
+  require(endIndex <= string.length) { "endIndex > string.length: $endIndex > ${string.length}" }
+
+  // Transcode a UTF-16 Java String to UTF-8 bytes.
+  var i = beginIndex
+  while (i < endIndex) {
+    var c = string[i].toInt()
+
+    when {
+      c < 0x80 -> {
+        val tail = writableSegment(1)
+        val data = tail.data
+        val segmentOffset = tail.limit - i
+        val runLimit = minOf(endIndex, Segment.SIZE - segmentOffset)
+
+        // Emit a 7-bit character with 1 byte.
+        data[segmentOffset + i++] = c.toByte() // 0xxxxxxx
+
+        // Fast-path contiguous runs of ASCII characters. This is ugly, but yields a ~4x performance
+        // improvement over independent calls to writeByte().
+        while (i < runLimit) {
+          c = string[i].toInt()
+          if (c >= 0x80) break
+          data[segmentOffset + i++] = c.toByte() // 0xxxxxxx
+        }
+
+        val runSize = i + segmentOffset - tail.limit // Equivalent to i - (previous i).
+        tail.limit += runSize
+        size += runSize.toLong()
+      }
+
+      c < 0x800 -> {
+        // Emit a 11-bit character with 2 bytes.
+        val tail = writableSegment(2)
+        /* ktlint-disable no-multi-spaces */
+        tail.data[tail.limit    ] = (c shr 6          or 0xc0).toByte() // 110xxxxx
+        tail.data[tail.limit + 1] = (c       and 0x3f or 0x80).toByte() // 10xxxxxx
+        /* ktlint-enable no-multi-spaces */
+        tail.limit += 2
+        size += 2L
+        i++
+      }
+
+      c < 0xd800 || c > 0xdfff -> {
+        // Emit a 16-bit character with 3 bytes.
+        val tail = writableSegment(3)
+        /* ktlint-disable no-multi-spaces */
+        tail.data[tail.limit    ] = (c shr 12          or 0xe0).toByte() // 1110xxxx
+        tail.data[tail.limit + 1] = (c shr  6 and 0x3f or 0x80).toByte() // 10xxxxxx
+        tail.data[tail.limit + 2] = (c        and 0x3f or 0x80).toByte() // 10xxxxxx
+        /* ktlint-enable no-multi-spaces */
+        tail.limit += 3
+        size += 3L
+        i++
+      }
+
+      else -> {
+        // c is a surrogate. Make sure it is a high surrogate & that its successor is a low
+        // surrogate. If not, the UTF-16 is invalid, in which case we emit a replacement
+        // character.
+        val low = (if (i + 1 < endIndex) string[i + 1].toInt() else 0)
+        if (c > 0xdbff || low !in 0xdc00..0xdfff) {
+          writeByte('?'.toInt())
+          i++
+        } else {
+          // UTF-16 high surrogate: 110110xxxxxxxxxx (10 bits)
+          // UTF-16 low surrogate:  110111yyyyyyyyyy (10 bits)
+          // Unicode code point:    00010000000000000000 + xxxxxxxxxxyyyyyyyyyy (21 bits)
+          val codePoint = 0x010000 + (c and 0x03ff shl 10 or (low and 0x03ff))
+
+          // Emit a 21-bit character with 4 bytes.
+          val tail = writableSegment(4)
+          /* ktlint-disable no-multi-spaces */
+          tail.data[tail.limit    ] = (codePoint shr 18          or 0xf0).toByte() // 11110xxx
+          tail.data[tail.limit + 1] = (codePoint shr 12 and 0x3f or 0x80).toByte() // 10xxxxxx
+          tail.data[tail.limit + 2] = (codePoint shr  6 and 0x3f or 0x80).toByte() // 10xxyyyy
+          tail.data[tail.limit + 3] = (codePoint        and 0x3f or 0x80).toByte() // 10yyyyyy
+          /* ktlint-enable no-multi-spaces */
+          tail.limit += 4
+          size += 4L
+          i += 2
+        }
+      }
+    }
+  }
+
+  return this
+}
+
+internal inline fun Buffer.commonWriteUtf8CodePoint(codePoint: Int): Buffer {
+  when {
+    codePoint < 0x80 -> {
+      // Emit a 7-bit code point with 1 byte.
+      writeByte(codePoint)
+    }
+    codePoint < 0x800 -> {
+      // Emit a 11-bit code point with 2 bytes.
+      val tail = writableSegment(2)
+      /* ktlint-disable no-multi-spaces */
+      tail.data[tail.limit    ] = (codePoint shr 6          or 0xc0).toByte() // 110xxxxx
+      tail.data[tail.limit + 1] = (codePoint       and 0x3f or 0x80).toByte() // 10xxxxxx
+      /* ktlint-enable no-multi-spaces */
+      tail.limit += 2
+      size += 2L
+    }
+    codePoint in 0xd800..0xdfff -> {
+      // Emit a replacement character for a partial surrogate.
+      writeByte('?'.toInt())
+    }
+    codePoint < 0x10000 -> {
+      // Emit a 16-bit code point with 3 bytes.
+      val tail = writableSegment(3)
+      /* ktlint-disable no-multi-spaces */
+      tail.data[tail.limit    ] = (codePoint shr 12          or 0xe0).toByte() // 1110xxxx
+      tail.data[tail.limit + 1] = (codePoint shr  6 and 0x3f or 0x80).toByte() // 10xxxxxx
+      tail.data[tail.limit + 2] = (codePoint        and 0x3f or 0x80).toByte() // 10xxxxxx
+      /* ktlint-enable no-multi-spaces */
+      tail.limit += 3
+      size += 3L
+    }
+    codePoint <= 0x10ffff -> {
+      // Emit a 21-bit code point with 4 bytes.
+      val tail = writableSegment(4)
+      /* ktlint-disable no-multi-spaces */
+      tail.data[tail.limit    ] = (codePoint shr 18          or 0xf0).toByte() // 11110xxx
+      tail.data[tail.limit + 1] = (codePoint shr 12 and 0x3f or 0x80).toByte() // 10xxxxxx
+      tail.data[tail.limit + 2] = (codePoint shr  6 and 0x3f or 0x80).toByte() // 10xxyyyy
+      tail.data[tail.limit + 3] = (codePoint        and 0x3f or 0x80).toByte() // 10yyyyyy
+      /* ktlint-enable no-multi-spaces */
+      tail.limit += 4
+      size += 4L
+    }
+    else -> {
+      throw IllegalArgumentException("Unexpected code point: ${codePoint.toHexString()}")
+    }
+  }
+
+  return this
+}
+
+internal inline fun Buffer.commonWriteAll(source: Source): Long {
+  var totalBytesRead = 0L
+  while (true) {
+    val readCount = source.read(this, Segment.SIZE.toLong())
+    if (readCount == -1L) break
+    totalBytesRead += readCount
+  }
+  return totalBytesRead
+}
+
+internal inline fun Buffer.commonWrite(source: Source, byteCount: Long): Buffer {
+  var byteCount = byteCount
+  while (byteCount > 0L) {
+    val read = source.read(this, byteCount)
+    if (read == -1L) throw EOFException()
+    byteCount -= read
+  }
+  return this
+}
+
+internal inline fun Buffer.commonWriteByte(b: Int): Buffer {
+  val tail = writableSegment(1)
+  tail.data[tail.limit++] = b.toByte()
+  size += 1L
+  return this
+}
+
+internal inline fun Buffer.commonWriteShort(s: Int): Buffer {
+  val tail = writableSegment(2)
+  val data = tail.data
+  var limit = tail.limit
+  data[limit++] = (s ushr 8 and 0xff).toByte()
+  data[limit++] = (s        and 0xff).toByte() // ktlint-disable no-multi-spaces
+  tail.limit = limit
+  size += 2L
+  return this
+}
+
+internal inline fun Buffer.commonWriteInt(i: Int): Buffer {
+  val tail = writableSegment(4)
+  val data = tail.data
+  var limit = tail.limit
+  data[limit++] = (i ushr 24 and 0xff).toByte()
+  data[limit++] = (i ushr 16 and 0xff).toByte()
+  data[limit++] = (i ushr  8 and 0xff).toByte() // ktlint-disable no-multi-spaces
+  data[limit++] = (i         and 0xff).toByte() // ktlint-disable no-multi-spaces
+  tail.limit = limit
+  size += 4L
+  return this
+}
+
+internal inline fun Buffer.commonWriteLong(v: Long): Buffer {
+  val tail = writableSegment(8)
+  val data = tail.data
+  var limit = tail.limit
+  data[limit++] = (v ushr 56 and 0xffL).toByte()
+  data[limit++] = (v ushr 48 and 0xffL).toByte()
+  data[limit++] = (v ushr 40 and 0xffL).toByte()
+  data[limit++] = (v ushr 32 and 0xffL).toByte()
+  data[limit++] = (v ushr 24 and 0xffL).toByte()
+  data[limit++] = (v ushr 16 and 0xffL).toByte()
+  data[limit++] = (v ushr  8 and 0xffL).toByte() // ktlint-disable no-multi-spaces
+  data[limit++] = (v         and 0xffL).toByte() // ktlint-disable no-multi-spaces
+  tail.limit = limit
+  size += 8L
+  return this
+}
+
+internal inline fun Buffer.commonWrite(source: Buffer, byteCount: Long) {
+  var byteCount = byteCount
+  // Move bytes from the head of the source buffer to the tail of this buffer
+  // while balancing two conflicting goals: don't waste CPU and don't waste
+  // memory.
+  //
+  //
+  // Don't waste CPU (ie. don't copy data around).
+  //
+  // Copying large amounts of data is expensive. Instead, we prefer to
+  // reassign entire segments from one buffer to the other.
+  //
+  //
+  // Don't waste memory.
+  //
+  // As an invariant, adjacent pairs of segments in a buffer should be at
+  // least 50% full, except for the head segment and the tail segment.
+  //
+  // The head segment cannot maintain the invariant because the application is
+  // consuming bytes from this segment, decreasing its level.
+  //
+  // The tail segment cannot maintain the invariant because the application is
+  // producing bytes, which may require new nearly-empty tail segments to be
+  // appended.
+  //
+  //
+  // Moving segments between buffers
+  //
+  // When writing one buffer to another, we prefer to reassign entire segments
+  // over copying bytes into their most compact form. Suppose we have a buffer
+  // with these segment levels [91%, 61%]. If we append a buffer with a
+  // single [72%] segment, that yields [91%, 61%, 72%]. No bytes are copied.
+  //
+  // Or suppose we have a buffer with these segment levels: [100%, 2%], and we
+  // want to append it to a buffer with these segment levels [99%, 3%]. This
+  // operation will yield the following segments: [100%, 2%, 99%, 3%]. That
+  // is, we do not spend time copying bytes around to achieve more efficient
+  // memory use like [100%, 100%, 4%].
+  //
+  // When combining buffers, we will compact adjacent buffers when their
+  // combined level doesn't exceed 100%. For example, when we start with
+  // [100%, 40%] and append [30%, 80%], the result is [100%, 70%, 80%].
+  //
+  //
+  // Splitting segments
+  //
+  // Occasionally we write only part of a source buffer to a sink buffer. For
+  // example, given a sink [51%, 91%], we may want to write the first 30% of
+  // a source [92%, 82%] to it. To simplify, we first transform the source to
+  // an equivalent buffer [30%, 62%, 82%] and then move the head segment,
+  // yielding sink [51%, 91%, 30%] and source [62%, 82%].
+
+  require(source !== this) { "source == this" }
+  checkOffsetAndCount(source.size, 0, byteCount)
+
+  while (byteCount > 0L) {
+    // Is a prefix of the source's head segment all that we need to move?
+    if (byteCount < source.head!!.limit - source.head!!.pos) {
+      val tail = if (head != null) head!!.prev else null
+      if (tail != null && tail.owner &&
+        byteCount + tail.limit - (if (tail.shared) 0 else tail.pos) <= Segment.SIZE) {
+        // Our existing segments are sufficient. Move bytes from source's head to our tail.
+        source.head!!.writeTo(tail, byteCount.toInt())
+        source.size -= byteCount
+        size += byteCount
+        return
+      } else {
+        // We're going to need another segment. Split the source's head
+        // segment in two, then move the first of those two to this buffer.
+        source.head = source.head!!.split(byteCount.toInt())
+      }
+    }
+
+    // Remove the source's head segment and append it to our tail.
+    val segmentToMove = source.head
+    val movedByteCount = (segmentToMove!!.limit - segmentToMove.pos).toLong()
+    source.head = segmentToMove.pop()
+    if (head == null) {
+      head = segmentToMove
+      segmentToMove.prev = segmentToMove
+      segmentToMove.next = segmentToMove.prev
+    } else {
+      var tail = head!!.prev
+      tail = tail!!.push(segmentToMove)
+      tail.compact()
+    }
+    source.size -= movedByteCount
+    size += movedByteCount
+    byteCount -= movedByteCount
+  }
+}
+
+internal inline fun Buffer.commonRead(sink: Buffer, byteCount: Long): Long {
+  var byteCount = byteCount
+  require(byteCount >= 0) { "byteCount < 0: $byteCount" }
+  if (size == 0L) return -1L
+  if (byteCount > size) byteCount = size
+  sink.write(this, byteCount)
+  return byteCount
+}
+
+internal inline fun Buffer.commonIndexOf(b: Byte, fromIndex: Long, toIndex: Long): Long {
+  var fromIndex = fromIndex
+  var toIndex = toIndex
+  require(fromIndex in 0..toIndex) { "size=$size fromIndex=$fromIndex toIndex=$toIndex" }
+
+  if (toIndex > size) toIndex = size
+  if (fromIndex == toIndex) return -1L
+
+  seek(fromIndex) { s, offset ->
+    var s = s ?: return -1L
+    var offset = offset
+
+    // Scan through the segments, searching for b.
+    while (offset < toIndex) {
+      val data = s.data
+      val limit = minOf(s.limit.toLong(), s.pos + toIndex - offset).toInt()
+      var pos = (s.pos + fromIndex - offset).toInt()
+      while (pos < limit) {
+        if (data[pos] == b) {
+          return pos - s.pos + offset
+        }
+        pos++
+      }
+
+      // Not in this segment. Try the next one.
+      offset += (s.limit - s.pos).toLong()
+      fromIndex = offset
+      s = s.next!!
+    }
+
+    return -1L
+  }
+}
+
+internal inline fun Buffer.commonIndexOf(bytes: ByteString, fromIndex: Long): Long {
+  var fromIndex = fromIndex
+  require(bytes.size > 0) { "bytes is empty" }
+  require(fromIndex >= 0L) { "fromIndex < 0: $fromIndex" }
+
+  seek(fromIndex) { s, offset ->
+    var s = s ?: return -1L
+    var offset = offset
+
+    // Scan through the segments, searching for the lead byte. Each time that is found, delegate
+    // to rangeEquals() to check for a complete match.
+    val targetByteArray = bytes.internalArray()
+    val b0 = targetByteArray[0]
+    val bytesSize = bytes.size
+    val resultLimit = size - bytesSize + 1L
+    while (offset < resultLimit) {
+      // Scan through the current segment.
+      val data = s.data
+      val segmentLimit = okio.minOf(s.limit, s.pos + resultLimit - offset).toInt()
+      for (pos in (s.pos + fromIndex - offset).toInt() until segmentLimit) {
+        if (data[pos] == b0 && rangeEquals(s, pos + 1, targetByteArray, 1, bytesSize)) {
+          return pos - s.pos + offset
+        }
+      }
+
+      // Not in this segment. Try the next one.
+      offset += (s.limit - s.pos).toLong()
+      fromIndex = offset
+      s = s.next!!
+    }
+
+    return -1L
+  }
+}
+
+internal inline fun Buffer.commonIndexOfElement(targetBytes: ByteString, fromIndex: Long): Long {
+  var fromIndex = fromIndex
+  require(fromIndex >= 0L) { "fromIndex < 0: $fromIndex" }
+
+  seek(fromIndex) { s, offset ->
+    var s = s ?: return -1L
+    var offset = offset
+
+    // Special case searching for one of two bytes. This is a common case for tools like Moshi,
+    // which search for pairs of chars like `\r` and `\n` or {@code `"` and `\`. The impact of this
+    // optimization is a ~5x speedup for this case without a substantial cost to other cases.
+    if (targetBytes.size == 2) {
+      // Scan through the segments, searching for either of the two bytes.
+      val b0 = targetBytes[0]
+      val b1 = targetBytes[1]
+      while (offset < size) {
+        val data = s.data
+        var pos = (s.pos + fromIndex - offset).toInt()
+        val limit = s.limit
+        while (pos < limit) {
+          val b = data[pos].toInt()
+          if (b == b0.toInt() || b == b1.toInt()) {
+            return pos - s.pos + offset
+          }
+          pos++
+        }
+
+        // Not in this segment. Try the next one.
+        offset += (s.limit - s.pos).toLong()
+        fromIndex = offset
+        s = s.next!!
+      }
+    } else {
+      // Scan through the segments, searching for a byte that's also in the array.
+      val targetByteArray = targetBytes.internalArray()
+      while (offset < size) {
+        val data = s.data
+        var pos = (s.pos + fromIndex - offset).toInt()
+        val limit = s.limit
+        while (pos < limit) {
+          val b = data[pos].toInt()
+          for (t in targetByteArray) {
+            if (b == t.toInt()) return pos - s.pos + offset
+          }
+          pos++
+        }
+
+        // Not in this segment. Try the next one.
+        offset += (s.limit - s.pos).toLong()
+        fromIndex = offset
+        s = s.next!!
+      }
+    }
+
+    return -1L
+  }
+}
+
+internal inline fun Buffer.commonRangeEquals(
+  offset: Long,
+  bytes: ByteString,
+  bytesOffset: Int,
+  byteCount: Int
+): Boolean {
+  if (offset < 0L ||
+    bytesOffset < 0 ||
+    byteCount < 0 ||
+    size - offset < byteCount ||
+    bytes.size - bytesOffset < byteCount) {
+    return false
+  }
+  for (i in 0 until byteCount) {
+    if (this[offset + i] != bytes[bytesOffset + i]) {
+      return false
+    }
+  }
+  return true
+}
+
+
+
+internal inline fun Buffer.commonEquals(other: Any?): Boolean {
+  if (this === other) return true
+  if (other !is Buffer) return false
+  if (size != other.size) return false
+  if (size == 0L) return true // Both buffers are empty.
+
+  var sa = this.head!!
+  var sb = other.head!!
+  var posA = sa.pos
+  var posB = sb.pos
+
+  var pos = 0L
+  var count: Long
+  while (pos < size) {
+    count = kotlin.comparisons.minOf(sa.limit - posA, sb.limit - posB).toLong()
+
+    for (i in 0L until count) {
+      if (sa.data[posA++] != sb.data[posB++]) return false
+    }
+
+    if (posA == sa.limit) {
+      sa = sa.next!!
+      posA = sa.pos
+    }
+
+    if (posB == sb.limit) {
+      sb = sb.next!!
+      posB = sb.pos
+    }
+    pos += count
+  }
+
+  return true
+}
+
+internal inline fun Buffer.commonHashCode(): Int {
+  var s = head ?: return 0
+  var result = 1
+  do {
+    var pos = s.pos
+    val limit = s.limit
+    while (pos < limit) {
+      result = 31 * result + s.data[pos]
+      pos++
+    }
+    s = s.next!!
+  } while (s !== head)
+  return result
+}

--- a/okio/src/commonMain/kotlin/okio/internal/ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/ByteString.kt
@@ -51,7 +51,7 @@ internal inline fun ByteString.commonBase64(): String = data.encodeBase64()
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun ByteString.commonBase64Url() = data.encodeBase64(map = BASE64_URL_SAFE)
 
-private val HEX_DIGITS =
+internal val HEX_DIGITS =
   charArrayOf('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
 
 @Suppress("NOTHING_TO_INLINE")

--- a/okio/src/commonTest/kotlin/okio/CommonBufferTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonBufferTest.kt
@@ -1,0 +1,442 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import okio.ByteString.Companion.decodeHex
+import kotlin.random.Random
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests solely for the behavior of Buffer's implementation. For generic BufferedSink or
+ * BufferedSource behavior use BufferedSinkTest or BufferedSourceTest, respectively.
+ */
+class CommonBufferTest {
+  @Test fun readAndWriteUtf8() {
+    val buffer = Buffer()
+    buffer.writeUtf8("ab")
+    assertEquals(2, buffer.size)
+    buffer.writeUtf8("cdef")
+    assertEquals(6, buffer.size)
+    assertEquals("abcd", buffer.readUtf8(4))
+    assertEquals(2, buffer.size)
+    assertEquals("ef", buffer.readUtf8(2))
+    assertEquals(0, buffer.size)
+    assertFailsWith<EOFException> {
+      buffer.readUtf8(1)
+    }
+  }
+
+  /** Buffer's toString is the same as ByteString's.  */
+  @Ignore @Test fun bufferToString() {
+    assertEquals("[size=0]", Buffer().toString())
+    assertEquals(
+      "[text=a\\r\\nb\\nc\\rd\\\\e]",
+      Buffer().writeUtf8("a\r\nb\nc\rd\\e").toString()
+    )
+    assertEquals(
+      "[text=Tyrannosaur]",
+      Buffer().writeUtf8("Tyrannosaur").toString()
+    )
+    assertEquals(
+      "[text=təˈranəˌsôr]", Buffer()
+        .write("74c999cb8872616ec999cb8c73c3b472".decodeHex())
+        .toString()
+    )
+    assertEquals(
+      "[hex=0000000000000000000000000000000000000000000000000000000000000000000000000000" +
+          "0000000000000000000000000000000000000000000000000000]",
+      Buffer().write(ByteArray(64)).toString()
+    )
+  }
+
+  @Test fun multipleSegmentBuffers() {
+    val buffer = Buffer()
+    buffer.writeUtf8('a'.repeat(1000))
+    buffer.writeUtf8('b'.repeat(2500))
+    buffer.writeUtf8('c'.repeat(5000))
+    buffer.writeUtf8('d'.repeat(10000))
+    buffer.writeUtf8('e'.repeat(25000))
+    buffer.writeUtf8('f'.repeat(50000))
+
+    assertEquals('a'.repeat(999), buffer.readUtf8(999)) // a...a
+    assertEquals("a" + 'b'.repeat(2500) + "c", buffer.readUtf8(2502)) // ab...bc
+    assertEquals('c'.repeat(4998), buffer.readUtf8(4998)) // c...c
+    assertEquals("c" + 'd'.repeat(10000) + "e", buffer.readUtf8(10002)) // cd...de
+    assertEquals('e'.repeat(24998), buffer.readUtf8(24998)) // e...e
+    assertEquals("e" + 'f'.repeat(50000), buffer.readUtf8(50001)) // ef...f
+    assertEquals(0, buffer.size)
+  }
+
+  @Test fun fillAndDrainPool() {
+    val buffer = Buffer()
+
+    // Take 2 * MAX_SIZE segments. This will drain the pool, even if other tests filled it.
+    buffer.write(ByteArray(SegmentPool.MAX_SIZE.toInt()))
+    buffer.write(ByteArray(SegmentPool.MAX_SIZE.toInt()))
+    assertEquals(0, SegmentPool.byteCount)
+
+    // Recycle MAX_SIZE segments. They're all in the pool.
+    buffer.readByteString(SegmentPool.MAX_SIZE)
+    assertEquals(SegmentPool.MAX_SIZE, SegmentPool.byteCount)
+
+    // Recycle MAX_SIZE more segments. The pool is full so they get garbage collected.
+    buffer.readByteString(SegmentPool.MAX_SIZE)
+    assertEquals(SegmentPool.MAX_SIZE, SegmentPool.byteCount)
+
+    // Take MAX_SIZE segments to drain the pool.
+    buffer.write(ByteArray(SegmentPool.MAX_SIZE.toInt()))
+    assertEquals(0, SegmentPool.byteCount)
+
+    // Take MAX_SIZE more segments. The pool is drained so these will need to be allocated.
+    buffer.write(ByteArray(SegmentPool.MAX_SIZE.toInt()))
+    assertEquals(0, SegmentPool.byteCount)
+  }
+
+  @Test fun moveBytesBetweenBuffersShareSegment() {
+    val size = Segment.SIZE / 2 - 1
+    val segmentSizes = moveBytesBetweenBuffers('a'.repeat(size), 'b'.repeat(size))
+    assertEquals(listOf(size * 2), segmentSizes)
+  }
+
+  @Test fun moveBytesBetweenBuffersReassignSegment() {
+    val size = Segment.SIZE / 2 + 1
+    val segmentSizes = moveBytesBetweenBuffers('a'.repeat(size), 'b'.repeat(size))
+    assertEquals(listOf(size, size), segmentSizes)
+  }
+
+  @Test fun moveBytesBetweenBuffersMultipleSegments() {
+    val size = 3 * Segment.SIZE + 1
+    val segmentSizes = moveBytesBetweenBuffers('a'.repeat(size), 'b'.repeat(size))
+    assertEquals(
+      listOf(
+        Segment.SIZE, Segment.SIZE, Segment.SIZE, 1,
+        Segment.SIZE, Segment.SIZE, Segment.SIZE, 1
+      ), segmentSizes
+    )
+  }
+
+  private fun moveBytesBetweenBuffers(vararg contents: String): List<Int> {
+    val expected = StringBuilder()
+    val buffer = Buffer()
+    for (s in contents) {
+      val source = Buffer()
+      source.writeUtf8(s)
+      buffer.writeAll(source)
+      expected.append(s)
+    }
+    val segmentSizes = segmentSizes(buffer)
+    assertEquals(expected.toString(), buffer.readUtf8(expected.length.toLong()))
+    return segmentSizes
+  }
+
+  /** The big part of source's first segment is being moved.  */
+  @Test fun writeSplitSourceBufferLeft() {
+    val writeSize = Segment.SIZE / 2 + 1
+
+    val sink = Buffer()
+    sink.writeUtf8('b'.repeat(Segment.SIZE - 10))
+
+    val source = Buffer()
+    source.writeUtf8('a'.repeat(Segment.SIZE * 2))
+    sink.write(source, writeSize.toLong())
+
+    assertEquals(listOf(Segment.SIZE - 10, writeSize), segmentSizes(sink))
+    assertEquals(listOf(Segment.SIZE - writeSize, Segment.SIZE), segmentSizes(source))
+  }
+
+  /** The big part of source's first segment is staying put.  */
+  @Test fun writeSplitSourceBufferRight() {
+    val writeSize = Segment.SIZE / 2 - 1
+
+    val sink = Buffer()
+    sink.writeUtf8('b'.repeat(Segment.SIZE - 10))
+
+    val source = Buffer()
+    source.writeUtf8('a'.repeat(Segment.SIZE * 2))
+    sink.write(source, writeSize.toLong())
+
+    assertEquals(listOf(Segment.SIZE - 10, writeSize), segmentSizes(sink))
+    assertEquals(listOf(Segment.SIZE - writeSize, Segment.SIZE), segmentSizes(source))
+  }
+
+  @Test fun writePrefixDoesntSplit() {
+    val sink = Buffer()
+    sink.writeUtf8('b'.repeat(10))
+
+    val source = Buffer()
+    source.writeUtf8('a'.repeat(Segment.SIZE * 2))
+    sink.write(source, 20)
+
+    assertEquals(listOf(30), segmentSizes(sink))
+    assertEquals(listOf(Segment.SIZE - 20, Segment.SIZE), segmentSizes(source))
+    assertEquals(30, sink.size)
+    assertEquals((Segment.SIZE * 2 - 20).toLong(), source.size)
+  }
+
+  @Test fun writePrefixDoesntSplitButRequiresCompact() {
+    val sink = Buffer()
+    sink.writeUtf8('b'.repeat(Segment.SIZE - 10)) // limit = size - 10
+    sink.readUtf8((Segment.SIZE - 20).toLong()) // pos = size = 20
+
+    val source = Buffer()
+    source.writeUtf8('a'.repeat(Segment.SIZE * 2))
+    sink.write(source, 20)
+
+    assertEquals(listOf(30), segmentSizes(sink))
+    assertEquals(listOf(Segment.SIZE - 20, Segment.SIZE), segmentSizes(source))
+    assertEquals(30, sink.size)
+    assertEquals((Segment.SIZE * 2 - 20).toLong(), source.size)
+  }
+
+  @Test fun moveAllRequestedBytesWithRead() {
+    val sink = Buffer()
+    sink.writeUtf8('a'.repeat(10))
+
+    val source = Buffer()
+    source.writeUtf8('b'.repeat(15))
+
+    assertEquals(10, source.read(sink, 10))
+    assertEquals(20, sink.size)
+    assertEquals(5, source.size)
+    assertEquals('a'.repeat(10) + 'b'.repeat(10), sink.readUtf8(20))
+  }
+
+  @Test fun moveFewerThanRequestedBytesWithRead() {
+    val sink = Buffer()
+    sink.writeUtf8('a'.repeat(10))
+
+    val source = Buffer()
+    source.writeUtf8('b'.repeat(20))
+
+    assertEquals(20, source.read(sink, 25))
+    assertEquals(30, sink.size)
+    assertEquals(0, source.size)
+    assertEquals('a'.repeat(10) + 'b'.repeat(20), sink.readUtf8(30))
+  }
+
+  @Test fun indexOfWithOffset() {
+    val buffer = Buffer()
+    val halfSegment = Segment.SIZE / 2
+    buffer.writeUtf8('a'.repeat(halfSegment))
+    buffer.writeUtf8('b'.repeat(halfSegment))
+    buffer.writeUtf8('c'.repeat(halfSegment))
+    buffer.writeUtf8('d'.repeat(halfSegment))
+    assertEquals(0, buffer.indexOf('a'.toByte(), 0))
+    assertEquals(
+      (halfSegment - 1).toLong(),
+      buffer.indexOf('a'.toByte(), (halfSegment - 1).toLong())
+    )
+    assertEquals(halfSegment.toLong(), buffer.indexOf('b'.toByte(), (halfSegment - 1).toLong()))
+    assertEquals(
+      (halfSegment * 2).toLong(),
+      buffer.indexOf('c'.toByte(), (halfSegment - 1).toLong())
+    )
+    assertEquals(
+      (halfSegment * 3).toLong(),
+      buffer.indexOf('d'.toByte(), (halfSegment - 1).toLong())
+    )
+    assertEquals(
+      (halfSegment * 3).toLong(),
+      buffer.indexOf('d'.toByte(), (halfSegment * 2).toLong())
+    )
+    assertEquals(
+      (halfSegment * 3).toLong(),
+      buffer.indexOf('d'.toByte(), (halfSegment * 3).toLong())
+    )
+    assertEquals(
+      (halfSegment * 4 - 1).toLong(),
+      buffer.indexOf('d'.toByte(), (halfSegment * 4 - 1).toLong())
+    )
+  }
+
+  @Test fun byteAt() {
+    val buffer = Buffer()
+    buffer.writeUtf8("a")
+    buffer.writeUtf8('b'.repeat(Segment.SIZE))
+    buffer.writeUtf8("c")
+    assertEquals('a'.toLong(), buffer.get(0).toLong())
+    assertEquals('a'.toLong(), buffer.get(0).toLong()) // getByte doesn't mutate!
+    assertEquals('c'.toLong(), buffer.get(buffer.size - 1).toLong())
+    assertEquals('b'.toLong(), buffer.get(buffer.size - 2).toLong())
+    assertEquals('b'.toLong(), buffer.get(buffer.size - 3).toLong())
+  }
+
+  @Test fun getByteOfEmptyBuffer() {
+    val buffer = Buffer()
+    assertFailsWith<IndexOutOfBoundsException> {
+      buffer.get(0)
+    }
+  }
+
+  @Test
+  fun writePrefixToEmptyBuffer() {
+    val sink = Buffer()
+    val source = Buffer()
+    source.writeUtf8("abcd")
+    sink.write(source, 2)
+    assertEquals("ab", sink.readUtf8(2))
+  }
+
+  @Suppress("ReplaceAssertBooleanWithAssertEquality")
+  @Test fun equalsAndHashCodeEmpty() {
+    val a = Buffer()
+    val b = Buffer()
+    assertTrue(a == b)
+    assertTrue(a.hashCode() == b.hashCode())
+  }
+
+  @Suppress("ReplaceAssertBooleanWithAssertEquality")
+  @Test fun equalsAndHashCode() {
+    val a = Buffer().writeUtf8("dog")
+    val b = Buffer().writeUtf8("hotdog")
+    assertFalse(a == b)
+    assertFalse(a.hashCode() == b.hashCode())
+
+    b.readUtf8(3) // Leaves b containing 'dog'.
+    assertTrue(a == b)
+    assertTrue(a.hashCode() == b.hashCode())
+  }
+
+  @Suppress("ReplaceAssertBooleanWithAssertEquality")
+  @Test fun equalsAndHashCodeSpanningSegments() {
+    val data = ByteArray(1024 * 1024)
+    val dice = Random(0)
+    dice.nextBytes(data)
+
+    val a = bufferWithRandomSegmentLayout(dice, data)
+    val b = bufferWithRandomSegmentLayout(dice, data)
+    assertTrue(a == b)
+    assertTrue(a.hashCode() == b.hashCode())
+
+    data[data.size / 2]++ // Change a single byte.
+    val c = bufferWithRandomSegmentLayout(dice, data)
+    assertFalse(a == c)
+    assertFalse(a.hashCode() == c.hashCode())
+  }
+
+  /**
+   * When writing data that's already buffered, there's no reason to page the
+   * data by segment.
+   */
+  @Test fun readAllWritesAllSegmentsAtOnce() {
+    val write1 = Buffer().writeUtf8(
+      'a'.repeat(Segment.SIZE)
+          + 'b'.repeat(Segment.SIZE)
+          + 'c'.repeat(Segment.SIZE)
+    )
+
+    val source = Buffer().writeUtf8(
+      'a'.repeat(Segment.SIZE)
+          + 'b'.repeat(Segment.SIZE)
+          + 'c'.repeat(Segment.SIZE)
+    )
+
+    val mockSink = MockSink()
+
+    assertEquals((Segment.SIZE * 3).toLong(), source.readAll(mockSink))
+    assertEquals(0, source.size)
+    mockSink.assertLog("write(" + write1 + ", " + write1.size + ")")
+  }
+
+  @Test fun writeAllMultipleSegments() {
+    val source = Buffer().writeUtf8('a'.repeat(Segment.SIZE * 3))
+    val sink = Buffer()
+
+    assertEquals((Segment.SIZE * 3).toLong(), sink.writeAll(source))
+    assertEquals(0, source.size)
+    assertEquals('a'.repeat(Segment.SIZE * 3), sink.readUtf8())
+  }
+
+  @Test fun copyTo() {
+    val source = Buffer()
+    source.writeUtf8("party")
+
+    val target = Buffer()
+    source.copyTo(target, 1, 3)
+
+    assertEquals("art", target.readUtf8())
+    assertEquals("party", source.readUtf8())
+  }
+
+  @Test fun copyToOnSegmentBoundary() {
+    val `as` = 'a'.repeat(Segment.SIZE)
+    val bs = 'b'.repeat(Segment.SIZE)
+    val cs = 'c'.repeat(Segment.SIZE)
+    val ds = 'd'.repeat(Segment.SIZE)
+
+    val source = Buffer()
+    source.writeUtf8(`as`)
+    source.writeUtf8(bs)
+    source.writeUtf8(cs)
+
+    val target = Buffer()
+    target.writeUtf8(ds)
+
+    source.copyTo(target, `as`.length.toLong(), (bs.length + cs.length).toLong())
+    assertEquals(ds + bs + cs, target.readUtf8())
+  }
+
+  @Test fun copyToOffSegmentBoundary() {
+    val `as` = 'a'.repeat(Segment.SIZE - 1)
+    val bs = 'b'.repeat(Segment.SIZE + 2)
+    val cs = 'c'.repeat(Segment.SIZE - 4)
+    val ds = 'd'.repeat(Segment.SIZE + 8)
+
+    val source = Buffer()
+    source.writeUtf8(`as`)
+    source.writeUtf8(bs)
+    source.writeUtf8(cs)
+
+    val target = Buffer()
+    target.writeUtf8(ds)
+
+    source.copyTo(target, `as`.length.toLong(), (bs.length + cs.length).toLong())
+    assertEquals(ds + bs + cs, target.readUtf8())
+  }
+
+  @Test fun copyToSourceAndTargetCanBeTheSame() {
+    val `as` = 'a'.repeat(Segment.SIZE)
+    val bs = 'b'.repeat(Segment.SIZE)
+
+    val source = Buffer()
+    source.writeUtf8(`as`)
+    source.writeUtf8(bs)
+
+    source.copyTo(source, 0, source.size)
+    assertEquals(`as` + bs + `as` + bs, source.readUtf8())
+  }
+
+  @Test fun copyToEmptySource() {
+    val source = Buffer()
+    val target = Buffer().writeUtf8("aaa")
+    source.copyTo(target, 0L, 0L)
+    assertEquals("", source.readUtf8())
+    assertEquals("aaa", target.readUtf8())
+  }
+
+  @Test fun copyToEmptyTarget() {
+    val source = Buffer().writeUtf8("aaa")
+    val target = Buffer()
+    source.copyTo(target, 0L, 3L)
+    assertEquals("aaa", source.readUtf8())
+    assertEquals("aaa", target.readUtf8())
+  }
+}

--- a/okio/src/commonTest/kotlin/okio/CommonOptionsTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonOptionsTest.kt
@@ -16,12 +16,11 @@
 package okio
 
 import okio.ByteString.Companion.encodeUtf8
-import okio.TestUtil.bufferWithSegments
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.fail
 
-class OptionsTest {
+class CommonOptionsTest {
   /** Confirm that options prefers the first-listed option, not the longest or shortest one. */
   @Test fun optionOrderTakesPrecedence() {
     assertSelect("abcdefg", 0, "abc", "abcdef")
@@ -29,7 +28,7 @@ class OptionsTest {
   }
 
   @Test fun simpleOptionsTrie() {
-    assertThat(utf8Options("hotdog", "hoth", "hot").trieString()).isEqualTo("""
+    assertEquals(utf8Options("hotdog", "hoth", "hot").trieString(), """
         |hot
         |   -> 2
         |   d
@@ -68,7 +67,7 @@ class OptionsTest {
         "readTimeout",
         "writeTimeout",
         "pingInterval")
-    assertThat(options.trieString()).isEqualTo("""
+    assertEquals(options.trieString(), """
         |a
         | uthenticator -> 17
         |c
@@ -200,13 +199,13 @@ class OptionsTest {
       utf8Options("abc", "abc")
       fail()
     } catch (expected: IllegalArgumentException) {
-      assertThat(expected).hasMessage("duplicate option: [text=abc]")
+      assertEquals(expected.message, "duplicate option: [text=abc]")
     }
   }
 
   @Test fun prefixesAreStripped() {
     val options = utf8Options("abcA", "abc", "abcB")
-    assertThat(options.trieString()).isEqualTo("""
+    assertEquals(options.trieString(), """
         |abc
         |   -> 1
         |   A -> 0
@@ -219,22 +218,22 @@ class OptionsTest {
   }
 
   @Test fun multiplePrefixesAreStripped() {
-    assertThat(utf8Options("a", "ab", "abc", "abcd", "abcde").trieString()).isEqualTo("""
+    assertEquals(utf8Options("a", "ab", "abc", "abcd", "abcde").trieString(), """
         |a -> 0
         |""".trimMargin())
-    assertThat(utf8Options("abc", "a", "ab", "abe", "abcd", "abcf").trieString()).isEqualTo("""
+    assertEquals(utf8Options("abc", "a", "ab", "abe", "abcd", "abcf").trieString(), """
         |a
         | -> 1
         | bc -> 0
         |""".trimMargin())
-    assertThat(utf8Options("abc", "ab", "a").trieString()).isEqualTo("""
+    assertEquals(utf8Options("abc", "ab", "a").trieString(), """
         |a
         | -> 2
         | b
         |  -> 1
         |  c -> 0
         |""".trimMargin())
-    assertThat(utf8Options("abcd", "abce", "abc", "abcf", "abcg").trieString()).isEqualTo("""
+    assertEquals(utf8Options("abcd", "abce", "abc", "abcf", "abcg").trieString(), """
         |abc
         |   -> 2
         |   d -> 0
@@ -373,11 +372,11 @@ class OptionsTest {
     val initialSize = data.size
     val actual = data.select(options)
 
-    assertThat(actual).isEqualTo(expected)
+    assertEquals(actual, expected)
     if (expected == -1) {
-      assertThat(data.size).isEqualTo(initialSize)
+      assertEquals(data.size, initialSize)
     } else {
-      assertThat(data.size + options[expected].size).isEqualTo(initialSize)
+      assertEquals(data.size + options[expected].size, initialSize)
     }
   }
 

--- a/okio/src/commonTest/kotlin/okio/MockSink.kt
+++ b/okio/src/commonTest/kotlin/okio/MockSink.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** A scriptable sink. Like Mockito, but worse and requiring less configuration.  */
+internal class MockSink : Sink {
+  private val log = mutableListOf<String>()
+  private val callThrows = LinkedHashMap<Int, IOException>()
+
+  fun assertLog(vararg messages: String) {
+    assertEquals(messages.toList(), log)
+  }
+
+  fun assertLogContains(message: String) {
+    assertTrue(message in log)
+  }
+
+  fun scheduleThrow(call: Int, e: IOException) {
+    callThrows[call] = e
+  }
+
+  private fun throwIfScheduled() {
+    val exception = callThrows[log.size - 1]
+    if (exception != null) throw exception
+  }
+
+  override fun write(source: Buffer, byteCount: Long) {
+    log.add("write($source, $byteCount)")
+    source.skip(byteCount)
+    throwIfScheduled()
+  }
+
+  override fun flush() {
+    log.add("flush()")
+    throwIfScheduled()
+  }
+
+  override fun timeout(): Timeout {
+    log.add("timeout()")
+    return Timeout.NONE
+  }
+
+  override fun close() {
+    log.add("close()")
+    throwIfScheduled()
+  }
+}

--- a/okio/src/commonTest/kotlin/okio/util.kt
+++ b/okio/src/commonTest/kotlin/okio/util.kt
@@ -1,0 +1,50 @@
+package okio
+
+import kotlin.random.Random
+
+fun Char.repeat(count: Int): String {
+  return toString().repeat(count)
+}
+
+fun segmentSizes(buffer: Buffer): List<Int> {
+  return generateSequence(buffer.head) { segment -> segment.next.takeIf { it !== buffer.head }}
+    .map { segment -> segment.limit - segment.pos }
+    .toList()
+}
+
+fun bufferWithRandomSegmentLayout(dice: Random, data: ByteArray): Buffer {
+  val result = Buffer()
+
+  // Writing to result directly will yield packed segments. Instead, write to
+  // other buffers, then write those buffers to result.
+  var pos = 0
+  var byteCount: Int
+  while (pos < data.size) {
+    byteCount = Segment.SIZE / 2 + dice.nextInt(Segment.SIZE / 2)
+    if (byteCount > data.size - pos) byteCount = data.size - pos
+    val offset = dice.nextInt(Segment.SIZE - byteCount)
+
+    val segment = Buffer()
+    segment.write(ByteArray(offset))
+    segment.write(data, pos, byteCount)
+    segment.skip(offset.toLong())
+
+    result.write(segment, byteCount.toLong())
+    pos += byteCount
+  }
+
+  return result
+}
+
+fun bufferWithSegments(vararg segments: String): Buffer {
+  val result = Buffer()
+  for (s in segments) {
+    val offsetInSegment = if (s.length < Segment.SIZE) (Segment.SIZE - s.length) / 2 else 0
+    val buffer = Buffer()
+    buffer.writeUtf8('_'.repeat(offsetInSegment))
+    buffer.writeUtf8(s)
+    buffer.skip(offsetInSegment.toLong())
+    result.write(buffer.copyTo(Buffer()), buffer.size)
+  }
+  return result
+}

--- a/okio/src/jsMain/kotlin/okio/Buffer.kt
+++ b/okio/src/jsMain/kotlin/okio/Buffer.kt
@@ -17,15 +17,37 @@ package okio
 
 import okio.internal.commonClear
 import okio.internal.commonCopyTo
+import okio.internal.commonEquals
 import okio.internal.commonGet
+import okio.internal.commonHashCode
+import okio.internal.commonIndexOf
+import okio.internal.commonIndexOfElement
+import okio.internal.commonRangeEquals
 import okio.internal.commonRead
+import okio.internal.commonReadAll
 import okio.internal.commonReadByte
 import okio.internal.commonReadByteArray
 import okio.internal.commonReadByteString
 import okio.internal.commonReadFully
 import okio.internal.commonSkip
+import okio.internal.commonReadInt
+import okio.internal.commonReadLong
+import okio.internal.commonReadShort
+import okio.internal.commonReadUtf8
+import okio.internal.commonReadUtf8CodePoint
+import okio.internal.commonReadUtf8Line
+import okio.internal.commonReadUtf8LineStrict
+import okio.internal.commonSelect
 import okio.internal.commonWritableSegment
 import okio.internal.commonWrite
+import okio.internal.commonWriteAll
+import okio.internal.commonWriteByte
+import okio.internal.commonWriteDecimalLong
+import okio.internal.commonWriteInt
+import okio.internal.commonWriteLong
+import okio.internal.commonWriteShort
+import okio.internal.commonWriteUtf8
+import okio.internal.commonWriteUtf8CodePoint
 
 actual class Buffer : BufferedSource, BufferedSink {
   internal actual var head: Segment? = null
@@ -39,13 +61,13 @@ actual class Buffer : BufferedSource, BufferedSink {
 
   actual override fun emit(): Buffer = this // Nowhere to emit to!
 
-  override fun exhausted(): Boolean = TODO()
+  override fun exhausted(): Boolean = size == 0L
 
   override fun require(byteCount: Long) {
-    TODO()
+    if (size < byteCount) throw EOFException()
   }
 
-  override fun request(byteCount: Long): Boolean = TODO()
+  override fun request(byteCount: Long): Boolean = size >= byteCount
 
   override fun peek(): BufferedSource = PeekSource(this).buffer()
 
@@ -64,21 +86,21 @@ actual class Buffer : BufferedSource, BufferedSink {
     offset: Long
   ): Buffer = copyTo(out, offset, size - offset)
 
-  operator fun get(pos: Long): Byte = commonGet(pos)
+  actual operator fun get(pos: Long): Byte = commonGet(pos)
 
   override fun readByte(): Byte = commonReadByte()
 
-  override fun readShort(): Short = TODO()
+  override fun readShort(): Short = commonReadShort()
 
-  override fun readInt(): Int = TODO()
+  override fun readInt(): Int = commonReadInt()
 
-  override fun readLong(): Long = TODO()
+  override fun readLong(): Long = commonReadLong()
 
-  override fun readShortLe(): Short = TODO()
+  override fun readShortLe(): Short = readShort().reverseBytes()
 
-  override fun readIntLe(): Int = TODO()
+  override fun readIntLe(): Int = readInt().reverseBytes()
 
-  override fun readLongLe(): Long = TODO()
+  override fun readLongLe(): Long = readLong().reverseBytes()
 
   override fun readDecimalLong(): Long = TODO()
 
@@ -88,21 +110,23 @@ actual class Buffer : BufferedSource, BufferedSink {
 
   override fun readByteString(byteCount: Long): ByteString = commonReadByteString(byteCount)
 
-  override fun readFully(sink: Buffer, byteCount: Long) = TODO()
+  override fun readFully(sink: Buffer, byteCount: Long): Unit = commonReadFully(sink, byteCount)
 
-  override fun readAll(sink: Sink): Long = TODO()
+  override fun readAll(sink: Sink): Long = commonReadAll(sink)
 
-  override fun readUtf8(): String = TODO()
+  override fun readUtf8(): String = readUtf8(size)
 
-  override fun readUtf8(byteCount: Long): String = TODO()
+  override fun readUtf8(byteCount: Long): String = commonReadUtf8(byteCount)
 
-  override fun readUtf8Line(): String? = TODO()
+  override fun readUtf8Line(): String? = commonReadUtf8Line()
 
-  override fun readUtf8LineStrict(): String = TODO()
+  override fun readUtf8LineStrict(): String = readUtf8LineStrict(Long.MAX_VALUE)
 
-  override fun readUtf8LineStrict(limit: Long): String = TODO()
+  override fun readUtf8LineStrict(limit: Long): String = commonReadUtf8LineStrict(limit)
 
-  override fun readUtf8CodePoint(): Int = TODO()
+  override fun readUtf8CodePoint(): Int = commonReadUtf8CodePoint()
+
+  override fun select(options: Options): Int = commonSelect(options)
 
   override fun readByteArray(): ByteArray = commonReadByteArray()
 
@@ -110,81 +134,85 @@ actual class Buffer : BufferedSource, BufferedSink {
 
   override fun read(sink: ByteArray): Int = commonRead(sink)
 
-  override fun readFully(sink: ByteArray) = commonReadFully(sink)
+  override fun readFully(sink: ByteArray): Unit = commonReadFully(sink)
 
   override fun read(sink: ByteArray, offset: Int, byteCount: Int): Int =
     commonRead(sink, offset, byteCount)
 
-  actual fun clear() = commonClear()
+  actual fun clear(): Unit = commonClear()
 
-  actual override fun skip(byteCount: Long) = commonSkip(byteCount)
+  actual override fun skip(byteCount: Long): Unit = commonSkip(byteCount)
 
   actual override fun write(byteString: ByteString): Buffer = commonWrite(byteString)
 
   internal actual fun writableSegment(minimumCapacity: Int): Segment =
     commonWritableSegment(minimumCapacity)
 
-  actual override fun writeUtf8(string: String): Buffer = TODO()
+  actual override fun writeUtf8(string: String): Buffer = writeUtf8(string, 0, string.length)
 
-  actual override fun writeUtf8(string: String, beginIndex: Int, endIndex: Int): Buffer = TODO()
+  actual override fun writeUtf8(string: String, beginIndex: Int, endIndex: Int): Buffer =
+    commonWriteUtf8(string, beginIndex, endIndex)
 
-  actual override fun writeUtf8CodePoint(codePoint: Int): Buffer = TODO()
+  actual override fun writeUtf8CodePoint(codePoint: Int): Buffer =
+    commonWriteUtf8CodePoint(codePoint)
 
   actual override fun write(source: ByteArray): Buffer = commonWrite(source)
 
   actual override fun write(source: ByteArray, offset: Int, byteCount: Int): Buffer =
     commonWrite(source, offset, byteCount)
 
-  override fun writeAll(source: Source): Long = TODO()
+  override fun writeAll(source: Source): Long = commonWriteAll(source)
 
-  actual override fun write(source: Source, byteCount: Long): Buffer = TODO()
+  actual override fun write(source: Source, byteCount: Long): Buffer =
+    commonWrite(source, byteCount)
 
-  actual override fun writeByte(b: Int): Buffer = TODO()
+  actual override fun writeByte(b: Int): Buffer = commonWriteByte(b)
 
-  actual override fun writeShort(s: Int): Buffer = TODO()
+  actual override fun writeShort(s: Int): Buffer = commonWriteShort(s)
 
-  actual override fun writeShortLe(s: Int): Buffer = TODO()
+  actual override fun writeShortLe(s: Int): Buffer = writeShort(s.reverseBytes())
 
-  actual override fun writeInt(i: Int): Buffer = TODO()
+  actual override fun writeInt(i: Int): Buffer = commonWriteInt(i)
 
-  actual override fun writeIntLe(i: Int): Buffer = TODO()
+  actual override fun writeIntLe(i: Int): Buffer = writeInt(i.reverseBytes())
 
-  actual override fun writeLong(v: Long): Buffer = TODO()
+  actual override fun writeLong(v: Long): Buffer = commonWriteLong(v)
 
-  actual override fun writeLongLe(v: Long): Buffer = TODO()
+  actual override fun writeLongLe(v: Long): Buffer = writeLong(v.reverseBytes())
 
-  actual override fun writeDecimalLong(v: Long): Buffer = TODO()
+  actual override fun writeDecimalLong(v: Long): Buffer = commonWriteDecimalLong(v)
 
   actual override fun writeHexadecimalUnsignedLong(v: Long): Buffer = TODO()
 
-  override fun write(source: Buffer, byteCount: Long) {
-    TODO()
-  }
+  override fun write(source: Buffer, byteCount: Long): Unit = commonWrite(source, byteCount)
 
-  override fun read(sink: Buffer, byteCount: Long): Long = TODO()
+  override fun read(sink: Buffer, byteCount: Long): Long = commonRead(sink, byteCount)
 
-  override fun indexOf(b: Byte): Long = TODO()
+  override fun indexOf(b: Byte): Long = indexOf(b, 0, Long.MAX_VALUE)
 
-  override fun indexOf(b: Byte, fromIndex: Long): Long = TODO()
+  override fun indexOf(b: Byte, fromIndex: Long): Long = indexOf(b, fromIndex, Long.MAX_VALUE)
 
-  override fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long = TODO()
+  override fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long =
+    commonIndexOf(b, fromIndex, toIndex)
 
-  override fun indexOf(bytes: ByteString): Long = TODO()
+  override fun indexOf(bytes: ByteString): Long = indexOf(bytes, 0)
 
-  override fun indexOf(bytes: ByteString, fromIndex: Long): Long = TODO()
+  override fun indexOf(bytes: ByteString, fromIndex: Long): Long = commonIndexOf(bytes, fromIndex)
 
-  override fun indexOfElement(targetBytes: ByteString): Long = TODO()
+  override fun indexOfElement(targetBytes: ByteString): Long = indexOfElement(targetBytes, 0L)
 
-  override fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long = TODO()
+  override fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long =
+    commonIndexOfElement(targetBytes, fromIndex)
 
-  override fun rangeEquals(offset: Long, bytes: ByteString): Boolean = TODO()
+  override fun rangeEquals(offset: Long, bytes: ByteString): Boolean =
+    rangeEquals(offset, bytes, 0, bytes.size)
 
   override fun rangeEquals(
     offset: Long,
     bytes: ByteString,
     bytesOffset: Int,
     byteCount: Int
-  ): Boolean = TODO()
+  ): Boolean = commonRangeEquals(offset, bytes, bytesOffset, byteCount)
 
   override fun flush() {
   }
@@ -192,5 +220,9 @@ actual class Buffer : BufferedSource, BufferedSink {
   override fun close() {
   }
 
-  override fun timeout() = Timeout.NONE
+  override fun timeout(): Timeout = Timeout.NONE
+
+  override fun equals(other: Any?): Boolean = commonEquals(other)
+
+  override fun hashCode(): Int = commonHashCode()
 }

--- a/okio/src/jsMain/kotlin/okio/BufferedSource.kt
+++ b/okio/src/jsMain/kotlin/okio/BufferedSource.kt
@@ -48,6 +48,8 @@ actual interface BufferedSource : Source {
 
   actual fun readByteString(byteCount: Long): ByteString
 
+  actual fun select(options: Options): Int
+
   actual fun readByteArray(): ByteArray
 
   actual fun readByteArray(byteCount: Long): ByteArray

--- a/okio/src/jvmMain/kotlin/okio/BufferedSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/BufferedSource.kt
@@ -294,7 +294,7 @@ actual interface BufferedSource : Source, ReadableByteChannel {
    * ```
    */
   @Throws(IOException::class)
-  fun select(options: Options): Int
+  actual fun select(options: Options): Int
 
   /** Removes all bytes from this and returns them as a byte array. */
   @Throws(IOException::class)

--- a/okio/src/jvmMain/kotlin/okio/RealBufferedSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/RealBufferedSource.kt
@@ -15,6 +15,8 @@
  */
 package okio
 
+import okio.internal.readUtf8Line
+import okio.internal.selectPrefix
 import java.io.EOFException
 import java.io.IOException
 import java.io.InputStream

--- a/okio/src/nativeMain/kotlin/okio/BufferedSource.kt
+++ b/okio/src/nativeMain/kotlin/okio/BufferedSource.kt
@@ -48,6 +48,8 @@ actual interface BufferedSource : Source {
 
   actual fun readByteString(byteCount: Long): ByteString
 
+  actual fun select(options: Options): Int
+
   actual fun readByteArray(): ByteArray
 
   actual fun readByteArray(byteCount: Long): ByteArray


### PR DESCRIPTION
Cut-pasted all the Buffer methods which don't rely on Java specifics to Kotlin/Common. Also copied the buffer unit tests but left the existing tests as is. Want to make sure we maintain that coverage during this transition.

 I'll go through and point out anything I did which might be questionable.