### PR TITLE
Copy RealBufferedSink and RealBufferedSource to Kotlin/Common

### DIFF
--- a/okio/src/commonMain/kotlin/okio/-Util.kt
+++ b/okio/src/commonMain/kotlin/okio/-Util.kt
@@ -91,36 +91,62 @@ internal fun arrayRangeEquals(
 }
 
 internal fun Byte.toHexString(): String {
-  val result = CharArray(4)
-  result[0] = '0'
-  result[1] = 'x'
-  result[2] = HEX_DIGIT_CHARS[this shr 4 and 0xf]
-  result[3] = HEX_DIGIT_CHARS[this       and 0xf] // ktlint-disable no-multi-spaces
+  val result = CharArray(2)
+  result[0] = HEX_DIGIT_CHARS[this shr 4 and 0xf]
+  result[1] = HEX_DIGIT_CHARS[this       and 0xf] // ktlint-disable no-multi-spaces
   return String(result)
 }
 
 internal fun Int.toHexString(): String {
-  val result = CharArray(10)
-  result[2] = HEX_DIGIT_CHARS[this shr 28 and 0xf]
-  result[3] = HEX_DIGIT_CHARS[this shr 24 and 0xf]
-  result[4] = HEX_DIGIT_CHARS[this shr 20 and 0xf]
-  result[5] = HEX_DIGIT_CHARS[this shr 16 and 0xf]
-  result[6] = HEX_DIGIT_CHARS[this shr 12 and 0xf]
-  result[7] = HEX_DIGIT_CHARS[this shr 8  and 0xf] // ktlint-disable no-multi-spaces
-  result[8] = HEX_DIGIT_CHARS[this shr 4  and 0xf] // ktlint-disable no-multi-spaces
-  result[9] = HEX_DIGIT_CHARS[this        and 0xf] // ktlint-disable no-multi-spaces
+  if (this == 0) return "0" // Required as code below does not handle 0
+
+  val result = CharArray(8)
+  result[0] = HEX_DIGIT_CHARS[this shr 28 and 0xf]
+  result[1] = HEX_DIGIT_CHARS[this shr 24 and 0xf]
+  result[2] = HEX_DIGIT_CHARS[this shr 20 and 0xf]
+  result[3] = HEX_DIGIT_CHARS[this shr 16 and 0xf]
+  result[4] = HEX_DIGIT_CHARS[this shr 12 and 0xf]
+  result[5] = HEX_DIGIT_CHARS[this shr 8  and 0xf] // ktlint-disable no-multi-spaces
+  result[6] = HEX_DIGIT_CHARS[this shr 4  and 0xf] // ktlint-disable no-multi-spaces
+  result[7] = HEX_DIGIT_CHARS[this        and 0xf] // ktlint-disable no-multi-spaces
 
   // Find the first non-zero index
-  var i = 2
-  while (i < 10) {
+  var i = 0
+  while (i < result.size) {
     if (result[i] != '0') break
     i++
   }
 
-  // shift and insert "0x"
-  i -= 2
-  result[i] = '0'
-  result[i + 1] = 'x'
+  return String(result, i, result.size - i)
+}
 
-  return String(result, i, 10 - i)
+internal fun Long.toHexString(): String {
+  if (this == 0L) return "0" // Required as code below does not handle 0
+
+  val result = CharArray(16)
+  result[ 0] = HEX_DIGIT_CHARS[(this shr 60 and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[ 1] = HEX_DIGIT_CHARS[(this shr 56 and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[ 2] = HEX_DIGIT_CHARS[(this shr 52 and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[ 3] = HEX_DIGIT_CHARS[(this shr 48 and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[ 4] = HEX_DIGIT_CHARS[(this shr 44 and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[ 5] = HEX_DIGIT_CHARS[(this shr 40 and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[ 6] = HEX_DIGIT_CHARS[(this shr 36 and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[ 7] = HEX_DIGIT_CHARS[(this shr 32 and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[ 8] = HEX_DIGIT_CHARS[(this shr 28 and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[ 9] = HEX_DIGIT_CHARS[(this shr 24 and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[10] = HEX_DIGIT_CHARS[(this shr 20 and 0xf).toInt()]
+  result[11] = HEX_DIGIT_CHARS[(this shr 16 and 0xf).toInt()]
+  result[12] = HEX_DIGIT_CHARS[(this shr 12 and 0xf).toInt()]
+  result[13] = HEX_DIGIT_CHARS[(this shr 8  and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[14] = HEX_DIGIT_CHARS[(this shr 4  and 0xf).toInt()] // ktlint-disable no-multi-spaces
+  result[15] = HEX_DIGIT_CHARS[(this        and 0xf).toInt()] // ktlint-disable no-multi-spaces
+
+  // Find the first non-zero index
+  var i = 0
+  while (i < result.size) {
+    if (result[i] != '0') break
+    i++
+  }
+
+  return String(result, i, result.size - i)
 }

--- a/okio/src/commonMain/kotlin/okio/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/Buffer.kt
@@ -109,6 +109,9 @@ expect class Buffer() : BufferedSource, BufferedSink {
 
   override fun writeHexadecimalUnsignedLong(v: Long): Buffer
 
+  /** Returns a deep copy of this buffer.  */
+  fun copy(): Buffer
+
   /** Returns an immutable copy of this buffer as a byte string.  */
   fun snapshot(): ByteString
 

--- a/okio/src/commonMain/kotlin/okio/Okio.kt
+++ b/okio/src/commonMain/kotlin/okio/Okio.kt
@@ -29,4 +29,11 @@ expect fun Source.buffer(): BufferedSource
 expect fun Sink.buffer(): BufferedSink
 
 /** Returns a sink that writes nowhere. */
-expect fun blackholeSink(): Sink
+expect fun blackholeSink(): Sink // expect/actual required for Java interop
+
+internal class BlackholeSink : Sink {
+  override fun write(source: Buffer, byteCount: Long) = source.skip(byteCount)
+  override fun flush() {}
+  override fun timeout() = Timeout.NONE
+  override fun close() {}
+}

--- a/okio/src/commonMain/kotlin/okio/RealBufferedSink.kt
+++ b/okio/src/commonMain/kotlin/okio/RealBufferedSink.kt
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package okio
 
-actual fun Source.buffer(): BufferedSource = RealBufferedSource(this)
-
-actual fun Sink.buffer(): BufferedSink = RealBufferedSink(this)
-
-actual fun blackholeSink(): Sink = BlackholeSink()
+internal expect class RealBufferedSink(
+  sink: Sink
+) : BufferedSink {
+  val sink: Sink
+  var closed: Boolean
+}

--- a/okio/src/commonMain/kotlin/okio/RealBufferedSource.kt
+++ b/okio/src/commonMain/kotlin/okio/RealBufferedSource.kt
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package okio
 
-actual fun Source.buffer(): BufferedSource = RealBufferedSource(this)
-
-actual fun Sink.buffer(): BufferedSink = RealBufferedSink(this)
-
-actual fun blackholeSink(): Sink = BlackholeSink()
+internal expect class RealBufferedSource(
+  source: Source
+) : BufferedSource {
+  val source: Source
+  var closed: Boolean
+}

--- a/okio/src/commonMain/kotlin/okio/internal/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/Buffer.kt
@@ -665,7 +665,7 @@ internal inline fun Buffer.commonReadDecimalLong(): Long {
       } else {
         if (seen == 0) {
           throw NumberFormatException(
-            "Expected leading [0-9] or '-' character but was ${b.toHexString()}")
+            "Expected leading [0-9] or '-' character but was 0x${b.toHexString()}")
         }
         // Set a flag to stop iteration. We still need to run through segment updating below.
         done = true
@@ -714,7 +714,7 @@ internal inline fun Buffer.commonReadHexadecimalUnsignedLong(): Long {
       } else {
         if (seen == 0) {
           throw NumberFormatException(
-            "Expected leading [0-9a-fA-F] character but was ${b.toHexString()}")
+            "Expected leading [0-9a-fA-F] character but was 0x${b.toHexString()}")
         }
         // Set a flag to stop iteration. We still need to run through segment updating below.
         done = true
@@ -866,7 +866,7 @@ internal inline fun Buffer.commonReadUtf8CodePoint(): Int {
   }
 
   if (size < byteCount) {
-    throw EOFException("size < $byteCount: $size (to read code point prefixed ${b0.toHexString()})")
+    throw EOFException("size < $byteCount: $size (to read code point prefixed 0x${b0.toHexString()})")
   }
 
   // Read the continuation bytes. If we encounter a non-continuation byte, the sequence consumed
@@ -1035,7 +1035,7 @@ internal inline fun Buffer.commonWriteUtf8CodePoint(codePoint: Int): Buffer {
       size += 4L
     }
     else -> {
-      throw IllegalArgumentException("Unexpected code point: ${codePoint.toHexString()}")
+      throw IllegalArgumentException("Unexpected code point: 0x${codePoint.toHexString()}")
     }
   }
 
@@ -1406,6 +1406,27 @@ internal inline fun Buffer.commonHashCode(): Int {
     }
     s = s.next!!
   } while (s !== head)
+  return result
+}
+
+internal inline fun Buffer.commonCopy(): Buffer {
+  val result = Buffer()
+  if (size == 0L) return result
+
+  val head = head!!
+  val headCopy = head.sharedCopy()
+
+  result.head = headCopy
+  headCopy.prev = result.head
+  headCopy.next = headCopy.prev
+
+  var s = head.next
+  while (s !== head) {
+    headCopy.prev!!.push(s!!.sharedCopy())
+    s = s.next
+  }
+
+  result.size = size
   return result
 }
 

--- a/okio/src/commonMain/kotlin/okio/internal/RealBufferedSink.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/RealBufferedSink.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO move to RealBufferedSink class: https://youtrack.jetbrains.com/issue/KT-20427
+@file:Suppress("NOTHING_TO_INLINE")
+
+package okio.internal
+
+import okio.Buffer
+import okio.BufferedSink
+import okio.ByteString
+import okio.EOFException
+import okio.RealBufferedSink
+import okio.Segment
+import okio.Source
+
+internal inline fun RealBufferedSink.commonWrite(source: Buffer, byteCount: Long) {
+  check(!closed) { "closed" }
+  buffer.write(source, byteCount)
+  emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWrite(byteString: ByteString): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.write(byteString)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWrite(
+  byteString: ByteString,
+  offset: Int,
+  byteCount: Int
+): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.write(byteString, offset, byteCount)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteUtf8(string: String): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeUtf8(string)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteUtf8(
+  string: String,
+  beginIndex: Int,
+  endIndex: Int
+): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeUtf8(string, beginIndex, endIndex)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteUtf8CodePoint(codePoint: Int): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeUtf8CodePoint(codePoint)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWrite(source: ByteArray): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.write(source)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWrite(
+  source: ByteArray,
+  offset: Int,
+  byteCount: Int
+): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.write(source, offset, byteCount)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteAll(source: Source): Long {
+  var totalBytesRead = 0L
+  while (true) {
+    val readCount: Long = source.read(buffer, Segment.SIZE.toLong())
+    if (readCount == -1L) break
+    totalBytesRead += readCount
+    emitCompleteSegments()
+  }
+  return totalBytesRead
+}
+
+internal inline fun RealBufferedSink.commonWrite(source: Source, byteCount: Long): BufferedSink {
+  var byteCount = byteCount
+  while (byteCount > 0L) {
+    val read = source.read(buffer, byteCount)
+    if (read == -1L) throw EOFException()
+    byteCount -= read
+    emitCompleteSegments()
+  }
+  return this
+}
+
+internal inline fun RealBufferedSink.commonWriteByte(b: Int): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeByte(b)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteShort(s: Int): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeShort(s)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteShortLe(s: Int): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeShortLe(s)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteInt(i: Int): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeInt(i)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteIntLe(i: Int): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeIntLe(i)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteLong(v: Long): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeLong(v)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteLongLe(v: Long): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeLongLe(v)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteDecimalLong(v: Long): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeDecimalLong(v)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonWriteHexadecimalUnsignedLong(v: Long): BufferedSink {
+  check(!closed) { "closed" }
+  buffer.writeHexadecimalUnsignedLong(v)
+  return emitCompleteSegments()
+}
+
+internal inline fun RealBufferedSink.commonEmitCompleteSegments(): BufferedSink {
+  check(!closed) { "closed" }
+  val byteCount = buffer.completeSegmentByteCount()
+  if (byteCount > 0L) sink.write(buffer, byteCount)
+  return this
+}
+
+internal inline fun RealBufferedSink.commonEmit(): BufferedSink {
+  check(!closed) { "closed" }
+  val byteCount = buffer.size
+  if (byteCount > 0L) sink.write(buffer, byteCount)
+  return this
+}
+
+internal inline fun RealBufferedSink.commonFlush() {
+  check(!closed) { "closed" }
+  if (buffer.size > 0L) {
+    sink.write(buffer, buffer.size)
+  }
+  sink.flush()
+}
+
+internal inline fun RealBufferedSink.commonClose() {
+  if (closed) return
+
+  // Emit buffered data to the underlying sink. If this fails, we still need
+  // to close the sink; otherwise we risk leaking resources.
+  var thrown: Throwable? = null
+  try {
+    if (buffer.size > 0) {
+      sink.write(buffer, buffer.size)
+    }
+  } catch (e: Throwable) {
+    thrown = e
+  }
+
+  try {
+    sink.close()
+  } catch (e: Throwable) {
+    if (thrown == null) thrown = e
+  }
+
+  closed = true
+
+  if (thrown != null) throw thrown
+}
+
+internal inline fun RealBufferedSink.commonTimeout() = sink.timeout()
+
+internal inline fun RealBufferedSink.commonToString() = "buffer($sink)"

--- a/okio/src/commonMain/kotlin/okio/internal/RealBufferedSource.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/RealBufferedSource.kt
@@ -1,0 +1,398 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO move to RealBufferedSource class: https://youtrack.jetbrains.com/issue/KT-20427
+@file:Suppress("NOTHING_TO_INLINE")
+
+package okio.internal
+
+import okio.Buffer
+import okio.BufferedSource
+import okio.ByteString
+import okio.EOFException
+import okio.Options
+import okio.PeekSource
+import okio.RealBufferedSource
+import okio.Segment
+import okio.Sink
+import okio.buffer
+import okio.checkOffsetAndCount
+
+internal inline fun RealBufferedSource.commonRead(sink: Buffer, byteCount: Long): Long {
+  require(byteCount >= 0) { "byteCount < 0: $byteCount" }
+  check(!closed) { "closed" }
+
+  if (buffer.size == 0L) {
+    val read = source.read(buffer, Segment.SIZE.toLong())
+    if (read == -1L) return -1L
+  }
+
+  val toRead = minOf(byteCount, buffer.size)
+  return buffer.read(sink, toRead)
+}
+
+internal inline fun RealBufferedSource.commonExhausted(): Boolean {
+  check(!closed) { "closed" }
+  return buffer.exhausted() && source.read(buffer, Segment.SIZE.toLong()) == -1L
+}
+
+internal inline fun RealBufferedSource.commonRequire(byteCount: Long) {
+  if (!request(byteCount)) throw EOFException()
+}
+
+internal inline fun RealBufferedSource.commonRequest(byteCount: Long): Boolean {
+  require(byteCount >= 0) { "byteCount < 0: $byteCount" }
+  check(!closed) { "closed" }
+  while (buffer.size < byteCount) {
+    if (source.read(buffer, Segment.SIZE.toLong()) == -1L) return false
+  }
+  return true
+}
+
+internal inline fun RealBufferedSource.commonReadByte(): Byte {
+  require(1)
+  return buffer.readByte()
+}
+
+internal inline fun RealBufferedSource.commonReadByteString(): ByteString {
+  buffer.writeAll(source)
+  return buffer.readByteString()
+}
+
+internal inline fun RealBufferedSource.commonReadByteString(byteCount: Long): ByteString {
+  require(byteCount)
+  return buffer.readByteString(byteCount)
+}
+
+internal inline fun RealBufferedSource.commonSelect(options: Options): Int {
+  check(!closed) { "closed" }
+
+  while (true) {
+    val index = buffer.selectPrefix(options, selectTruncated = true)
+    when (index) {
+      -1 -> {
+        return -1
+      }
+      -2 -> {
+        // We need to grow the buffer. Do that, then try it all again.
+        if (source.read(buffer, Segment.SIZE.toLong()) == -1L) return -1
+      }
+      else -> {
+        // We matched a full byte string: consume it and return it.
+        val selectedSize = options.byteStrings[index].size
+        buffer.skip(selectedSize.toLong())
+        return index
+      }
+    }
+  }
+}
+
+internal inline fun RealBufferedSource.commonReadByteArray(): ByteArray {
+  buffer.writeAll(source)
+  return buffer.readByteArray()
+}
+
+internal inline fun RealBufferedSource.commonReadByteArray(byteCount: Long): ByteArray {
+  require(byteCount)
+  return buffer.readByteArray(byteCount)
+}
+
+internal inline fun RealBufferedSource.commonReadFully(sink: ByteArray) {
+  try {
+    require(sink.size.toLong())
+  } catch (e: EOFException) {
+    // The underlying source is exhausted. Copy the bytes we got before rethrowing.
+    var offset = 0
+    while (buffer.size > 0L) {
+      val read = buffer.read(sink, offset, buffer.size.toInt())
+      if (read == -1) throw AssertionError()
+      offset += read
+    }
+    throw e
+  }
+
+  buffer.readFully(sink)
+}
+
+internal inline fun RealBufferedSource.commonRead(sink: ByteArray, offset: Int, byteCount: Int): Int {
+  checkOffsetAndCount(sink.size.toLong(), offset.toLong(), byteCount.toLong())
+
+  if (buffer.size == 0L) {
+    val read = source.read(buffer, Segment.SIZE.toLong())
+    if (read == -1L) return -1
+  }
+
+  val toRead = okio.minOf(byteCount, buffer.size).toInt()
+  return buffer.read(sink, offset, toRead)
+}
+
+internal inline fun RealBufferedSource.commonReadFully(sink: Buffer, byteCount: Long) {
+  try {
+    require(byteCount)
+  } catch (e: EOFException) {
+    // The underlying source is exhausted. Copy the bytes we got before rethrowing.
+    sink.writeAll(buffer)
+    throw e
+  }
+
+  buffer.readFully(sink, byteCount)
+}
+
+internal inline fun RealBufferedSource.commonReadAll(sink: Sink): Long {
+  var totalBytesWritten: Long = 0
+  while (source.read(buffer, Segment.SIZE.toLong()) != -1L) {
+    val emitByteCount = buffer.completeSegmentByteCount()
+    if (emitByteCount > 0L) {
+      totalBytesWritten += emitByteCount
+      sink.write(buffer, emitByteCount)
+    }
+  }
+  if (buffer.size > 0L) {
+    totalBytesWritten += buffer.size
+    sink.write(buffer, buffer.size)
+  }
+  return totalBytesWritten
+}
+
+internal inline fun RealBufferedSource.commonReadUtf8(): String {
+  buffer.writeAll(source)
+  return buffer.readUtf8()
+}
+
+internal inline fun RealBufferedSource.commonReadUtf8(byteCount: Long): String {
+  require(byteCount)
+  return buffer.readUtf8(byteCount)
+}
+
+internal inline fun RealBufferedSource.commonReadUtf8Line(): String? {
+  val newline = indexOf('\n'.toByte())
+
+  return if (newline == -1L) {
+    if (buffer.size != 0L) {
+      readUtf8(buffer.size)
+    } else {
+      null
+    }
+  } else {
+    buffer.readUtf8Line(newline)
+  }
+}
+
+internal inline fun RealBufferedSource.commonReadUtf8LineStrict(limit: Long): String {
+  require(limit >= 0) { "limit < 0: $limit" }
+  val scanLength = if (limit == Long.MAX_VALUE) Long.MAX_VALUE else limit + 1
+  val newline = indexOf('\n'.toByte(), 0, scanLength)
+  if (newline != -1L) return buffer.readUtf8Line(newline)
+  if (scanLength < Long.MAX_VALUE &&
+    request(scanLength) && buffer[scanLength - 1] == '\r'.toByte() &&
+    request(scanLength + 1) && buffer[scanLength] == '\n'.toByte()
+  ) {
+    return buffer.readUtf8Line(scanLength) // The line was 'limit' UTF-8 bytes followed by \r\n.
+  }
+  val data = Buffer()
+  buffer.copyTo(data, 0, okio.minOf(32, buffer.size))
+  throw EOFException(
+    "\\n not found: limit=" + minOf(buffer.size, limit) +
+      " content=" + data.readByteString().hex() + '…'.toString()
+  )
+}
+
+internal inline fun RealBufferedSource.commonReadUtf8CodePoint(): Int {
+  require(1)
+
+  val b0 = buffer[0].toInt()
+  when {
+    b0 and 0xe0 == 0xc0 -> require(2)
+    b0 and 0xf0 == 0xe0 -> require(3)
+    b0 and 0xf8 == 0xf0 -> require(4)
+  }
+
+  return buffer.readUtf8CodePoint()
+}
+
+internal inline fun RealBufferedSource.commonReadShort(): Short {
+  require(2)
+  return buffer.readShort()
+}
+
+internal inline fun RealBufferedSource.commonReadShortLe(): Short {
+  require(2)
+  return buffer.readShortLe()
+}
+
+internal inline fun RealBufferedSource.commonReadInt(): Int {
+  require(4)
+  return buffer.readInt()
+}
+
+internal inline fun RealBufferedSource.commonReadIntLe(): Int {
+  require(4)
+  return buffer.readIntLe()
+}
+
+internal inline fun RealBufferedSource.commonReadLong(): Long {
+  require(8)
+  return buffer.readLong()
+}
+
+internal inline fun RealBufferedSource.commonReadLongLe(): Long {
+  require(8)
+  return buffer.readLongLe()
+}
+
+internal inline fun RealBufferedSource.commonReadDecimalLong(): Long {
+  require(1)
+
+  var pos = 0L
+  while (request(pos + 1)) {
+    val b = buffer[pos]
+    if ((b < '0'.toByte() || b > '9'.toByte()) && (pos != 0L || b != '-'.toByte())) {
+      // Non-digit, or non-leading negative sign.
+      if (pos == 0L) {
+        throw NumberFormatException("Expected leading [0-9] or '-' character but was 0x${b.toString(16)}")
+      }
+      break
+    }
+    pos++
+  }
+
+  return buffer.readDecimalLong()
+}
+
+internal inline fun RealBufferedSource.commonReadHexadecimalUnsignedLong(): Long {
+  require(1)
+
+  var pos = 0
+  while (request((pos + 1).toLong())) {
+    val b = buffer[pos.toLong()]
+    if ((b < '0'.toByte() || b > '9'.toByte()) &&
+      (b < 'a'.toByte() || b > 'f'.toByte()) &&
+      (b < 'A'.toByte() || b > 'F'.toByte())
+    ) {
+      // Non-digit, or non-leading negative sign.
+      if (pos == 0) {
+        throw NumberFormatException("Expected leading [0-9a-fA-F] character but was 0x${b.toString(16)}")
+      }
+      break
+    }
+    pos++
+  }
+
+  return buffer.readHexadecimalUnsignedLong()
+}
+
+internal inline fun RealBufferedSource.commonSkip(byteCount: Long) {
+  var byteCount = byteCount
+  check(!closed) { "closed" }
+  while (byteCount > 0) {
+    if (buffer.size == 0L && source.read(buffer, Segment.SIZE.toLong()) == -1L) {
+      throw EOFException()
+    }
+    val toSkip = minOf(byteCount, buffer.size)
+    buffer.skip(toSkip)
+    byteCount -= toSkip
+  }
+}
+
+internal inline fun RealBufferedSource.commonIndexOf(b: Byte, fromIndex: Long, toIndex: Long): Long {
+  var fromIndex = fromIndex
+  check(!closed) { "closed" }
+  require(fromIndex in 0L..toIndex) { "fromIndex=$fromIndex toIndex=$toIndex" }
+
+  while (fromIndex < toIndex) {
+    val result = buffer.indexOf(b, fromIndex, toIndex)
+    if (result != -1L) return result
+
+    // The byte wasn't in the buffer. Give up if we've already reached our target size or if the
+    // underlying stream is exhausted.
+    val lastBufferSize = buffer.size
+    if (lastBufferSize >= toIndex || source.read(buffer, Segment.SIZE.toLong()) == -1L) return -1L
+
+    // Continue the search from where we left off.
+    fromIndex = maxOf(fromIndex, lastBufferSize)
+  }
+  return -1L
+}
+
+internal inline fun RealBufferedSource.commonIndexOf(bytes: ByteString, fromIndex: Long): Long {
+  var fromIndex = fromIndex
+  check(!closed) { "closed" }
+
+  while (true) {
+    val result = buffer.indexOf(bytes, fromIndex)
+    if (result != -1L) return result
+
+    val lastBufferSize = buffer.size
+    if (source.read(buffer, Segment.SIZE.toLong()) == -1L) return -1L
+
+    // Keep searching, picking up from where we left off.
+    fromIndex = maxOf(fromIndex, lastBufferSize - bytes.size + 1)
+  }
+}
+
+internal inline fun RealBufferedSource.commonIndexOfElement(targetBytes: ByteString, fromIndex: Long): Long {
+  var fromIndex = fromIndex
+  check(!closed) { "closed" }
+
+  while (true) {
+    val result = buffer.indexOfElement(targetBytes, fromIndex)
+    if (result != -1L) return result
+
+    val lastBufferSize = buffer.size
+    if (source.read(buffer, Segment.SIZE.toLong()) == -1L) return -1L
+
+    // Keep searching, picking up from where we left off.
+    fromIndex = maxOf(fromIndex, lastBufferSize)
+  }
+}
+
+internal inline fun RealBufferedSource.commonRangeEquals(
+  offset: Long,
+  bytes: ByteString,
+  bytesOffset: Int,
+  byteCount: Int
+): Boolean {
+  check(!closed) { "closed" }
+
+  if (offset < 0L ||
+    bytesOffset < 0 ||
+    byteCount < 0 ||
+    bytes.size - bytesOffset < byteCount
+  ) {
+    return false
+  }
+  for (i in 0 until byteCount) {
+    val bufferOffset = offset + i
+    if (!request(bufferOffset + 1)) return false
+    if (buffer[bufferOffset] != bytes[bytesOffset + i]) return false
+  }
+  return true
+}
+
+internal inline fun RealBufferedSource.commonPeek(): BufferedSource {
+  return PeekSource(this).buffer()
+}
+
+internal inline fun RealBufferedSource.commonClose() {
+  if (closed) return
+  closed = true
+  source.close()
+  buffer.clear()
+}
+
+internal inline fun RealBufferedSource.commonTimeout() = source.timeout()
+
+internal inline fun RealBufferedSource.commonToString() = "buffer($source)"

--- a/okio/src/commonTest/kotlin/okio/BufferedSinkFactory.kt
+++ b/okio/src/commonTest/kotlin/okio/BufferedSinkFactory.kt
@@ -13,10 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package okio
 
-actual fun Source.buffer(): BufferedSource = RealBufferedSource(this)
+internal interface BufferedSinkFactory {
 
-actual fun Sink.buffer(): BufferedSink = RealBufferedSink(this)
+  fun create(data: Buffer): BufferedSink
 
-actual fun blackholeSink(): Sink = BlackholeSink()
+  companion object {
+    val BUFFER: BufferedSinkFactory = object : BufferedSinkFactory {
+      override fun create(data: Buffer): BufferedSink {
+        return data
+      }
+    }
+
+    val REAL_BUFFERED_SINK: BufferedSinkFactory = object : BufferedSinkFactory {
+      override fun create(data: Buffer): BufferedSink {
+        return (data as Sink).buffer()
+      }
+    }
+  }
+}

--- a/okio/src/commonTest/kotlin/okio/BufferedSinkTest.kt
+++ b/okio/src/commonTest/kotlin/okio/BufferedSinkTest.kt
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package okio
+
+import okio.ByteString.Companion.encodeUtf8
+import okio.ByteString.Companion.decodeHex
+import kotlin.math.pow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class BufferSinkTest : AbstractBufferedSinkTest(BufferedSinkFactory.BUFFER)
+class RealBufferedSinkTest : AbstractBufferedSinkTest(BufferedSinkFactory.REAL_BUFFERED_SINK)
+
+abstract class AbstractBufferedSinkTest internal constructor(
+  factory: BufferedSinkFactory
+) {
+  private val data: Buffer = Buffer()
+  private val sink: BufferedSink = factory.create(data)
+
+  @Test fun writeNothing() {
+    sink.writeUtf8("")
+    sink.flush()
+    assertEquals(0, data.size)
+  }
+
+  @Test fun writeBytes() {
+    sink.writeByte(0xab)
+    sink.writeByte(0xcd)
+    sink.flush()
+    assertEquals("[hex=abcd]", data.toString())
+  }
+
+  @Test fun writeLastByteInSegment() {
+    sink.writeUtf8("a".repeat(Segment.SIZE - 1))
+    sink.writeByte(0x20)
+    sink.writeByte(0x21)
+    sink.flush()
+    assertEquals(listOf(Segment.SIZE, 1), segmentSizes(data))
+    assertEquals("a".repeat(Segment.SIZE - 1), data.readUtf8(Segment.SIZE - 1L))
+    assertEquals("[text= !]", data.toString())
+  }
+
+  @Test fun writeShort() {
+    sink.writeShort(0xabcd)
+    sink.writeShort(0x4321)
+    sink.flush()
+    assertEquals("[hex=abcd4321]", data.toString())
+  }
+
+  @Test fun writeShortLe() {
+    sink.writeShortLe(0xcdab)
+    sink.writeShortLe(0x2143)
+    sink.flush()
+    assertEquals("[hex=abcd4321]", data.toString())
+  }
+
+  @Test fun writeInt() {
+    sink.writeInt(-0x543210ff)
+    sink.writeInt(-0x789abcdf)
+    sink.flush()
+    assertEquals("[hex=abcdef0187654321]", data.toString())
+  }
+
+  @Test fun writeLastIntegerInSegment() {
+    sink.writeUtf8("a".repeat(Segment.SIZE - 4))
+    sink.writeInt(-0x543210ff)
+    sink.writeInt(-0x789abcdf)
+    sink.flush()
+    assertEquals(listOf(Segment.SIZE, 4), segmentSizes(data))
+    assertEquals("a".repeat(Segment.SIZE - 4), data.readUtf8(Segment.SIZE - 4L))
+    assertEquals("[hex=abcdef0187654321]", data.toString())
+  }
+
+  @Test fun writeIntegerDoesNotQuiteFitInSegment() {
+    sink.writeUtf8("a".repeat(Segment.SIZE - 3))
+    sink.writeInt(-0x543210ff)
+    sink.writeInt(-0x789abcdf)
+    sink.flush()
+    assertEquals(listOf(Segment.SIZE - 3, 8), segmentSizes(data))
+    assertEquals("a".repeat(Segment.SIZE - 3), data.readUtf8(Segment.SIZE - 3L))
+    assertEquals("[hex=abcdef0187654321]", data.toString())
+  }
+
+  @Test fun writeIntLe() {
+    sink.writeIntLe(-0x543210ff)
+    sink.writeIntLe(-0x789abcdf)
+    sink.flush()
+    assertEquals("[hex=01efcdab21436587]", data.toString())
+  }
+
+  @Test fun writeLong() {
+    sink.writeLong(-0x543210fe789abcdfL)
+    sink.writeLong(-0x350145414f4ea400L)
+    sink.flush()
+    assertEquals("[hex=abcdef0187654321cafebabeb0b15c00]", data.toString())
+  }
+
+  @Test fun writeLongLe() {
+    sink.writeLongLe(-0x543210fe789abcdfL)
+    sink.writeLongLe(-0x350145414f4ea400L)
+    sink.flush()
+    assertEquals("[hex=2143658701efcdab005cb1b0bebafeca]", data.toString())
+  }
+
+  @Test fun writeByteString() {
+    sink.write("təˈranəˌsôr".encodeUtf8())
+    sink.flush()
+    assertEquals("74c999cb8872616ec999cb8c73c3b472".decodeHex(), data.readByteString())
+  }
+
+  @Test fun writeByteStringOffset() {
+    sink.write("təˈranəˌsôr".encodeUtf8(), 5, 5)
+    sink.flush()
+    assertEquals("72616ec999".decodeHex(), data.readByteString())
+  }
+
+  @Test fun writeStringUtf8() {
+    sink.writeUtf8("təˈranəˌsôr")
+    sink.flush()
+    assertEquals("74c999cb8872616ec999cb8c73c3b472".decodeHex(), data.readByteString())
+  }
+
+  @Test fun writeSubstringUtf8() {
+    sink.writeUtf8("təˈranəˌsôr", 3, 7)
+    sink.flush()
+    assertEquals("72616ec999".decodeHex(), data.readByteString())
+  }
+
+  @Test fun writeAll() {
+    val source = Buffer().writeUtf8("abcdef")
+
+    assertEquals(6, sink.writeAll(source))
+    assertEquals(0, source.size)
+    sink.flush()
+    assertEquals("abcdef", data.readUtf8())
+  }
+
+  @Test fun writeSource() {
+    val source = Buffer().writeUtf8("abcdef")
+
+    // Force resolution of the Source method overload.
+    sink.write(source as Source, 4)
+    sink.flush()
+    assertEquals("abcd", data.readUtf8())
+    assertEquals("ef", source.readUtf8())
+  }
+
+  @Test fun writeSourceReadsFully() {
+    val source = object : Source by Buffer() {
+      override fun read(sink: Buffer, byteCount: Long): Long {
+        sink.writeUtf8("abcd")
+        return 4
+      }
+    }
+
+    sink.write(source, 8)
+    sink.flush()
+    assertEquals("abcdabcd", data.readUtf8())
+  }
+
+  @Test fun writeSourcePropagatesEof() {
+    val source: Source = Buffer().writeUtf8("abcd")
+
+    try {
+      sink.write(source, 8)
+      fail()
+    } catch (expected: EOFException) {
+    }
+
+    // Ensure that whatever was available was correctly written.
+    sink.flush()
+    assertEquals("abcd", data.readUtf8())
+  }
+
+  @Test fun writeSourceWithZeroIsNoOp() {
+    // This test ensures that a zero byte count never calls through to read the source. It may be
+    // tied to something like a socket which will potentially block trying to read a segment when
+    // ultimately we don't want any data.
+    val source = object : Source by Buffer() {
+      override fun read(sink: Buffer, byteCount: Long): Long {
+        throw AssertionError()
+      }
+    }
+    sink.write(source, 0)
+    assertEquals(0, data.size)
+  }
+
+  @Test fun writeAllExhausted() {
+    val source = Buffer()
+    assertEquals(0, sink.writeAll(source))
+    assertEquals(0, source.size)
+  }
+
+  @Test fun closeEmitsBufferedBytes() {
+    sink.writeByte('a'.toInt())
+    sink.close()
+    assertEquals('a', data.readByte().toChar())
+  }
+
+  @Test fun longDecimalString() {
+    assertLongDecimalString(0)
+    assertLongDecimalString(Long.MIN_VALUE)
+    assertLongDecimalString(Long.MAX_VALUE)
+
+    for (i in 1..19) {
+      val value = 10.0.pow(i).toLong()
+      assertLongDecimalString(value - 1)
+      assertLongDecimalString(value)
+    }
+  }
+
+  private fun assertLongDecimalString(value: Long) {
+    sink.writeDecimalLong(value).writeUtf8("zzz").flush()
+    val expected = "${value}zzz"
+    val actual = data.readUtf8()
+    assertEquals(expected, actual, "$value expected $expected but was $actual")
+  }
+
+  @Test fun longHexString() {
+    assertLongHexString(0)
+    assertLongHexString(Long.MIN_VALUE)
+    assertLongHexString(Long.MAX_VALUE)
+
+    for (i in 0..62) {
+      assertLongHexString((1L shl i) - 1)
+      assertLongHexString(1L shl i)
+    }
+  }
+
+  private fun assertLongHexString(value: Long) {
+    sink.writeHexadecimalUnsignedLong(value).writeUtf8("zzz").flush()
+    val expected = "${value.toHexString()}zzz"
+    val actual = data.readUtf8()
+    assertEquals(expected, actual, "$value expected $expected but was $actual")
+  }
+}

--- a/okio/src/commonTest/kotlin/okio/BufferedSourceFactory.kt
+++ b/okio/src/commonTest/kotlin/okio/BufferedSourceFactory.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package okio
+
+internal interface BufferedSourceFactory {
+  class Pipe(
+    var sink: BufferedSink,
+    var source: BufferedSource
+  )
+
+  val isOneByteAtATime: Boolean
+
+  fun pipe(): Pipe
+
+  companion object {
+    val BUFFER: BufferedSourceFactory = object : BufferedSourceFactory {
+
+      override val isOneByteAtATime: Boolean
+        get() = false
+
+      override fun pipe(): Pipe {
+        val buffer = Buffer()
+        return Pipe(
+          buffer,
+          buffer
+        )
+      }
+    }
+
+    val REAL_BUFFERED_SOURCE: BufferedSourceFactory = object :
+      BufferedSourceFactory {
+
+      override val isOneByteAtATime: Boolean
+        get() = false
+
+      override fun pipe(): Pipe {
+        val buffer = Buffer()
+        return Pipe(
+          buffer,
+          (buffer as Source).buffer()
+        )
+      }
+    }
+
+    /**
+     * A factory deliberately written to create buffers whose internal segments are always 1 byte
+     * long. We like testing with these segments because are likely to trigger bugs!
+     */
+    val ONE_BYTE_AT_A_TIME_BUFFERED_SOURCE: BufferedSourceFactory = object :
+      BufferedSourceFactory {
+
+      override val isOneByteAtATime: Boolean
+        get() = true
+
+      override fun pipe(): Pipe {
+        val buffer = Buffer()
+        return Pipe(
+          buffer,
+          object : Source by buffer {
+            override fun read(sink: Buffer, byteCount: Long): Long {
+              // Read one byte into a new buffer, then clone it so that the segment is shared.
+              // Shared segments cannot be compacted so we'll get a long chain of short segments.
+              val box = Buffer()
+              val result = buffer.read(box, minOf(byteCount, 1L))
+              if (result > 0L) sink.write(box.copy(), result)
+              return result
+            }
+          }.buffer()
+        )
+      }
+    }
+
+    val ONE_BYTE_AT_A_TIME_BUFFER: BufferedSourceFactory = object :
+      BufferedSourceFactory {
+
+      override val isOneByteAtATime: Boolean
+        get() = true
+
+      override fun pipe(): Pipe {
+        val buffer = Buffer()
+        return Pipe(
+          object : Sink by buffer {
+            override fun write(source: Buffer, byteCount: Long) {
+              // Write each byte into a new buffer, then clone it so that the segments are shared.
+              // Shared segments cannot be compacted so we'll get a long chain of short segments.
+              for (i in 0 until byteCount) {
+                val box = Buffer()
+                box.write(source, 1)
+                buffer.write(box.copy(), 1)
+              }
+            }
+          }.buffer(),
+          buffer
+        )
+      }
+    }
+
+    val PEEK_BUFFER: BufferedSourceFactory = object : BufferedSourceFactory {
+
+      override val isOneByteAtATime: Boolean
+        get() = false
+
+      override fun pipe(): Pipe {
+        val buffer = Buffer()
+        return Pipe(
+          buffer,
+          buffer.peek()
+        )
+      }
+    }
+
+    val PEEK_BUFFERED_SOURCE: BufferedSourceFactory = object :
+      BufferedSourceFactory {
+
+      override val isOneByteAtATime: Boolean
+        get() = false
+
+      override fun pipe(): Pipe {
+        val buffer = Buffer()
+        return Pipe(
+          buffer,
+          (buffer as Source).buffer().peek()
+        )
+      }
+    }
+  }
+}

--- a/okio/src/commonTest/kotlin/okio/BufferedSourceTest.kt
+++ b/okio/src/commonTest/kotlin/okio/BufferedSourceTest.kt
@@ -1,0 +1,1306 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package okio
+
+import okio.ByteString.Companion.decodeHex
+import okio.ByteString.Companion.encodeUtf8
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class BufferSourceTest : AbstractBufferedSourceTest(BufferedSourceFactory.BUFFER)
+class RealBufferedSourceTest : AbstractBufferedSourceTest(BufferedSourceFactory.REAL_BUFFERED_SOURCE)
+class OneByteAtATimeBufferedSourceTest : AbstractBufferedSourceTest(BufferedSourceFactory.ONE_BYTE_AT_A_TIME_BUFFERED_SOURCE)
+class OneByteAtATimeBufferTest : AbstractBufferedSourceTest(BufferedSourceFactory.ONE_BYTE_AT_A_TIME_BUFFER)
+class PeekBufferTest : AbstractBufferedSourceTest(BufferedSourceFactory.PEEK_BUFFER)
+class PeekBufferedSourceTest : AbstractBufferedSourceTest(BufferedSourceFactory.PEEK_BUFFERED_SOURCE)
+
+abstract class AbstractBufferedSourceTest internal constructor(
+  private val factory: BufferedSourceFactory
+) {
+  private val sink: BufferedSink
+  private val source: BufferedSource
+
+  init {
+    val pipe = factory.pipe()
+    sink = pipe.sink
+    source = pipe.source
+  }
+
+  @Test fun readBytes() {
+    sink.write(byteArrayOf(0xab.toByte(), 0xcd.toByte()))
+    sink.emit()
+    assertEquals(0xab, (source.readByte() and 0xff).toLong())
+    assertEquals(0xcd, (source.readByte() and 0xff).toLong())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readByteTooShortThrows() {
+    try {
+      source.readByte()
+      fail()
+    } catch (expected: EOFException) {
+    }
+  }
+
+  @Test fun readShort() {
+    sink.write(byteArrayOf(0xab.toByte(), 0xcd.toByte(), 0xef.toByte(), 0x01.toByte()))
+    sink.emit()
+    assertEquals(0xabcd.toShort().toLong(), source.readShort().toLong())
+    assertEquals(0xef01.toShort().toLong(), source.readShort().toLong())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readShortLe() {
+    sink.write(byteArrayOf(0xab.toByte(), 0xcd.toByte(), 0xef.toByte(), 0x10.toByte()))
+    sink.emit()
+    assertEquals(0xcdab.toShort().toLong(), source.readShortLe().toLong())
+    assertEquals(0x10ef.toShort().toLong(), source.readShortLe().toLong())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readShortSplitAcrossMultipleSegments() {
+    sink.writeUtf8("a".repeat(Segment.SIZE - 1))
+    sink.write(byteArrayOf(0xab.toByte(), 0xcd.toByte()))
+    sink.emit()
+    source.skip((Segment.SIZE - 1).toLong())
+    assertEquals(0xabcd.toShort().toLong(), source.readShort().toLong())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readShortTooShortThrows() {
+    sink.writeShort(Short.MAX_VALUE.toInt())
+    sink.emit()
+    source.readByte()
+    try {
+      source.readShort()
+      fail()
+    } catch (expected: EOFException) {
+    }
+  }
+
+  @Test fun readShortLeTooShortThrows() {
+    sink.writeShortLe(Short.MAX_VALUE.toInt())
+    sink.emit()
+    source.readByte()
+    try {
+      source.readShortLe()
+      fail()
+    } catch (expected: EOFException) {
+    }
+  }
+
+  @Test fun readInt() {
+    sink.write(
+      byteArrayOf(
+        0xab.toByte(),
+        0xcd.toByte(),
+        0xef.toByte(),
+        0x01.toByte(),
+        0x87.toByte(),
+        0x65.toByte(),
+        0x43.toByte(),
+        0x21.toByte()
+      )
+    )
+    sink.emit()
+    assertEquals(-0x543210ff, source.readInt().toLong())
+    assertEquals(-0x789abcdf, source.readInt().toLong())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readIntLe() {
+    sink.write(
+      byteArrayOf(
+        0xab.toByte(),
+        0xcd.toByte(),
+        0xef.toByte(),
+        0x10.toByte(),
+        0x87.toByte(),
+        0x65.toByte(),
+        0x43.toByte(),
+        0x21.toByte()
+      )
+    )
+    sink.emit()
+    assertEquals(0x10efcdab, source.readIntLe().toLong())
+    assertEquals(0x21436587, source.readIntLe().toLong())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readIntSplitAcrossMultipleSegments() {
+    sink.writeUtf8("a".repeat(Segment.SIZE - 3))
+    sink.write(byteArrayOf(0xab.toByte(), 0xcd.toByte(), 0xef.toByte(), 0x01.toByte()))
+    sink.emit()
+    source.skip((Segment.SIZE - 3).toLong())
+    assertEquals(-0x543210ff, source.readInt().toLong())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readIntTooShortThrows() {
+    sink.writeInt(Int.MAX_VALUE)
+    sink.emit()
+    source.readByte()
+    try {
+      source.readInt()
+      fail()
+    } catch (expected: EOFException) {
+    }
+  }
+
+  @Test fun readIntLeTooShortThrows() {
+    sink.writeIntLe(Int.MAX_VALUE)
+    sink.emit()
+    source.readByte()
+    try {
+      source.readIntLe()
+      fail()
+    } catch (expected: EOFException) {
+    }
+  }
+
+  @Test fun readLong() {
+    sink.write(
+      byteArrayOf(
+        0xab.toByte(),
+        0xcd.toByte(),
+        0xef.toByte(),
+        0x10.toByte(),
+        0x87.toByte(),
+        0x65.toByte(),
+        0x43.toByte(),
+        0x21.toByte(),
+        0x36.toByte(),
+        0x47.toByte(),
+        0x58.toByte(),
+        0x69.toByte(),
+        0x12.toByte(),
+        0x23.toByte(),
+        0x34.toByte(),
+        0x45.toByte()
+      )
+    )
+    sink.emit()
+    assertEquals(-0x543210ef789abcdfL, source.readLong())
+    assertEquals(0x3647586912233445L, source.readLong())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readLongLe() {
+    sink.write(
+      byteArrayOf(
+        0xab.toByte(),
+        0xcd.toByte(),
+        0xef.toByte(),
+        0x10.toByte(),
+        0x87.toByte(),
+        0x65.toByte(),
+        0x43.toByte(),
+        0x21.toByte(),
+        0x36.toByte(),
+        0x47.toByte(),
+        0x58.toByte(),
+        0x69.toByte(),
+        0x12.toByte(),
+        0x23.toByte(),
+        0x34.toByte(),
+        0x45.toByte()
+      )
+    )
+    sink.emit()
+    assertEquals(0x2143658710efcdabL, source.readLongLe())
+    assertEquals(0x4534231269584736L, source.readLongLe())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readLongSplitAcrossMultipleSegments() {
+    sink.writeUtf8("a".repeat(Segment.SIZE - 7))
+    sink.write(
+      byteArrayOf(
+        0xab.toByte(),
+        0xcd.toByte(),
+        0xef.toByte(),
+        0x01.toByte(),
+        0x87.toByte(),
+        0x65.toByte(),
+        0x43.toByte(),
+        0x21.toByte()
+      )
+    )
+    sink.emit()
+    source.skip((Segment.SIZE - 7).toLong())
+    assertEquals(-0x543210fe789abcdfL, source.readLong())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readLongTooShortThrows() {
+    sink.writeLong(Long.MAX_VALUE)
+    sink.emit()
+    source.readByte()
+    try {
+      source.readLong()
+      fail()
+    } catch (expected: EOFException) {
+    }
+  }
+
+  @Test fun readLongLeTooShortThrows() {
+    sink.writeLongLe(Long.MAX_VALUE)
+    sink.emit()
+    source.readByte()
+    try {
+      source.readLongLe()
+      fail()
+    } catch (expected: EOFException) {
+    }
+  }
+
+  @Test fun readAll() {
+    source.buffer.writeUtf8("abc")
+    sink.writeUtf8("def")
+    sink.emit()
+
+    val sink = Buffer()
+    assertEquals(6, source.readAll(sink))
+    assertEquals("abcdef", sink.readUtf8())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readAllExhausted() {
+    val mockSink = MockSink()
+    assertEquals(0, source.readAll(mockSink))
+    assertTrue(source.exhausted())
+    mockSink.assertLog()
+  }
+
+  @Test fun readExhaustedSource() {
+    val sink = Buffer()
+    sink.writeUtf8("a".repeat(10))
+    assertEquals(-1, source.read(sink, 10))
+    assertEquals(10, sink.size)
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readZeroBytesFromSource() {
+    val sink = Buffer()
+    sink.writeUtf8("a".repeat(10))
+
+    // Either 0 or -1 is reasonable here. For consistency with Android's
+    // ByteArrayInputStream we return 0.
+    assertEquals(-1, source.read(sink, 0))
+    assertEquals(10, sink.size)
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun readFully() {
+    sink.writeUtf8("a".repeat(10000))
+    sink.emit()
+    val sink = Buffer()
+    source.readFully(sink, 9999)
+    assertEquals("a".repeat(9999), sink.readUtf8())
+    assertEquals("a", source.readUtf8())
+  }
+
+  @Test fun readFullyTooShortThrows() {
+    sink.writeUtf8("Hi")
+    sink.emit()
+    val sink = Buffer()
+    try {
+      source.readFully(sink, 5)
+      fail()
+    } catch (ignored: EOFException) {
+    }
+
+    // Verify we read all that we could from the source.
+    assertEquals("Hi", sink.readUtf8())
+  }
+
+  @Test fun readFullyByteArray() {
+    val data = Buffer()
+    data.writeUtf8("Hello").writeUtf8("e".repeat(Segment.SIZE))
+
+    val expected = data.copy().readByteArray()
+    sink.write(data, data.size)
+    sink.emit()
+
+    val sink = ByteArray(Segment.SIZE + 5)
+    source.readFully(sink)
+    assertArrayEquals(expected, sink)
+  }
+
+  @Test fun readFullyByteArrayTooShortThrows() {
+    sink.writeUtf8("Hello")
+    sink.emit()
+
+    val array = ByteArray(6)
+    try {
+      source.readFully(array)
+      fail()
+    } catch (ignored: EOFException) {
+    }
+
+    // Verify we read all that we could from the source.
+    assertArrayEquals(
+      byteArrayOf(
+        'H'.toByte(),
+        'e'.toByte(),
+        'l'.toByte(),
+        'l'.toByte(),
+        'o'.toByte(),
+        0
+      ), array
+    )
+  }
+
+  @Test fun readIntoByteArray() {
+    sink.writeUtf8("abcd")
+    sink.emit()
+
+    val sink = ByteArray(3)
+    val read = source.read(sink)
+    if (factory.isOneByteAtATime) {
+      assertEquals(1, read.toLong())
+      val expected = byteArrayOf('a'.toByte(), 0, 0)
+      assertArrayEquals(expected, sink)
+    } else {
+      assertEquals(3, read.toLong())
+      val expected = byteArrayOf('a'.toByte(), 'b'.toByte(), 'c'.toByte())
+      assertArrayEquals(expected, sink)
+    }
+  }
+
+  @Test fun readIntoByteArrayNotEnough() {
+    sink.writeUtf8("abcd")
+    sink.emit()
+
+    val sink = ByteArray(5)
+    val read = source.read(sink)
+    if (factory.isOneByteAtATime) {
+      assertEquals(1, read.toLong())
+      val expected = byteArrayOf('a'.toByte(), 0, 0, 0, 0)
+      assertArrayEquals(expected, sink)
+    } else {
+      assertEquals(4, read.toLong())
+      val expected = byteArrayOf('a'.toByte(), 'b'.toByte(), 'c'.toByte(), 'd'.toByte(), 0)
+      assertArrayEquals(expected, sink)
+    }
+  }
+
+  @Test fun readIntoByteArrayOffsetAndCount() {
+    sink.writeUtf8("abcd")
+    sink.emit()
+
+    val sink = ByteArray(7)
+    val read = source.read(sink, 2, 3)
+    if (factory.isOneByteAtATime) {
+      assertEquals(1, read.toLong())
+      val expected = byteArrayOf(0, 0, 'a'.toByte(), 0, 0, 0, 0)
+      assertArrayEquals(expected, sink)
+    } else {
+      assertEquals(3, read.toLong())
+      val expected = byteArrayOf(0, 0, 'a'.toByte(), 'b'.toByte(), 'c'.toByte(), 0, 0)
+      assertArrayEquals(expected, sink)
+    }
+  }
+
+  @Test fun readByteArray() {
+    val string = "abcd" + "e".repeat(Segment.SIZE)
+    sink.writeUtf8(string)
+    sink.emit()
+    assertArrayEquals(string.asUtf8ToByteArray(), source.readByteArray())
+  }
+
+  @Test fun readByteArrayPartial() {
+    sink.writeUtf8("abcd")
+    sink.emit()
+    assertEquals("[97, 98, 99]", source.readByteArray(3).contentToString())
+    assertEquals("d", source.readUtf8(1))
+  }
+
+  @Test fun readByteArrayTooShortThrows() {
+    sink.writeUtf8("abc")
+    sink.emit()
+    try {
+      source.readByteArray(4)
+      fail()
+    } catch (expected: EOFException) {
+    }
+
+    assertEquals("abc", source.readUtf8()) // The read shouldn't consume any data.
+  }
+
+  @Test fun readByteString() {
+    sink.writeUtf8("abcd").writeUtf8("e".repeat(Segment.SIZE))
+    sink.emit()
+    assertEquals("abcd" + "e".repeat(Segment.SIZE), source.readByteString().utf8())
+  }
+
+  @Test fun readByteStringPartial() {
+    sink.writeUtf8("abcd").writeUtf8("e".repeat(Segment.SIZE))
+    sink.emit()
+    assertEquals("abc", source.readByteString(3).utf8())
+    assertEquals("d", source.readUtf8(1))
+  }
+
+  @Test fun readByteStringTooShortThrows() {
+    sink.writeUtf8("abc")
+    sink.emit()
+    try {
+      source.readByteString(4)
+      fail()
+    } catch (expected: EOFException) {
+    }
+
+    assertEquals("abc", source.readUtf8()) // The read shouldn't consume any data.
+  }
+
+  @Test fun readUtf8SpansSegments() {
+    sink.writeUtf8("a".repeat(Segment.SIZE * 2))
+    sink.emit()
+    source.skip((Segment.SIZE - 1).toLong())
+    assertEquals("aa", source.readUtf8(2))
+  }
+
+  @Test fun readUtf8Segment() {
+    sink.writeUtf8("a".repeat(Segment.SIZE))
+    sink.emit()
+    assertEquals("a".repeat(Segment.SIZE), source.readUtf8(Segment.SIZE.toLong()))
+  }
+
+  @Test fun readUtf8PartialBuffer() {
+    sink.writeUtf8("a".repeat(Segment.SIZE + 20))
+    sink.emit()
+    assertEquals("a".repeat(Segment.SIZE + 10), source.readUtf8((Segment.SIZE + 10).toLong()))
+  }
+
+  @Test fun readUtf8EntireBuffer() {
+    sink.writeUtf8("a".repeat(Segment.SIZE * 2))
+    sink.emit()
+    assertEquals("a".repeat(Segment.SIZE * 2), source.readUtf8())
+  }
+
+  @Test fun readUtf8TooShortThrows() {
+    sink.writeUtf8("abc")
+    sink.emit()
+    try {
+      source.readUtf8(4L)
+      fail()
+    } catch (expected: EOFException) {
+    }
+
+    assertEquals("abc", source.readUtf8()) // The read shouldn't consume any data.
+  }
+
+  @Test fun skip() {
+    sink.writeUtf8("a")
+    sink.writeUtf8("b".repeat(Segment.SIZE))
+    sink.writeUtf8("c")
+    sink.emit()
+    source.skip(1)
+    assertEquals('b'.toLong(), (source.readByte() and 0xff).toLong())
+    source.skip((Segment.SIZE - 2).toLong())
+    assertEquals('b'.toLong(), (source.readByte() and 0xff).toLong())
+    source.skip(1)
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun skipInsufficientData() {
+    sink.writeUtf8("a")
+    sink.emit()
+
+    try {
+      source.skip(2)
+      fail()
+    } catch (ignored: EOFException) {
+    }
+  }
+
+  @Test fun indexOf() {
+    // The segment is empty.
+    assertEquals(-1, source.indexOf('a'.toByte()))
+
+    // The segment has one value.
+    sink.writeUtf8("a") // a
+    sink.emit()
+    assertEquals(0, source.indexOf('a'.toByte()))
+    assertEquals(-1, source.indexOf('b'.toByte()))
+
+    // The segment has lots of data.
+    sink.writeUtf8("b".repeat(Segment.SIZE - 2)) // ab...b
+    sink.emit()
+    assertEquals(0, source.indexOf('a'.toByte()))
+    assertEquals(1, source.indexOf('b'.toByte()))
+    assertEquals(-1, source.indexOf('c'.toByte()))
+
+    // The segment doesn't start at 0, it starts at 2.
+    source.skip(2) // b...b
+    assertEquals(-1, source.indexOf('a'.toByte()))
+    assertEquals(0, source.indexOf('b'.toByte()))
+    assertEquals(-1, source.indexOf('c'.toByte()))
+
+    // The segment is full.
+    sink.writeUtf8("c") // b...bc
+    sink.emit()
+    assertEquals(-1, source.indexOf('a'.toByte()))
+    assertEquals(0, source.indexOf('b'.toByte()))
+    assertEquals((Segment.SIZE - 3).toLong(), source.indexOf('c'.toByte()))
+
+    // The segment doesn't start at 2, it starts at 4.
+    source.skip(2) // b...bc
+    assertEquals(-1, source.indexOf('a'.toByte()))
+    assertEquals(0, source.indexOf('b'.toByte()))
+    assertEquals((Segment.SIZE - 5).toLong(), source.indexOf('c'.toByte()))
+
+    // Two segments.
+    sink.writeUtf8("d") // b...bcd, d is in the 2nd segment.
+    sink.emit()
+    assertEquals((Segment.SIZE - 4).toLong(), source.indexOf('d'.toByte()))
+    assertEquals(-1, source.indexOf('e'.toByte()))
+  }
+
+  @Test fun indexOfByteWithStartOffset() {
+    sink.writeUtf8("a").writeUtf8("b".repeat(Segment.SIZE)).writeUtf8("c")
+    sink.emit()
+    assertEquals(-1, source.indexOf('a'.toByte(), 1))
+    assertEquals(15, source.indexOf('b'.toByte(), 15))
+  }
+
+  @Test fun indexOfByteWithBothOffsets() {
+    if (factory.isOneByteAtATime) {
+      // When run on Travis this causes out-of-memory errors.
+      return
+    }
+    val a = 'a'.toByte()
+    val c = 'c'.toByte()
+
+    val size = Segment.SIZE * 5
+    val bytes = ByteArray(size) { a }
+
+    // These are tricky places where the buffer
+    // starts, ends, or segments come together.
+    val points = intArrayOf(
+      0,
+      1,
+      2,
+      Segment.SIZE - 1,
+      Segment.SIZE,
+      Segment.SIZE + 1,
+      size / 2 - 1,
+      size / 2,
+      size / 2 + 1,
+      size - Segment.SIZE - 1,
+      size - Segment.SIZE,
+      size - Segment.SIZE + 1,
+      size - 3,
+      size - 2,
+      size - 1
+    )
+
+    // In each iteration, we write c to the known point and then search for it using different
+    // windows. Some of the windows don't overlap with c's position, and therefore a match shouldn't
+    // be found.
+    for (p in points) {
+      bytes[p] = c
+      sink.write(bytes)
+      sink.emit()
+
+      assertEquals(p.toLong(), source.indexOf(c, 0, size.toLong()))
+      assertEquals(p.toLong(), source.indexOf(c, 0, (p + 1).toLong()))
+      assertEquals(p.toLong(), source.indexOf(c, p.toLong(), size.toLong()))
+      assertEquals(p.toLong(), source.indexOf(c, p.toLong(), (p + 1).toLong()))
+      assertEquals(p.toLong(), source.indexOf(c, (p / 2).toLong(), (p * 2 + 1).toLong()))
+      assertEquals(-1, source.indexOf(c, 0, (p / 2).toLong()))
+      assertEquals(-1, source.indexOf(c, 0, p.toLong()))
+      assertEquals(-1, source.indexOf(c, 0, 0))
+      assertEquals(-1, source.indexOf(c, p.toLong(), p.toLong()))
+
+      // Reset.
+      source.readUtf8()
+      bytes[p] = a
+    }
+  }
+
+  @Test fun indexOfByteInvalidBoundsThrows() {
+    sink.writeUtf8("abc")
+    sink.emit()
+
+    try {
+      source.indexOf('a'.toByte(), -1)
+      fail("Expected failure: fromIndex < 0")
+    } catch (expected: IllegalArgumentException) {
+    }
+
+    try {
+      source.indexOf('a'.toByte(), 10, 0)
+      fail("Expected failure: fromIndex > toIndex")
+    } catch (expected: IllegalArgumentException) {
+    }
+  }
+
+  @Test fun indexOfByteString() {
+    assertEquals(-1, source.indexOf("flop".encodeUtf8()))
+
+    sink.writeUtf8("flip flop")
+    sink.emit()
+    assertEquals(5, source.indexOf("flop".encodeUtf8()))
+    source.readUtf8() // Clear stream.
+
+    // Make sure we backtrack and resume searching after partial match.
+    sink.writeUtf8("hi hi hi hey")
+    sink.emit()
+    assertEquals(3, source.indexOf("hi hi hey".encodeUtf8()))
+  }
+
+  @Test fun indexOfByteStringAtSegmentBoundary() {
+    sink.writeUtf8("a".repeat(Segment.SIZE - 1))
+    sink.writeUtf8("bcd")
+    sink.emit()
+    assertEquals(
+      (Segment.SIZE - 3).toLong(),
+      source.indexOf("aabc".encodeUtf8(), (Segment.SIZE - 4).toLong())
+    )
+    assertEquals(
+      (Segment.SIZE - 3).toLong(),
+      source.indexOf("aabc".encodeUtf8(), (Segment.SIZE - 3).toLong())
+    )
+    assertEquals(
+      (Segment.SIZE - 2).toLong(),
+      source.indexOf("abcd".encodeUtf8(), (Segment.SIZE - 2).toLong())
+    )
+    assertEquals(
+      (Segment.SIZE - 2).toLong(),
+      source.indexOf("abc".encodeUtf8(), (Segment.SIZE - 2).toLong())
+    )
+    assertEquals(
+      (Segment.SIZE - 2).toLong(),
+      source.indexOf("abc".encodeUtf8(), (Segment.SIZE - 2).toLong())
+    )
+    assertEquals(
+      (Segment.SIZE - 2).toLong(),
+      source.indexOf("ab".encodeUtf8(), (Segment.SIZE - 2).toLong())
+    )
+    assertEquals(
+      (Segment.SIZE - 2).toLong(),
+      source.indexOf("a".encodeUtf8(), (Segment.SIZE - 2).toLong())
+    )
+    assertEquals(
+      (Segment.SIZE - 1).toLong(),
+      source.indexOf("bc".encodeUtf8(), (Segment.SIZE - 2).toLong())
+    )
+    assertEquals(
+      (Segment.SIZE - 1).toLong(),
+      source.indexOf("b".encodeUtf8(), (Segment.SIZE - 2).toLong())
+    )
+    assertEquals(
+      Segment.SIZE.toLong(),
+      source.indexOf("c".encodeUtf8(), (Segment.SIZE - 2).toLong())
+    )
+    assertEquals(
+      Segment.SIZE.toLong(),
+      source.indexOf("c".encodeUtf8(), Segment.SIZE.toLong())
+    )
+    assertEquals(
+      (Segment.SIZE + 1).toLong(),
+      source.indexOf("d".encodeUtf8(), (Segment.SIZE - 2).toLong())
+    )
+    assertEquals(
+      (Segment.SIZE + 1).toLong(),
+      source.indexOf("d".encodeUtf8(), (Segment.SIZE + 1).toLong())
+    )
+  }
+
+  @Test fun indexOfDoesNotWrapAround() {
+    sink.writeUtf8("a".repeat(Segment.SIZE - 1))
+    sink.writeUtf8("bcd")
+    sink.emit()
+    assertEquals(-1, source.indexOf("abcda".encodeUtf8(), (Segment.SIZE - 3).toLong()))
+  }
+
+  @Test fun indexOfByteStringWithOffset() {
+    assertEquals(-1, source.indexOf("flop".encodeUtf8(), 1))
+
+    sink.writeUtf8("flop flip flop")
+    sink.emit()
+    assertEquals(10, source.indexOf("flop".encodeUtf8(), 1))
+    source.readUtf8() // Clear stream
+
+    // Make sure we backtrack and resume searching after partial match.
+    sink.writeUtf8("hi hi hi hi hey")
+    sink.emit()
+    assertEquals(6, source.indexOf("hi hi hey".encodeUtf8(), 1))
+  }
+
+  @Test fun indexOfByteStringInvalidArgumentsThrows() {
+    try {
+      source.indexOf(ByteString.of())
+      fail()
+    } catch (e: IllegalArgumentException) {
+      assertEquals("bytes is empty", e.message)
+    }
+
+    try {
+      source.indexOf("hi".encodeUtf8(), -1)
+      fail()
+    } catch (e: IllegalArgumentException) {
+      assertEquals("fromIndex < 0: -1", e.message)
+    }
+  }
+
+  /**
+   * With [BufferedSourceFactory.ONE_BYTE_AT_A_TIME_BUFFERED_SOURCE], this code was extremely slow.
+   * https://github.com/square/okio/issues/171
+   */
+  @Test fun indexOfByteStringAcrossSegmentBoundaries() {
+    sink.writeUtf8("a".repeat(Segment.SIZE * 2 - 3))
+    sink.writeUtf8("bcdefg")
+    sink.emit()
+    assertEquals((Segment.SIZE * 2 - 4).toLong(), source.indexOf("ab".encodeUtf8()))
+    assertEquals((Segment.SIZE * 2 - 4).toLong(), source.indexOf("abc".encodeUtf8()))
+    assertEquals((Segment.SIZE * 2 - 4).toLong(), source.indexOf("abcd".encodeUtf8()))
+    assertEquals((Segment.SIZE * 2 - 4).toLong(), source.indexOf("abcde".encodeUtf8()))
+    assertEquals((Segment.SIZE * 2 - 4).toLong(), source.indexOf("abcdef".encodeUtf8()))
+    assertEquals((Segment.SIZE * 2 - 4).toLong(), source.indexOf("abcdefg".encodeUtf8()))
+    assertEquals((Segment.SIZE * 2 - 3).toLong(), source.indexOf("bcdefg".encodeUtf8()))
+    assertEquals((Segment.SIZE * 2 - 2).toLong(), source.indexOf("cdefg".encodeUtf8()))
+    assertEquals((Segment.SIZE * 2 - 1).toLong(), source.indexOf("defg".encodeUtf8()))
+    assertEquals((Segment.SIZE * 2).toLong(), source.indexOf("efg".encodeUtf8()))
+    assertEquals((Segment.SIZE * 2 + 1).toLong(), source.indexOf("fg".encodeUtf8()))
+    assertEquals((Segment.SIZE * 2 + 2).toLong(), source.indexOf("g".encodeUtf8()))
+  }
+
+  @Test fun indexOfElement() {
+    sink.writeUtf8("a").writeUtf8("b".repeat(Segment.SIZE)).writeUtf8("c")
+    sink.emit()
+    assertEquals(0, source.indexOfElement("DEFGaHIJK".encodeUtf8()))
+    assertEquals(1, source.indexOfElement("DEFGHIJKb".encodeUtf8()))
+    assertEquals((Segment.SIZE + 1).toLong(), source.indexOfElement("cDEFGHIJK".encodeUtf8()))
+    assertEquals(1, source.indexOfElement("DEFbGHIc".encodeUtf8()))
+    assertEquals(-1L, source.indexOfElement("DEFGHIJK".encodeUtf8()))
+    assertEquals(-1L, source.indexOfElement("".encodeUtf8()))
+  }
+
+  @Test fun indexOfElementWithOffset() {
+    sink.writeUtf8("a").writeUtf8("b".repeat(Segment.SIZE)).writeUtf8("c")
+    sink.emit()
+    assertEquals(-1, source.indexOfElement("DEFGaHIJK".encodeUtf8(), 1))
+    assertEquals(15, source.indexOfElement("DEFGHIJKb".encodeUtf8(), 15))
+  }
+
+  @Test fun indexOfByteWithFromIndex() {
+    sink.writeUtf8("aaa")
+    sink.emit()
+    assertEquals(0, source.indexOf('a'.toByte()))
+    assertEquals(0, source.indexOf('a'.toByte(), 0))
+    assertEquals(1, source.indexOf('a'.toByte(), 1))
+    assertEquals(2, source.indexOf('a'.toByte(), 2))
+  }
+
+  @Test fun indexOfByteStringWithFromIndex() {
+    sink.writeUtf8("aaa")
+    sink.emit()
+    assertEquals(0, source.indexOf("a".encodeUtf8()))
+    assertEquals(0, source.indexOf("a".encodeUtf8(), 0))
+    assertEquals(1, source.indexOf("a".encodeUtf8(), 1))
+    assertEquals(2, source.indexOf("a".encodeUtf8(), 2))
+  }
+
+  @Test fun indexOfElementWithFromIndex() {
+    sink.writeUtf8("aaa")
+    sink.emit()
+    assertEquals(0, source.indexOfElement("a".encodeUtf8()))
+    assertEquals(0, source.indexOfElement("a".encodeUtf8(), 0))
+    assertEquals(1, source.indexOfElement("a".encodeUtf8(), 1))
+    assertEquals(2, source.indexOfElement("a".encodeUtf8(), 2))
+  }
+
+  @Test fun request() {
+    sink.writeUtf8("a").writeUtf8("b".repeat(Segment.SIZE)).writeUtf8("c")
+    sink.emit()
+    assertTrue(source.request((Segment.SIZE + 2).toLong()))
+    assertFalse(source.request((Segment.SIZE + 3).toLong()))
+  }
+
+  @Test fun require() {
+    sink.writeUtf8("a").writeUtf8("b".repeat(Segment.SIZE)).writeUtf8("c")
+    sink.emit()
+    source.require((Segment.SIZE + 2).toLong())
+    try {
+      source.require((Segment.SIZE + 3).toLong())
+      fail()
+    } catch (expected: EOFException) {
+    }
+  }
+
+  @Test fun longHexString() {
+    assertLongHexString("8000000000000000", Long.MIN_VALUE)
+    assertLongHexString("fffffffffffffffe", -0x2L)
+    assertLongHexString("FFFFFFFFFFFFFFFe", -0x2L)
+    assertLongHexString("ffffffffffffffff", -0x1L)
+    assertLongHexString("FFFFFFFFFFFFFFFF", -0x1L)
+    assertLongHexString("0000000000000000", 0x0L)
+    assertLongHexString("0000000000000001", 0x1L)
+    assertLongHexString("7999999999999999", 0x7999999999999999L)
+
+    assertLongHexString("FF", 0xFF)
+    assertLongHexString("0000000000000001", 0x1)
+  }
+
+  @Test fun hexStringWithManyLeadingZeros() {
+    assertLongHexString("00000000000000001", 0x1)
+    assertLongHexString("0000000000000000ffffffffffffffff", -0x1L)
+    assertLongHexString("00000000000000007fffffffffffffff", 0x7fffffffffffffffL)
+    assertLongHexString("0".repeat(Segment.SIZE + 1) + "1", 0x1)
+  }
+
+  private fun assertLongHexString(s: String, expected: Long) {
+    sink.writeUtf8(s)
+    sink.emit()
+    val actual = source.readHexadecimalUnsignedLong()
+    assertEquals(expected, actual, "$s --> $expected")
+  }
+
+  @Test fun longHexStringAcrossSegment() {
+    sink.writeUtf8("a".repeat(Segment.SIZE - 8)).writeUtf8("FFFFFFFFFFFFFFFF")
+    sink.emit()
+    source.skip((Segment.SIZE - 8).toLong())
+    assertEquals(-1, source.readHexadecimalUnsignedLong())
+  }
+
+  @Test fun longHexStringTooLongThrows() {
+    try {
+      sink.writeUtf8("fffffffffffffffff")
+      sink.emit()
+      source.readHexadecimalUnsignedLong()
+      fail()
+    } catch (e: NumberFormatException) {
+      assertEquals("Number too large: fffffffffffffffff", e.message)
+    }
+  }
+
+  @Test fun longHexStringTooShortThrows() {
+    try {
+      sink.writeUtf8(" ")
+      sink.emit()
+      source.readHexadecimalUnsignedLong()
+      fail()
+    } catch (e: NumberFormatException) {
+      assertEquals("Expected leading [0-9a-fA-F] character but was 0x20", e.message)
+    }
+  }
+
+  @Test fun longHexEmptySourceThrows() {
+    try {
+      sink.writeUtf8("")
+      sink.emit()
+      source.readHexadecimalUnsignedLong()
+      fail()
+    } catch (expected: EOFException) {
+    }
+  }
+
+  @Test fun longDecimalString() {
+    assertLongDecimalString("-9223372036854775808", Long.MIN_VALUE)
+    assertLongDecimalString("-1", -1L)
+    assertLongDecimalString("0", 0L)
+    assertLongDecimalString("1", 1L)
+    assertLongDecimalString("9223372036854775807", Long.MAX_VALUE)
+
+    assertLongDecimalString("00000001", 1L)
+    assertLongDecimalString("-000001", -1L)
+  }
+
+  private fun assertLongDecimalString(s: String, expected: Long) {
+    sink.writeUtf8(s)
+    sink.writeUtf8("zzz")
+    sink.emit()
+    val actual = source.readDecimalLong()
+    assertEquals(expected, actual, "$s --> $expected")
+    assertEquals("zzz", source.readUtf8())
+  }
+
+  @Test fun longDecimalStringAcrossSegment() {
+    sink.writeUtf8("a".repeat(Segment.SIZE - 8)).writeUtf8("1234567890123456")
+    sink.writeUtf8("zzz")
+    sink.emit()
+    source.skip((Segment.SIZE - 8).toLong())
+    assertEquals(1234567890123456L, source.readDecimalLong())
+    assertEquals("zzz", source.readUtf8())
+  }
+
+  @Test fun longDecimalStringTooLongThrows() {
+    try {
+      sink.writeUtf8("12345678901234567890") // Too many digits.
+      sink.emit()
+      source.readDecimalLong()
+      fail()
+    } catch (e: NumberFormatException) {
+      assertEquals("Number too large: 12345678901234567890", e.message)
+    }
+  }
+
+  @Test fun longDecimalStringTooHighThrows() {
+    try {
+      sink.writeUtf8("9223372036854775808") // Right size but cannot fit.
+      sink.emit()
+      source.readDecimalLong()
+      fail()
+    } catch (e: NumberFormatException) {
+      assertEquals("Number too large: 9223372036854775808", e.message)
+    }
+  }
+
+  @Test fun longDecimalStringTooLowThrows() {
+    try {
+      sink.writeUtf8("-9223372036854775809") // Right size but cannot fit.
+      sink.emit()
+      source.readDecimalLong()
+      fail()
+    } catch (e: NumberFormatException) {
+      assertEquals("Number too large: -9223372036854775809", e.message)
+    }
+  }
+
+  @Test fun longDecimalStringTooShortThrows() {
+    try {
+      sink.writeUtf8(" ")
+      sink.emit()
+      source.readDecimalLong()
+      fail()
+    } catch (e: NumberFormatException) {
+      assertEquals("Expected leading [0-9] or '-' character but was 0x20", e.message)
+    }
+  }
+
+  @Test fun longDecimalEmptyThrows() {
+    try {
+      sink.writeUtf8("")
+      sink.emit()
+      source.readDecimalLong()
+      fail()
+    } catch (expected: EOFException) {
+    }
+  }
+
+  @Test fun codePoints() {
+    sink.write("7f".decodeHex())
+    sink.emit()
+    assertEquals(0x7f, source.readUtf8CodePoint().toLong())
+
+    sink.write("dfbf".decodeHex())
+    sink.emit()
+    assertEquals(0x07ff, source.readUtf8CodePoint().toLong())
+
+    sink.write("efbfbf".decodeHex())
+    sink.emit()
+    assertEquals(0xffff, source.readUtf8CodePoint().toLong())
+
+    sink.write("f48fbfbf".decodeHex())
+    sink.emit()
+    assertEquals(0x10ffff, source.readUtf8CodePoint().toLong())
+  }
+
+  @Test fun decimalStringWithManyLeadingZeros() {
+    assertLongDecimalString("00000000000000001", 1)
+    assertLongDecimalString("00000000000000009223372036854775807", Long.MAX_VALUE)
+    assertLongDecimalString("-00000000000000009223372036854775808", Long.MIN_VALUE)
+    assertLongDecimalString("0".repeat(Segment.SIZE + 1) + "1", 1)
+  }
+
+  @Test fun select() {
+    val options = Options.of(
+      "ROCK".encodeUtf8(),
+      "SCISSORS".encodeUtf8(),
+      "PAPER".encodeUtf8()
+    )
+
+    sink.writeUtf8("PAPER,SCISSORS,ROCK")
+    sink.emit()
+    assertEquals(2, source.select(options).toLong())
+    assertEquals(','.toLong(), source.readByte().toLong())
+    assertEquals(1, source.select(options).toLong())
+    assertEquals(','.toLong(), source.readByte().toLong())
+    assertEquals(0, source.select(options).toLong())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun selectSpanningMultipleSegments() {
+    val commonPrefix = randomBytes(Segment.SIZE + 10)
+    val a = Buffer().write(commonPrefix).writeUtf8("a").readByteString()
+    val bc = Buffer().write(commonPrefix).writeUtf8("bc").readByteString()
+    val bd = Buffer().write(commonPrefix).writeUtf8("bd").readByteString()
+    val options = Options.of(a, bc, bd)
+
+    sink.write(bd)
+    sink.write(a)
+    sink.write(bc)
+    sink.emit()
+
+    assertEquals(2, source.select(options).toLong())
+    assertEquals(0, source.select(options).toLong())
+    assertEquals(1, source.select(options).toLong())
+    assertTrue(source.exhausted())
+  }
+
+  @Test fun selectNotFound() {
+    val options = Options.of(
+      "ROCK".encodeUtf8(),
+      "SCISSORS".encodeUtf8(),
+      "PAPER".encodeUtf8()
+    )
+
+    sink.writeUtf8("SPOCK")
+    sink.emit()
+    assertEquals(-1, source.select(options).toLong())
+    assertEquals("SPOCK", source.readUtf8())
+  }
+
+  @Test fun selectValuesHaveCommonPrefix() {
+    val options = Options.of(
+      "abcd".encodeUtf8(),
+      "abce".encodeUtf8(),
+      "abcc".encodeUtf8()
+    )
+
+    sink.writeUtf8("abcc").writeUtf8("abcd").writeUtf8("abce")
+    sink.emit()
+    assertEquals(2, source.select(options).toLong())
+    assertEquals(0, source.select(options).toLong())
+    assertEquals(1, source.select(options).toLong())
+  }
+
+  @Test fun selectLongerThanSource() {
+    val options = Options.of(
+      "abcd".encodeUtf8(),
+      "abce".encodeUtf8(),
+      "abcc".encodeUtf8()
+    )
+    sink.writeUtf8("abc")
+    sink.emit()
+    assertEquals(-1, source.select(options).toLong())
+    assertEquals("abc", source.readUtf8())
+  }
+
+  @Test fun selectReturnsFirstByteStringThatMatches() {
+    val options = Options.of(
+      "abcd".encodeUtf8(),
+      "abc".encodeUtf8(),
+      "abcde".encodeUtf8()
+    )
+    sink.writeUtf8("abcdef")
+    sink.emit()
+    assertEquals(0, source.select(options).toLong())
+    assertEquals("ef", source.readUtf8())
+  }
+
+  @Test fun selectFromEmptySource() {
+    val options = Options.of(
+      "abc".encodeUtf8(),
+      "def".encodeUtf8()
+    )
+    assertEquals(-1, source.select(options).toLong())
+  }
+
+  @Test fun selectNoByteStringsFromEmptySource() {
+    val options = Options.of()
+    assertEquals(-1, source.select(options).toLong())
+  }
+
+  @Test fun peek() {
+    sink.writeUtf8("abcdefghi")
+    sink.emit()
+
+    assertEquals("abc", source.readUtf8(3))
+
+    val peek = source.peek()
+    assertEquals("def", peek.readUtf8(3))
+    assertEquals("ghi", peek.readUtf8(3))
+    assertFalse(peek.request(1))
+
+    assertEquals("def", source.readUtf8(3))
+  }
+
+  @Test fun peekMultiple() {
+    sink.writeUtf8("abcdefghi")
+    sink.emit()
+
+    assertEquals("abc", source.readUtf8(3))
+
+    val peek1 = source.peek()
+    val peek2 = source.peek()
+
+    assertEquals("def", peek1.readUtf8(3))
+
+    assertEquals("def", peek2.readUtf8(3))
+    assertEquals("ghi", peek2.readUtf8(3))
+    assertFalse(peek2.request(1))
+
+    assertEquals("ghi", peek1.readUtf8(3))
+    assertFalse(peek1.request(1))
+
+    assertEquals("def", source.readUtf8(3))
+  }
+
+  @Test fun peekLarge() {
+    sink.writeUtf8("abcdef")
+    sink.writeUtf8("g".repeat(2 * Segment.SIZE))
+    sink.writeUtf8("hij")
+    sink.emit()
+
+    assertEquals("abc", source.readUtf8(3))
+
+    val peek = source.peek()
+    assertEquals("def", peek.readUtf8(3))
+    peek.skip((2 * Segment.SIZE).toLong())
+    assertEquals("hij", peek.readUtf8(3))
+    assertFalse(peek.request(1))
+
+    assertEquals("def", source.readUtf8(3))
+    source.skip((2 * Segment.SIZE).toLong())
+    assertEquals("hij", source.readUtf8(3))
+  }
+
+  @Test fun peekInvalid() {
+    sink.writeUtf8("abcdefghi")
+    sink.emit()
+
+    assertEquals("abc", source.readUtf8(3))
+
+    val peek = source.peek()
+    assertEquals("def", peek.readUtf8(3))
+    assertEquals("ghi", peek.readUtf8(3))
+    assertFalse(peek.request(1))
+
+    assertEquals("def", source.readUtf8(3))
+
+    try {
+      peek.readUtf8()
+      fail()
+    } catch (e: IllegalStateException) {
+      assertEquals("Peek source is invalid because upstream source was used", e.message)
+    }
+  }
+
+  @Test fun peekSegmentThenInvalid() {
+    sink.writeUtf8("abc")
+    sink.writeUtf8("d".repeat(2 * Segment.SIZE))
+    sink.emit()
+
+    assertEquals("abc", source.readUtf8(3))
+
+    // Peek a little data and skip the rest of the upstream source
+    val peek = source.peek()
+    assertEquals("ddd", peek.readUtf8(3))
+    source.readAll(blackholeSink())
+
+    // Skip the rest of the buffered data
+    peek.skip(peek.buffer.size)
+
+    try {
+      peek.readByte()
+      fail()
+    } catch (e: IllegalStateException) {
+      assertEquals("Peek source is invalid because upstream source was used", e.message)
+    }
+  }
+
+  @Test fun peekDoesntReadTooMuch() {
+    // 6 bytes in source's buffer plus 3 bytes upstream.
+    sink.writeUtf8("abcdef")
+    sink.emit()
+    source.require(6L)
+    sink.writeUtf8("ghi")
+    sink.emit()
+
+    val peek = source.peek()
+
+    // Read 3 bytes. This reads some of the buffered data.
+    assertTrue(peek.request(3))
+    if (source !is Buffer) {
+      assertEquals(6, source.buffer.size)
+      assertEquals(6, peek.buffer.size)
+    }
+    assertEquals("abc", peek.readUtf8(3L))
+
+    // Read 3 more bytes. This exhausts the buffered data.
+    assertTrue(peek.request(3))
+    if (source !is Buffer) {
+      assertEquals(6, source.buffer.size)
+      assertEquals(3, peek.buffer.size)
+    }
+    assertEquals("def", peek.readUtf8(3L))
+
+    // Read 3 more bytes. This draws new bytes.
+    assertTrue(peek.request(3))
+    assertEquals(9, source.buffer.size)
+    assertEquals(3, peek.buffer.size)
+    assertEquals("ghi", peek.readUtf8(3L))
+  }
+
+  @Test fun rangeEquals() {
+    sink.writeUtf8("A man, a plan, a canal. Panama.")
+    sink.emit()
+    assertTrue(source.rangeEquals(7, "a plan".encodeUtf8()))
+    assertTrue(source.rangeEquals(0, "A man".encodeUtf8()))
+    assertTrue(source.rangeEquals(24, "Panama".encodeUtf8()))
+    assertFalse(source.rangeEquals(24, "Panama. Panama. Panama.".encodeUtf8()))
+  }
+
+  @Test fun rangeEqualsWithOffsetAndCount() {
+    sink.writeUtf8("A man, a plan, a canal. Panama.")
+    sink.emit()
+    assertTrue(source.rangeEquals(7, "aaa plannn".encodeUtf8(), 2, 6))
+    assertTrue(source.rangeEquals(0, "AAA mannn".encodeUtf8(), 2, 5))
+    assertTrue(source.rangeEquals(24, "PPPanamaaa".encodeUtf8(), 2, 6))
+  }
+
+  @Test fun rangeEqualsOnlyReadsUntilMismatch() {
+    if (factory !== BufferedSourceFactory.ONE_BYTE_AT_A_TIME_BUFFERED_SOURCE) return // Other sources read in chunks anyway.
+
+    sink.writeUtf8("A man, a plan, a canal. Panama.")
+    sink.emit()
+    assertFalse(source.rangeEquals(0, ("A man.").encodeUtf8()))
+    assertEquals("A man,", source.buffer.readUtf8())
+  }
+
+  @Test fun rangeEqualsArgumentValidation() {
+    // Negative source offset.
+    assertFalse(source.rangeEquals(-1, "A".encodeUtf8()))
+    // Negative bytes offset.
+    assertFalse(source.rangeEquals(0, "A".encodeUtf8(), -1, 1))
+    // Bytes offset longer than bytes length.
+    assertFalse(source.rangeEquals(0, "A".encodeUtf8(), 2, 1))
+    // Negative byte count.
+    assertFalse(source.rangeEquals(0, "A".encodeUtf8(), 0, -1))
+    // Byte count longer than bytes length.
+    assertFalse(source.rangeEquals(0, "A".encodeUtf8(), 0, 2))
+    // Bytes offset plus byte count longer than bytes length.
+    assertFalse(source.rangeEquals(0, "A".encodeUtf8(), 1, 1))
+  }
+
+  @Test fun factorySegmentSizes() {
+    sink.writeUtf8("abc")
+    sink.emit()
+    source.require(3)
+    if (factory.isOneByteAtATime) {
+      assertEquals(listOf(1, 1, 1), segmentSizes(source.buffer))
+    } else {
+      assertEquals(listOf(3), segmentSizes(source.buffer))
+    }
+  }
+}

--- a/okio/src/commonTest/kotlin/okio/ByteStringFactory.kt
+++ b/okio/src/commonTest/kotlin/okio/ByteStringFactory.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package okio
+
+import okio.ByteString.Companion.decodeHex
+import okio.ByteString.Companion.encodeUtf8
+import okio.internal.commonAsUtf8ToByteArray
+
+internal interface ByteStringFactory {
+  fun decodeHex(hex: String): ByteString
+
+  fun encodeUtf8(s: String): ByteString
+
+  companion object {
+    val BYTE_STRING: ByteStringFactory = object : ByteStringFactory {
+      override fun decodeHex(hex: String) = hex.decodeHex()
+      override fun encodeUtf8(s: String) = s.encodeUtf8()
+    }
+
+    val SEGMENTED_BYTE_STRING: ByteStringFactory = object : ByteStringFactory {
+      override fun decodeHex(hex: String) = Buffer().apply { write(hex.decodeHex()) }.snapshot()
+      override fun encodeUtf8(s: String) = Buffer().apply { writeUtf8(s) }.snapshot()
+    }
+
+    val ONE_BYTE_PER_SEGMENT: ByteStringFactory = object : ByteStringFactory {
+      override fun decodeHex(hex: String) = makeSegments(hex.decodeHex())
+      override fun encodeUtf8(s: String) = makeSegments(s.encodeUtf8())
+    }
+
+    // For Kotlin/JVM, the native Java UTF-8 encoder is used. This forces
+    // testing of the Okio encoder used for Kotlin/JS and Kotlin/Native to be
+    // tested on JVM as well.
+    val OKIO_ENCODER: ByteStringFactory = object : ByteStringFactory {
+      override fun decodeHex(hex: String) = hex.decodeHex()
+      override fun encodeUtf8(s: String) =
+        ByteString.of(*s.commonAsUtf8ToByteArray())
+    }
+  }
+}

--- a/okio/src/commonTest/kotlin/okio/ByteStringTest.kt
+++ b/okio/src/commonTest/kotlin/okio/ByteStringTest.kt
@@ -29,45 +29,12 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
-class CommonByteStringTest {
-  class ByteString : AbstractByteStringTest(ByteStringFactory.BYTE_STRING)
-  class SegmentedByteString : AbstractByteStringTest(ByteStringFactory.SEGMENTED_BYTE_STRING)
-  class OneBytePerSegment : AbstractByteStringTest(ByteStringFactory.ONE_BYTE_PER_SEGMENT)
-  class OkioEncoder : AbstractByteStringTest(ByteStringFactory.OKIO_ENCODER)
-}
+class ByteStringTest : AbstractByteStringTest(ByteStringFactory.BYTE_STRING)
+class SegmentedByteStringTest : AbstractByteStringTest(ByteStringFactory.SEGMENTED_BYTE_STRING)
+class ByteStringOneBytePerSegmentTest : AbstractByteStringTest(ByteStringFactory.ONE_BYTE_PER_SEGMENT)
+class OkioEncoderTest : AbstractByteStringTest(ByteStringFactory.OKIO_ENCODER)
 
-interface ByteStringFactory {
-  fun decodeHex(hex: String): ByteString
-
-  fun encodeUtf8(s: String): ByteString
-
-  companion object {
-    val BYTE_STRING: ByteStringFactory = object : ByteStringFactory {
-      override fun decodeHex(hex: String) = hex.decodeHex()
-      override fun encodeUtf8(s: String) = s.encodeUtf8()
-    }
-
-    val SEGMENTED_BYTE_STRING: ByteStringFactory = object : ByteStringFactory {
-      override fun decodeHex(hex: String) = Buffer().apply { write(hex.decodeHex()) }.snapshot()
-      override fun encodeUtf8(s: String) = Buffer().apply { writeUtf8(s) }.snapshot()
-    }
-
-    val ONE_BYTE_PER_SEGMENT: ByteStringFactory = object : ByteStringFactory {
-      override fun decodeHex(hex: String) = makeSegments(hex.decodeHex())
-      override fun encodeUtf8(s: String) = makeSegments(s.encodeUtf8())
-    }
-
-    // For Kotlin/JVM, the native Java UTF-8 encoder is used. This forces
-    // testing of the Okio encoder used for Kotlin/JS and Kotlin/Native to be
-    // tested on JVM as well.
-    val OKIO_ENCODER: ByteStringFactory = object : ByteStringFactory {
-      override fun decodeHex(hex: String) = hex.decodeHex()
-      override fun encodeUtf8(s: String) = ByteString.of(*s.commonAsUtf8ToByteArray())
-    }
-  }
-}
-
-abstract class AbstractByteStringTest(
+abstract class AbstractByteStringTest internal constructor(
   private val factory: ByteStringFactory
 ) {
   @Test fun get() {

--- a/okio/src/commonTest/kotlin/okio/CommonOkioKotlinTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonOkioKotlinTest.kt
@@ -13,10 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package okio
 
-actual fun Source.buffer(): BufferedSource = RealBufferedSource(this)
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
-actual fun Sink.buffer(): BufferedSink = RealBufferedSink(this)
+class CommonOkioKotlinTest {
+  @Test fun sourceBuffer() {
+    val source = Buffer().writeUtf8("a")
+    val buffered = (source as Source).buffer()
+    assertEquals(buffered.readUtf8(), "a")
+    assertEquals(source.size, 0L)
+  }
 
-actual fun blackholeSink(): Sink = BlackholeSink()
+  @Test fun sinkBuffer() {
+    val sink = Buffer()
+    val buffered = (sink as Sink).buffer()
+    buffered.writeUtf8("a")
+    assertEquals(sink.size, 0L)
+    buffered.flush()
+    assertEquals(sink.size, 1L)
+  }
+
+  @Test fun blackhole() {
+    blackholeSink().write(Buffer().writeUtf8("a"), 1L)
+  }
+}

--- a/okio/src/commonTest/kotlin/okio/CommonRealBufferedSinkTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonRealBufferedSinkTest.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package okio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+/**
+ * Tests solely for the behavior of RealBufferedSink's implementation. For generic
+ * BufferedSink behavior use BufferedSinkTest.
+ */
+class CommonRealBufferedSinkTest {
+  @Test fun bufferedSinkEmitsTailWhenItIsComplete() {
+    val sink = Buffer()
+    val bufferedSink = (sink as Sink).buffer()
+    bufferedSink.writeUtf8("a".repeat(Segment.SIZE - 1))
+    assertEquals(0, sink.size)
+    bufferedSink.writeByte(0)
+    assertEquals(Segment.SIZE.toLong(), sink.size)
+    assertEquals(0, bufferedSink.buffer.size)
+  }
+
+  @Test fun bufferedSinkEmitMultipleSegments() {
+    val sink = Buffer()
+    val bufferedSink = (sink as Sink).buffer()
+    bufferedSink.writeUtf8("a".repeat(Segment.SIZE * 4 - 1))
+    assertEquals(Segment.SIZE.toLong() * 3L, sink.size)
+    assertEquals(Segment.SIZE.toLong() - 1L, bufferedSink.buffer.size)
+  }
+
+  @Test fun bufferedSinkFlush() {
+    val sink = Buffer()
+    val bufferedSink = (sink as Sink).buffer()
+    bufferedSink.writeByte('a'.toInt())
+    assertEquals(0, sink.size)
+    bufferedSink.flush()
+    assertEquals(0, bufferedSink.buffer.size)
+    assertEquals(1, sink.size)
+  }
+
+  @Test fun bytesEmittedToSinkWithFlush() {
+    val sink = Buffer()
+    val bufferedSink = (sink as Sink).buffer()
+    bufferedSink.writeUtf8("abc")
+    bufferedSink.flush()
+    assertEquals(3, sink.size)
+  }
+
+  @Test fun bytesNotEmittedToSinkWithoutFlush() {
+    val sink = Buffer()
+    val bufferedSink = (sink as Sink).buffer()
+    bufferedSink.writeUtf8("abc")
+    assertEquals(0, sink.size)
+  }
+
+  @Test fun bytesEmittedToSinkWithEmit() {
+    val sink = Buffer()
+    val bufferedSink = (sink as Sink).buffer()
+    bufferedSink.writeUtf8("abc")
+    bufferedSink.emit()
+    assertEquals(3, sink.size)
+  }
+
+  @Test fun completeSegmentsEmitted() {
+    val sink = Buffer()
+    val bufferedSink = (sink as Sink).buffer()
+    bufferedSink.writeUtf8("a".repeat(Segment.SIZE * 3))
+    assertEquals(Segment.SIZE.toLong() * 3L, sink.size)
+  }
+
+  @Test fun incompleteSegmentsNotEmitted() {
+    val sink = Buffer()
+    val bufferedSink = (sink as Sink).buffer()
+    bufferedSink.writeUtf8("a".repeat(Segment.SIZE * 3 - 1))
+    assertEquals(Segment.SIZE.toLong() * 2L, sink.size)
+  }
+
+  @Test fun closeWithExceptionWhenWriting() {
+    val mockSink = MockSink()
+    mockSink.scheduleThrow(0, IOException())
+    val bufferedSink = mockSink.buffer()
+    bufferedSink.writeByte('a'.toInt())
+    try {
+      bufferedSink.close()
+      fail()
+    } catch (expected: IOException) {
+    }
+
+    mockSink.assertLog("write([text=a], 1)", "close()")
+  }
+
+  @Test fun closeWithExceptionWhenClosing() {
+    val mockSink = MockSink()
+    mockSink.scheduleThrow(1, IOException())
+    val bufferedSink = mockSink.buffer()
+    bufferedSink.writeByte('a'.toInt())
+    try {
+      bufferedSink.close()
+      fail()
+    } catch (expected: IOException) {
+    }
+
+    mockSink.assertLog("write([text=a], 1)", "close()")
+  }
+
+  @Test fun closeWithExceptionWhenWritingAndClosing() {
+    val mockSink = MockSink()
+    mockSink.scheduleThrow(0, IOException("first"))
+    mockSink.scheduleThrow(1, IOException("second"))
+    val bufferedSink = mockSink.buffer()
+    bufferedSink.writeByte('a'.toInt())
+    try {
+      bufferedSink.close()
+      fail()
+    } catch (expected: IOException) {
+      assertEquals("first", expected.message)
+    }
+
+    mockSink.assertLog("write([text=a], 1)", "close()")
+  }
+
+  @Test fun operationsAfterClose() {
+    val mockSink = MockSink()
+    val bufferedSink = mockSink.buffer()
+    bufferedSink.writeByte('a'.toInt())
+    bufferedSink.close()
+
+    // Test a sample set of methods.
+    try {
+      bufferedSink.writeByte('a'.toInt())
+      fail()
+    } catch (expected: IllegalStateException) {
+    }
+
+    try {
+      bufferedSink.write(ByteArray(10))
+      fail()
+    } catch (expected: IllegalStateException) {
+    }
+
+    try {
+      bufferedSink.emitCompleteSegments()
+      fail()
+    } catch (expected: IllegalStateException) {
+    }
+
+    try {
+      bufferedSink.emit()
+      fail()
+    } catch (expected: IllegalStateException) {
+    }
+
+    try {
+      bufferedSink.flush()
+      fail()
+    } catch (expected: IllegalStateException) {
+    }
+  }
+
+  @Test fun writeAll() {
+    val mockSink = MockSink()
+    val bufferedSink = mockSink.buffer()
+
+    bufferedSink.buffer.writeUtf8("abc")
+    assertEquals(3, bufferedSink.writeAll(Buffer().writeUtf8("def")))
+
+    assertEquals(6, bufferedSink.buffer.size)
+    assertEquals("abcdef", bufferedSink.buffer.readUtf8(6))
+    mockSink.assertLog() // No writes.
+  }
+
+  @Test fun writeAllExhausted() {
+    val mockSink = MockSink()
+    val bufferedSink = mockSink.buffer()
+
+    assertEquals(0, bufferedSink.writeAll(Buffer()))
+    assertEquals(0, bufferedSink.buffer.size)
+    mockSink.assertLog() // No writes.
+  }
+
+  @Test fun writeAllWritesOneSegmentAtATime() {
+    val write1 = Buffer().writeUtf8("a".repeat(Segment.SIZE))
+    val write2 = Buffer().writeUtf8("b".repeat(Segment.SIZE))
+    val write3 = Buffer().writeUtf8("c".repeat(Segment.SIZE))
+
+    val source = Buffer().writeUtf8(
+      "${"a".repeat(Segment.SIZE)}${"b".repeat(Segment.SIZE)}${"c".repeat(Segment.SIZE)}"
+    )
+
+    val mockSink = MockSink()
+    val bufferedSink = mockSink.buffer()
+    assertEquals(Segment.SIZE.toLong() * 3L, bufferedSink.writeAll(source))
+
+    mockSink.assertLog(
+      "write($write1, ${write1.size})",
+      "write($write2, ${write2.size})",
+      "write($write3, ${write3.size})"
+    )
+  }
+}

--- a/okio/src/commonTest/kotlin/okio/CommonRealBufferedSourceTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonRealBufferedSourceTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package okio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+/**
+ * Tests solely for the behavior of RealBufferedSource's implementation. For generic
+ * BufferedSource behavior use BufferedSourceTest.
+ */
+class CommonRealBufferedSourceTest {
+  @Test fun indexOfStopsReadingAtLimit() {
+    val buffer = Buffer().writeUtf8("abcdef")
+    val bufferedSource = (object : Source by buffer {
+      override fun read(sink: Buffer, byteCount: Long): Long {
+        return buffer.read(sink, minOf(1, byteCount))
+      }
+    }).buffer()
+
+    assertEquals(6, buffer.size)
+    assertEquals(-1, bufferedSource.indexOf('e'.toByte(), 0, 4))
+    assertEquals(2, buffer.size)
+  }
+
+  @Test fun requireTracksBufferFirst() {
+    val source = Buffer()
+    source.writeUtf8("bb")
+
+    val bufferedSource = (source as Source).buffer()
+    bufferedSource.buffer.writeUtf8("aa")
+
+    bufferedSource.require(2)
+    assertEquals(2, bufferedSource.buffer.size)
+    assertEquals(2, source.size)
+  }
+
+  @Test fun requireIncludesBufferBytes() {
+    val source = Buffer()
+    source.writeUtf8("b")
+
+    val bufferedSource = (source as Source).buffer()
+    bufferedSource.buffer.writeUtf8("a")
+
+    bufferedSource.require(2)
+    assertEquals("ab", bufferedSource.buffer.readUtf8(2))
+  }
+
+  @Test fun requireInsufficientData() {
+    val source = Buffer()
+    source.writeUtf8("a")
+
+    val bufferedSource = (source as Source).buffer()
+
+    try {
+      bufferedSource.require(2)
+      fail()
+    } catch (expected: EOFException) {
+    }
+  }
+
+  @Test fun requireReadsOneSegmentAtATime() {
+    val source = Buffer()
+    source.writeUtf8("a".repeat(Segment.SIZE))
+    source.writeUtf8("b".repeat(Segment.SIZE))
+
+    val bufferedSource = (source as Source).buffer()
+
+    bufferedSource.require(2)
+    assertEquals(Segment.SIZE.toLong(), source.size)
+    assertEquals(Segment.SIZE.toLong(), bufferedSource.buffer.size)
+  }
+
+  @Test fun skipReadsOneSegmentAtATime() {
+    val source = Buffer()
+    source.writeUtf8("a".repeat(Segment.SIZE))
+    source.writeUtf8("b".repeat(Segment.SIZE))
+    val bufferedSource = (source as Source).buffer()
+    bufferedSource.skip(2)
+    assertEquals(Segment.SIZE.toLong(), source.size)
+    assertEquals(Segment.SIZE.toLong() - 2L, bufferedSource.buffer.size)
+  }
+
+  @Test fun skipTracksBufferFirst() {
+    val source = Buffer()
+    source.writeUtf8("bb")
+
+    val bufferedSource = (source as Source).buffer()
+    bufferedSource.buffer.writeUtf8("aa")
+
+    bufferedSource.skip(2)
+    assertEquals(0, bufferedSource.buffer.size)
+    assertEquals(2, source.size)
+  }
+
+  @Test fun operationsAfterClose() {
+    val source = Buffer()
+    val bufferedSource = (source as Source).buffer()
+    bufferedSource.close()
+
+    // Test a sample set of methods.
+    try {
+      bufferedSource.indexOf(1.toByte())
+      fail()
+    } catch (expected: IllegalStateException) {
+    }
+
+    try {
+      bufferedSource.skip(1)
+      fail()
+    } catch (expected: IllegalStateException) {
+    }
+
+    try {
+      bufferedSource.readByte()
+      fail()
+    } catch (expected: IllegalStateException) {
+    }
+
+    try {
+      bufferedSource.readByteString(10)
+      fail()
+    } catch (expected: IllegalStateException) {
+    }
+  }
+
+  /**
+   * We don't want readAll to buffer an unbounded amount of data. Instead it
+   * should buffer a segment, write it, and repeat.
+   */
+  @Test fun readAllReadsOneSegmentAtATime() {
+    val write1 = Buffer().writeUtf8("a".repeat(Segment.SIZE))
+    val write2 = Buffer().writeUtf8("b".repeat(Segment.SIZE))
+    val write3 = Buffer().writeUtf8("c".repeat(Segment.SIZE))
+
+    val source = Buffer().writeUtf8(
+      "${"a".repeat(Segment.SIZE)}${"b".repeat(Segment.SIZE)}${"c".repeat(Segment.SIZE)}"
+    )
+
+    val mockSink = MockSink()
+    val bufferedSource = (source as Source).buffer()
+    assertEquals(Segment.SIZE.toLong() * 3L, bufferedSource.readAll(mockSink))
+    mockSink.assertLog(
+      "write($write1, ${write1.size})",
+      "write($write2, ${write2.size})",
+      "write($write3, ${write3.size})"
+    )
+  }
+}

--- a/okio/src/commonTest/kotlin/okio/util.kt
+++ b/okio/src/commonTest/kotlin/okio/util.kt
@@ -16,6 +16,7 @@
 package okio
 
 import kotlin.random.Random
+import kotlin.test.assertEquals
 
 fun Char.repeat(count: Int): String {
   return toString().repeat(count)
@@ -31,6 +32,17 @@ fun segmentSizes(buffer: Buffer): List<Int> {
     segment = segment.next!!
   }
   return sizes
+}
+
+fun assertArrayEquals(a: ByteArray, b: ByteArray) {
+  assertEquals(a.contentToString(), b.contentToString())
+}
+
+fun randomBytes(length: Int): ByteString {
+  val random = Random(0)
+  val randomBytes = ByteArray(length)
+  random.nextBytes(randomBytes)
+  return ByteString.of(*randomBytes)
 }
 
 fun bufferWithRandomSegmentLayout(dice: Random, data: ByteArray): Buffer {

--- a/okio/src/jsMain/kotlin/okio/Buffer.kt
+++ b/okio/src/jsMain/kotlin/okio/Buffer.kt
@@ -17,6 +17,7 @@ package okio
 
 import okio.internal.commonClear
 import okio.internal.commonCompleteSegmentByteCount
+import okio.internal.commonCopy
 import okio.internal.commonCopyTo
 import okio.internal.commonEquals
 import okio.internal.commonGet
@@ -184,7 +185,7 @@ actual class Buffer : BufferedSource, BufferedSink {
 
   actual override fun writeShort(s: Int): Buffer = commonWriteShort(s)
 
-  actual override fun writeShortLe(s: Int): Buffer = writeShort(s.reverseBytes())
+  actual override fun writeShortLe(s: Int): Buffer = writeShort(s.toShort().reverseBytes().toInt())
 
   actual override fun writeInt(i: Int): Buffer = commonWriteInt(i)
 
@@ -246,6 +247,9 @@ actual class Buffer : BufferedSource, BufferedSink {
    * is a string like `[text=Hello]` or `[hex=0000ffff]`.
    */
   override fun toString() = snapshot().toString()
+
+  /** Returns a deep copy of this buffer. */
+  actual fun copy(): Buffer = commonCopy()
 
   /** Returns an immutable copy of this buffer as a byte string.  */
   actual fun snapshot(): ByteString = commonSnapshot()

--- a/okio/src/jvmMain/kotlin/okio/Buffer.kt
+++ b/okio/src/jvmMain/kotlin/okio/Buffer.kt
@@ -17,6 +17,7 @@ package okio
 
 import okio.internal.commonClear
 import okio.internal.commonCompleteSegmentByteCount
+import okio.internal.commonCopy
 import okio.internal.commonCopyTo
 import okio.internal.commonEquals
 import okio.internal.commonGet
@@ -555,22 +556,11 @@ actual class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
    */
   override fun toString() = snapshot().toString()
 
-  /** Returns a deep copy of this buffer.  */
-  public override fun clone(): Buffer {
-    val result = Buffer()
-    if (size == 0L) return result
+  /** Returns a deep copy of this buffer. */
+  actual fun copy(): Buffer = commonCopy()
 
-    result.head = head!!.sharedCopy()
-    result.head!!.prev = result.head
-    result.head!!.next = result.head!!.prev
-    var s = head!!.next
-    while (s !== head) {
-      result.head!!.prev!!.push(s!!.sharedCopy())
-      s = s.next
-    }
-    result.size = size
-    return result
-  }
+  /** Returns a deep copy of this buffer. */
+  public override fun clone(): Buffer = copy()
 
   actual fun snapshot(): ByteString = commonSnapshot()
 

--- a/okio/src/jvmMain/kotlin/okio/Okio.kt
+++ b/okio/src/jvmMain/kotlin/okio/Okio.kt
@@ -111,13 +111,6 @@ private class InputStreamSource(
 @JvmName("blackhole")
 actual fun blackholeSink(): Sink = BlackholeSink()
 
-private class BlackholeSink : Sink {
-  override fun write(source: Buffer, byteCount: Long) = source.skip(byteCount)
-  override fun flush() {}
-  override fun timeout() = Timeout.NONE
-  override fun close() {}
-}
-
 /**
  * Returns a sink that writes to `socket`. Prefer this over [sink]
  * because this method honors timeouts. When the socket

--- a/okio/src/jvmTest/kotlin/okio/OkioKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/OkioKotlinTest.kt
@@ -31,22 +31,6 @@ import java.nio.file.StandardOpenOption.APPEND
 class OkioKotlinTest {
   @get:Rule val temp = TemporaryFolder()
 
-  @Test fun sourceBuffer() {
-    val source = Buffer().writeUtf8("a")
-    val buffered = (source as Source).buffer()
-    assertThat(buffered.readUtf8()).isEqualTo("a")
-    assertThat(source.size).isEqualTo(0L)
-  }
-
-  @Test fun sinkBuffer() {
-    val sink = Buffer()
-    val buffered = (sink as Sink).buffer()
-    buffered.writeUtf8("a")
-    assertThat(sink.size).isEqualTo(0L)
-    buffered.flush()
-    assertThat(sink.size).isEqualTo(1L)
-  }
-
   @Test fun outputStreamSink() {
     val baos = ByteArrayOutputStream()
     val sink = baos.sink()
@@ -117,10 +101,6 @@ class OkioKotlinTest {
     val file = File(folder, "new.txt")
     file.toPath().source(StandardOpenOption.CREATE_NEW)
     // This still throws NoSuchFileException...
-  }
-
-  @Test fun blackhole() {
-    blackholeSink().write(Buffer().writeUtf8("a"), 1L)
   }
 
   @Test fun socketSink() {

--- a/okio/src/nativeMain/kotlin/okio/Buffer.kt
+++ b/okio/src/nativeMain/kotlin/okio/Buffer.kt
@@ -17,6 +17,7 @@ package okio
 
 import okio.internal.commonClear
 import okio.internal.commonCompleteSegmentByteCount
+import okio.internal.commonCopy
 import okio.internal.commonCopyTo
 import okio.internal.commonEquals
 import okio.internal.commonGet
@@ -184,7 +185,7 @@ actual class Buffer : BufferedSource, BufferedSink {
 
   actual override fun writeShort(s: Int): Buffer = commonWriteShort(s)
 
-  actual override fun writeShortLe(s: Int): Buffer = writeShort(s.reverseBytes())
+  actual override fun writeShortLe(s: Int): Buffer = writeShort(s.toShort().reverseBytes().toInt())
 
   actual override fun writeInt(i: Int): Buffer = commonWriteInt(i)
 
@@ -246,6 +247,9 @@ actual class Buffer : BufferedSource, BufferedSink {
    * is a string like `[text=Hello]` or `[hex=0000ffff]`.
    */
   override fun toString() = snapshot().toString()
+
+  /** Returns a deep copy of this buffer. */
+  actual fun copy(): Buffer = commonCopy()
 
   /** Returns an immutable copy of this buffer as a byte string.  */
   actual fun snapshot(): ByteString = commonSnapshot()

--- a/okio/src/nativeMain/kotlin/okio/Okio.kt
+++ b/okio/src/nativeMain/kotlin/okio/Okio.kt
@@ -15,8 +15,8 @@
  */
 package okio
 
-actual fun Source.buffer(): BufferedSource = TODO()
+actual fun Source.buffer(): BufferedSource = RealBufferedSource(this)
 
-actual fun Sink.buffer(): BufferedSink = TODO()
+actual fun Sink.buffer(): BufferedSink = RealBufferedSink(this)
 
-actual fun blackholeSink(): Sink = TODO()
+actual fun blackholeSink(): Sink = BlackholeSink()


### PR DESCRIPTION
Copied the BufferedSourceTest and BufferedSinkTest files to Kotlin/Common. This involved converting them to Kotlin (thanks IntelliJ), changing parameterized unit test mechanism, removing Java specific unit tests, adding the `Buffer#copy()` method as an alternative to Java specific `Buffer#clone()`, and fixing a bug.

I've also moved RealBufferedSource and RealBufferedSink to Kotlin/Common but wanted to start this pull request with the unit test move.