### PR TITLE
Make AsyncTimeout.withTimeout public

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/AsyncTimeout.kt
+++ b/okio/src/jvmMain/kotlin/okio/AsyncTimeout.kt
@@ -151,19 +151,22 @@ open class AsyncTimeout : Timeout() {
       throwOnTimeout = true
       return result
     } catch (e: IOException) {
-      throw if (!exit()) e else newTimeoutException(e)
+      throw if (!exit()) e else `access$newTimeoutException`(e)
     } finally {
       val timedOut = exit()
-      if (timedOut && throwOnTimeout) throw newTimeoutException(null)
+      if (timedOut && throwOnTimeout) throw `access$newTimeoutException`(null)
     }
   }
+
+  @PublishedApi // Binary compatible trampoline function
+  internal fun `access$newTimeoutException`(cause: IOException?) = newTimeoutException(cause)
 
   /**
    * Returns an [IOException] to represent a timeout. By default this method returns
    * [InterruptedIOException]. If [cause] is non-null it is set as the cause of the
    * returned exception.
    */
-  open fun newTimeoutException(cause: IOException?): IOException {
+  protected open fun newTimeoutException(cause: IOException?): IOException {
     val e = InterruptedIOException("timeout")
     if (cause != null) {
       e.initCause(cause)

--- a/okio/src/jvmMain/kotlin/okio/AsyncTimeout.kt
+++ b/okio/src/jvmMain/kotlin/okio/AsyncTimeout.kt
@@ -143,6 +143,7 @@ open class AsyncTimeout : Timeout() {
    * Throws an IOException if [throwOnTimeout] is `true` and a timeout occurred. See
    * [newTimeoutException] for the type of exception thrown.
    */
+  @PublishedApi
   internal fun exit(throwOnTimeout: Boolean) {
     val timedOut = exit()
     if (timedOut && throwOnTimeout) throw newTimeoutException(null)
@@ -153,6 +154,7 @@ open class AsyncTimeout : Timeout() {
    * occurred. See [newTimeoutException] for the type of exception
    * returned.
    */
+  @PublishedApi
   internal fun exit(cause: IOException): IOException {
     return if (!exit()) cause else newTimeoutException(cause)
   }
@@ -161,7 +163,7 @@ open class AsyncTimeout : Timeout() {
    * Surrounds [block] with calls to [enter] and [exit], throwing an exception from
    * [newTimeoutException] if a timeout occurred.
    */
-  internal inline fun <T> withTimeout(block: () -> T): T {
+  inline fun <T> withTimeout(block: () -> T): T {
     var throwOnTimeout = false
     enter()
     try {


### PR DESCRIPTION
Follow up to #661 

It is possible to make internal functions available to an inline'd function using the `@PublishedApi` annotation. This effectively makes them part of the public API of the project but only usable through the the inline function.

We could take this one step farther and remove the 2 internal `exit` functions since they are only used from the `withTimeout` function. However, this would mean making `newTimeoutException` public as well.