### PR TITLE
Use SegmentedByteString when reading a significantly large ByteString

### DIFF
--- a/okio/jvm/jmh/src/jmh/java/com/squareup/okio/benchmarks/ReadByteStringBenchmark.java
+++ b/okio/jvm/jmh/src/jmh/java/com/squareup/okio/benchmarks/ReadByteStringBenchmark.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okio.benchmarks;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okio.Buffer;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+@Fork(1)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ReadByteStringBenchmark {
+
+  Buffer buffer;
+
+  @Param({"32768"})
+  int bufferSize;
+
+  @Param({"8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "16384",
+      "32768"})
+  int byteStringSize;
+
+  @Setup
+  public void setup() {
+    buffer = new Buffer().write(new byte[bufferSize]);
+  }
+
+  @Benchmark
+  public void readByteString() throws IOException {
+    buffer.write(buffer.readByteString(byteStringSize));
+  }
+
+  @Benchmark
+  public void readByteString_toByteArray() throws IOException {
+    buffer.write(buffer.readByteString(byteStringSize).toByteArray());
+  }
+
+  public static void main(String[] args) throws IOException, RunnerException {
+    Main.main(new String[]{
+        ReadByteStringBenchmark.class.getName()
+    });
+  }
+}

--- a/okio/src/commonTest/kotlin/okio/CommonBufferTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonBufferTest.kt
@@ -93,11 +93,11 @@ class CommonBufferTest {
     assertEquals(0, SegmentPool.byteCount)
 
     // Recycle MAX_SIZE segments. They're all in the pool.
-    buffer.readByteString(SegmentPool.MAX_SIZE)
+    buffer.skip(SegmentPool.MAX_SIZE)
     assertEquals(SegmentPool.MAX_SIZE, SegmentPool.byteCount)
 
     // Recycle MAX_SIZE more segments. The pool is full so they get garbage collected.
-    buffer.readByteString(SegmentPool.MAX_SIZE)
+    buffer.skip(SegmentPool.MAX_SIZE)
     assertEquals(SegmentPool.MAX_SIZE, SegmentPool.byteCount)
 
     // Take MAX_SIZE segments to drain the pool.

--- a/okio/src/jvmTest/java/okio/BufferTest.java
+++ b/okio/src/jvmTest/java/okio/BufferTest.java
@@ -102,11 +102,11 @@ public final class BufferTest {
     assertEquals(0, segmentPoolByteCount());
 
     // Recycle MAX_SIZE segments. They're all in the pool.
-    buffer.readByteString(SEGMENT_POOL_MAX_SIZE);
+    buffer.skip(SEGMENT_POOL_MAX_SIZE);
     assertEquals(SEGMENT_POOL_MAX_SIZE, segmentPoolByteCount());
 
     // Recycle MAX_SIZE more segments. The pool is full so they get garbage collected.
-    buffer.readByteString(SEGMENT_POOL_MAX_SIZE);
+    buffer.skip(SEGMENT_POOL_MAX_SIZE);
     assertEquals(SEGMENT_POOL_MAX_SIZE, segmentPoolByteCount());
 
     // Take MAX_SIZE segments to drain the pool.


### PR DESCRIPTION
Inspired by the discussion in #611, I took a look at some performance for `readByteString` using `snapshot` instead. `BASELINE` report represents the original implementation. The `SNAPSHOT` report is if `snapshot` was always used when calling `readByteString`.

Given these benchmarks, I went with a switching point of `4096`. Keeps the current behavior for small reads but switches to `snapshot` for large reads when writing a SegmentedByteString is much more efficient.

If there are other operations you would like to see numbers for, I will add them to the benchmark. I'm not completely convinced this is a good representation of how ByteString is used in the wild so would appreciate suggestions.

Benchmark for: `buffer.write(buffer.readByteString(byteStringSize));`
```
BASELINE
--------
Benchmark                                                      (bufferSize)  (byteStringSize)    Mode     Cnt     Score   Error  Units
ReadByteStringBenchmark.readByteString                                32768                 8  sample  250167     0.081 � 0.014  us/op
ReadByteStringBenchmark.readByteString                                32768                16  sample  242176     0.075 � 0.004  us/op
ReadByteStringBenchmark.readByteString                                32768                32  sample  242098     0.081 � 0.007  us/op
ReadByteStringBenchmark.readByteString                                32768                64  sample  274452     0.090 � 0.007  us/op
ReadByteStringBenchmark.readByteString                                32768               128  sample  384520     0.085 � 0.004  us/op
ReadByteStringBenchmark.readByteString                                32768               256  sample  272389     0.128 � 0.023  us/op
ReadByteStringBenchmark.readByteString                                32768               512  sample  228566     0.132 � 0.014  us/op
ReadByteStringBenchmark.readByteString                                32768              1024  sample  217187     0.249 � 0.042  us/op
ReadByteStringBenchmark.readByteString                                32768              2048  sample  218633     0.409 � 0.041  us/op
ReadByteStringBenchmark.readByteString                                32768              4096  sample  262453     0.657 � 0.039  us/op
ReadByteStringBenchmark.readByteString                                32768              8192  sample  317205     1.059 � 0.044  us/op
ReadByteStringBenchmark.readByteString                                32768             16384  sample  320514     2.055 � 0.064  us/op
ReadByteStringBenchmark.readByteString                                32768             32768  sample  270074     4.747 � 0.086  us/op

SNAPSHOT
-----------
Benchmark                                                      (bufferSize)  (byteStringSize)    Mode     Cnt     Score   Error  Units
ReadByteStringBenchmark.readByteString                                32768                 8  sample  327932     0.094 � 0.004  us/op
ReadByteStringBenchmark.readByteString                                32768                16  sample  331186     0.098 � 0.009  us/op
ReadByteStringBenchmark.readByteString                                32768                32  sample  335507     0.101 � 0.019  us/op
ReadByteStringBenchmark.readByteString                                32768                64  sample  340354     0.090 � 0.003  us/op
ReadByteStringBenchmark.readByteString                                32768               128  sample  352379     0.105 � 0.027  us/op
ReadByteStringBenchmark.readByteString                                32768               256  sample  333690     0.095 � 0.008  us/op
ReadByteStringBenchmark.readByteString                                32768               512  sample  366717     0.085 � 0.012  us/op
ReadByteStringBenchmark.readByteString                                32768              1024  sample  368105     0.086 � 0.012  us/op
ReadByteStringBenchmark.readByteString                                32768              2048  sample  332940     0.096 � 0.011  us/op
ReadByteStringBenchmark.readByteString                                32768              4096  sample  365727     0.084 � 0.004  us/op
ReadByteStringBenchmark.readByteString                                32768              8192  sample  344423     0.095 � 0.016  us/op
ReadByteStringBenchmark.readByteString                                32768             16384  sample  257286     0.113 � 0.019  us/op
ReadByteStringBenchmark.readByteString                                32768             32768  sample  332721     0.159 � 0.018  us/op
```

Benchmark for: `buffer.write(buffer.readByteString(byteStringSize).toByteArray());`
```
BASELINE
--------
Benchmark                                                                              (bufferSize)  (byteStringSize)    Mode     Cnt     Score   Error  Units
ReadByteStringBenchmark.readByteString_toByteArray                                            32768                 8  sample  233190     0.091 � 0.025  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768                16  sample  210334     0.095 � 0.022  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768                32  sample  213908     0.088 � 0.026  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768                64  sample  208568     0.095 � 0.019  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768               128  sample  325105     0.099 � 0.014  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768               256  sample  257433     0.116 � 0.004  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768               512  sample  312478     0.154 � 0.013  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768              1024  sample  294925     0.307 � 0.024  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768              2048  sample  283436     0.612 � 0.040  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768              4096  sample  312685     1.065 � 0.044  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768              8192  sample  338558     1.949 � 0.060  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768             16384  sample  335765     3.812 � 0.070  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768             32768  sample  292222     8.684 � 0.101  us/op

SNAPSHOT
-----------
Benchmark                                                                              (bufferSize)  (byteStringSize)    Mode     Cnt     Score   Error  Units
ReadByteStringBenchmark.readByteString_toByteArray                                            32768                 8  sample  223787     0.145 � 0.019  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768                16  sample  298604     0.170 � 0.049  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768                32  sample  235275     0.136 � 0.019  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768                64  sample  238826     0.128 � 0.022  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768               128  sample  216197     0.141 � 0.029  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768               256  sample  353672     0.216 � 0.018  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768               512  sample  240704     0.195 � 0.029  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768              1024  sample  274725     0.282 � 0.025  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768              2048  sample  288854     1.112 � 0.066  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768              4096  sample  319519     1.274 � 0.046  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768              8192  sample  369331     1.808 � 0.057  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768             16384  sample  333867     3.488 � 0.075  us/op
ReadByteStringBenchmark.readByteString_toByteArray                                            32768             32768  sample  175988     7.530 � 0.180  us/op
```