### PR TITLE
Throw new InterruptedIOException subtype on timeout

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/AsyncTimeout.kt
+++ b/okio/src/jvmMain/kotlin/okio/AsyncTimeout.kt
@@ -16,7 +16,6 @@
 package okio
 
 import java.io.IOException
-import java.io.InterruptedIOException
 import java.util.concurrent.TimeUnit
 
 /**
@@ -163,11 +162,10 @@ open class AsyncTimeout : Timeout() {
 
   /**
    * Returns an [IOException] to represent a timeout. By default this method returns
-   * [InterruptedIOException]. If [cause] is non-null it is set as the cause of the
-   * returned exception.
+   * [TimeoutException]. If [cause] is non-null it is set as the cause of the returned exception.
    */
   protected open fun newTimeoutException(cause: IOException?): IOException {
-    val e = InterruptedIOException("timeout")
+    val e = TimeoutException("timeout")
     if (cause != null) {
       e.initCause(cause)
     }

--- a/okio/src/jvmTest/java/okio/AsyncTimeoutTest.java
+++ b/okio/src/jvmTest/java/okio/AsyncTimeoutTest.java
@@ -16,7 +16,6 @@
 package okio;
 
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -198,7 +197,7 @@ public final class AsyncTimeoutTest {
     try {
       timeoutSink.write(data, 1);
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
     }
   }
 
@@ -218,7 +217,7 @@ public final class AsyncTimeoutTest {
     try {
       timeoutSink.flush();
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
     }
   }
 
@@ -238,7 +237,7 @@ public final class AsyncTimeoutTest {
     try {
       timeoutSink.close();
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
     }
   }
 
@@ -259,7 +258,7 @@ public final class AsyncTimeoutTest {
     try {
       timeoutSource.read(new Buffer(), 0);
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
     }
   }
 
@@ -279,7 +278,7 @@ public final class AsyncTimeoutTest {
     try {
       timeoutSource.close();
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
     }
   }
 

--- a/okio/src/jvmTest/java/okio/AsyncTimeoutTest.java
+++ b/okio/src/jvmTest/java/okio/AsyncTimeoutTest.java
@@ -301,7 +301,7 @@ public final class AsyncTimeoutTest {
     try {
       timeoutSink.write(data, 1);
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
       assertEquals("timeout", expected.getMessage());
       assertEquals("exception and timeout", expected.getCause().getMessage());
     }

--- a/okio/src/jvmTest/java/okio/PipeTest.java
+++ b/okio/src/jvmTest/java/okio/PipeTest.java
@@ -16,7 +16,6 @@
 package okio;
 
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
@@ -109,7 +108,7 @@ public final class PipeTest {
     try {
       pipe.sink().write(new Buffer().writeUtf8("def"), 3L);
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
       assertEquals("timeout", expected.getMessage());
     }
     assertElapsed(1000.0, start);
@@ -127,7 +126,7 @@ public final class PipeTest {
     try {
       pipe.source().read(readBuffer, 6L);
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
       assertEquals("timeout", expected.getMessage());
     }
     assertElapsed(1000.0, start);

--- a/okio/src/jvmTest/java/okio/WaitUntilNotifiedTest.java
+++ b/okio/src/jvmTest/java/okio/WaitUntilNotifiedTest.java
@@ -50,33 +50,33 @@ public final class WaitUntilNotifiedTest {
     assertElapsed(1000.0, start);
   }
 
-  @Test public synchronized void timeout() {
+  @Test public synchronized void timeout() throws InterruptedIOException {
     Timeout timeout = new Timeout();
     timeout.timeout(1000, TimeUnit.MILLISECONDS);
     double start = now();
     try {
       timeout.waitUntilNotified(this);
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
       assertEquals("timeout", expected.getMessage());
     }
     assertElapsed(1000.0, start);
   }
 
-  @Test public synchronized void deadline() {
+  @Test public synchronized void deadline() throws InterruptedIOException {
     Timeout timeout = new Timeout();
     timeout.deadline(1000, TimeUnit.MILLISECONDS);
     double start = now();
     try {
       timeout.waitUntilNotified(this);
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
       assertEquals("timeout", expected.getMessage());
     }
     assertElapsed(1000.0, start);
   }
 
-  @Test public synchronized void deadlineBeforeTimeout() {
+  @Test public synchronized void deadlineBeforeTimeout() throws InterruptedIOException {
     Timeout timeout = new Timeout();
     timeout.timeout(5000, TimeUnit.MILLISECONDS);
     timeout.deadline(1000, TimeUnit.MILLISECONDS);
@@ -84,13 +84,13 @@ public final class WaitUntilNotifiedTest {
     try {
       timeout.waitUntilNotified(this);
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
       assertEquals("timeout", expected.getMessage());
     }
     assertElapsed(1000.0, start);
   }
 
-  @Test public synchronized void timeoutBeforeDeadline() {
+  @Test public synchronized void timeoutBeforeDeadline() throws InterruptedIOException {
     Timeout timeout = new Timeout();
     timeout.timeout(1000, TimeUnit.MILLISECONDS);
     timeout.deadline(5000, TimeUnit.MILLISECONDS);
@@ -98,20 +98,20 @@ public final class WaitUntilNotifiedTest {
     try {
       timeout.waitUntilNotified(this);
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
       assertEquals("timeout", expected.getMessage());
     }
     assertElapsed(1000.0, start);
   }
 
-  @Test public synchronized void deadlineAlreadyReached() {
+  @Test public synchronized void deadlineAlreadyReached() throws InterruptedIOException {
     Timeout timeout = new Timeout();
     timeout.deadlineNanoTime(System.nanoTime());
     double start = now();
     try {
       timeout.waitUntilNotified(this);
       fail();
-    } catch (InterruptedIOException expected) {
+    } catch (TimeoutException expected) {
       assertEquals("timeout", expected.getMessage());
     }
     assertElapsed(0.0, start);


### PR DESCRIPTION
Introduces TimeoutException which a caller can catch if it just wants to just deal with timeout and deadline reached, but not interrupts.