### PR TITLE
Switch travis to use openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
-
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer # Updates JDK 8 to the latest available.
+  - openjdk8
 
 after_success:
   - .buildscript/deploy_snapshot.sh


### PR DESCRIPTION
This is instead of using oraclejdk8

The Oracle Jdk8 doesn't seem to be supported by Travis on Xenial:
https://travis-ci.community/t/expected-feature-release-number-in-range-of-9-to-12-but-got-8-installing-oraclejdk8/1345/8