### PR TITLE
Kotlin 1.3.50

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.versions = [
-      'kotlin': '1.3.50-eap-86',
+      'kotlin': '1.3.50',
       'jmhPlugin': '0.4.8',
       'animalSnifferPlugin': '1.5.0',
       'dokka': '0.9.18',

--- a/okio/src/jvmTest/kotlin/okio/BufferCursorKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferCursorKotlinTest.kt
@@ -98,7 +98,7 @@ class BufferCursorKotlinTest {
 
     buffer.readAndWriteUnsafe().use { cursor ->
       while (cursor.next() != -1) {
-        Arrays.fill(cursor.data!!, cursor.start, cursor.end, 'x'.toByte())
+        cursor.data!!.fill('x'.toByte(), cursor.start, cursor.end)
       }
     }
 

--- a/okio/src/jvmTest/kotlin/okio/BufferCursorKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferCursorKotlinTest.kt
@@ -23,7 +23,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameter
 import org.junit.runners.Parameterized.Parameters
-import java.util.Arrays
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotSame

--- a/okio/src/jvmTest/kotlin/okio/TestUtil.kt
+++ b/okio/src/jvmTest/kotlin/okio/TestUtil.kt
@@ -103,11 +103,7 @@ object TestUtil {
   }
 
   @JvmStatic
-  fun repeat(c: Char, count: Int): String {
-    val array = CharArray(count)
-    Arrays.fill(array, c)
-    return String(array)
-  }
+  fun repeat(c: Char, count: Int) = c.toString().repeat(count)
 
   @JvmStatic
   fun assertEquivalent(b1: ByteString, b2: ByteString) {


### PR DESCRIPTION
Replace `Array.fill` usage with new `Array.fill` extension from stdlib.