### PR TITLE
CipherSink & CipherSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,7 +759,7 @@ which `key` and `iv` parameters should both be 16 bytes long.
 void encryptAes(ByteString bytes, File file, byte[] key, byte[] iv) throws GeneralSecurityException, IOException {
     Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
     cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
-    try (BufferedSink sink = Okio.buffer(Okio.sink(cipher, Okio.sink(file)))) {
+    try (BufferedSink sink = Okio.buffer(Okio.sink(cipher, Okio.buffer(Okio.sink(file))))) {
         sink.write(bytes);
     }
 }
@@ -767,7 +767,7 @@ void encryptAes(ByteString bytes, File file, byte[] key, byte[] iv) throws Gener
 ByteString decryptAesToByteString(File file, byte[] key, byte[] iv) throws GeneralSecurityException, IOException {
     Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
     cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
-    try (BufferedSource source = Okio.buffer(Okio.source(cipher, Okio.source(file)))) {
+    try (BufferedSource source = Okio.buffer(Okio.source(cipher, Okio.buffer(Okio.source(file))))) {
         return source.readByteString();
     }
 }
@@ -781,14 +781,14 @@ fun encryptAes(bytes: ByteString, file: File, key: ByteArray, iv: ByteArray) {
   val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding").apply {
     init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
   }
-  cipher.sink(file.sink()).buffer().use { it.write(bytes) }
+  cipher.sink(file.sink().buffer()).buffer().use { it.write(bytes) }
 }
 
 fun decryptAesToByteString(file: File, key: ByteArray, iv: ByteArray): ByteString {
   val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding").apply {
     init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
   }
-  return cipher.source(file.source()).buffer().use(BufferedSource::readByteString)
+  return cipher.source(file.source().buffer()).buffer().use(BufferedSource::readByteString)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -744,6 +744,53 @@ As with hashing, you can generate an HMAC from a `ByteString`, `Buffer`, `Hashin
 `HashingSink`. Note that Okio doesn’t implement HMAC for MD5. Okio uses Java’s
 `java.security.MessageDigest` for cryptographic hashes and `javax.crypto.Mac` for HMAC.
 
+### Encryption/Decryption
+
+Use `Okio.sink(Cipher, Sink)` or `Okio.source(Cipher, Source)` to
+encrypt or decrypt a stream using a block cipher.
+
+Callers are responsible for the initialization of the encryption or
+decryption cipher with the chosen algorithm, the key, and
+algorithm-specific additional parameters like the initialization vector.
+The following example shows a typical usage with AES encryption, in
+which `key` and `iv` parameters should both be 16 bytes long.
+
+```java
+void encryptAes(ByteString bytes, File file, byte[] key, byte[] iv) throws GeneralSecurityException, IOException {
+    Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+    cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+    try (BufferedSink sink = Okio.buffer(Okio.sink(cipher, Okio.sink(file)))) {
+        sink.write(bytes);
+    }
+}
+
+ByteString decryptAesToByteString(File file, byte[] key, byte[] iv) throws GeneralSecurityException, IOException {
+    Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+    cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+    try (BufferedSource source = Okio.buffer(Okio.source(cipher, Okio.source(file)))) {
+        return source.readByteString();
+    }
+}
+```
+
+In Kotlin, these encryption/decryption methods are provided as
+extensions on the `Cipher` class.
+
+```kotlin
+fun encryptAes(bytes: ByteString, file: File, key: ByteArray, iv: ByteArray) {
+  val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding").apply {
+    init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+  }
+  cipher.sink(file.sink()).buffer().use { it.write(bytes) }
+}
+
+fun decryptAesToByteString(file: File, key: ByteArray, iv: ByteArray): ByteString {
+  val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding").apply {
+    init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+  }
+  return cipher.source(file.source()).buffer().use(BufferedSource::readByteString)
+}
+```
 
 Releases
 --------

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -106,7 +106,7 @@ private class CipherSink internal constructor(
     var thrown: Throwable? = null
     val buffer = sink.buffer
 
-    // For block cipher, output size cannot block size in doFinal
+    // For block cipher, output size cannot exceed block size in doFinal
     val s = buffer.writableSegment(outputSize)
 
     try {

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -1,0 +1,93 @@
+package okio
+
+import java.io.IOException
+import javax.crypto.Cipher
+
+class CipherSink internal constructor(private val sink: BufferedSink, private val cipher: Cipher) : Sink {
+  constructor(sink: Sink, cipher: Cipher) : this(sink.buffer(), cipher)
+
+  private var closed = false
+
+  @Throws(IOException::class)
+  override fun write(source: Buffer, byteCount: Long) {
+    checkOffsetAndCount(source.size, 0, byteCount)
+    check(!closed) { "closed" }
+
+    var remaining = byteCount
+    while (remaining > 0) {
+      val head = source.head!!
+      var toCipher = minOf(remaining, head.limit - head.pos).toInt()
+      var outputSize = cipher.getOutputSize(toCipher)
+      // TODO: Consider using fixed block size (imposed and verified in constructor)
+      while (outputSize > Segment.SIZE) {
+        toCipher /= 2
+        outputSize = cipher.getOutputSize(toCipher)
+      }
+
+      val buffer = sink.buffer
+      val s = buffer.writableSegment(outputSize)
+      val ciphered = cipher.update(head.data, head.pos, toCipher, s.data, s.limit)
+      s.limit += ciphered
+      buffer.size += ciphered
+
+      if (s.pos == s.limit) {
+        buffer.head = s.pop()
+        SegmentPool.recycle(s)
+      }
+
+      source.size -= toCipher
+      head.pos += toCipher
+      if (head.pos == head.limit) {
+        source.head = head.pop()
+        SegmentPool.recycle(head)
+      }
+
+      remaining -= toCipher
+    }
+  }
+
+  override fun flush() {}
+
+  override fun timeout(): Timeout =
+    sink.timeout()
+
+  @Throws(IOException::class)
+  override fun close() {
+    if (closed) return
+
+    var thrown: Throwable? = null
+
+    val outputSize = cipher.getOutputSize(0)
+    if (outputSize != 0) {
+      val buffer = sink.buffer
+      val s = buffer.writableSegment(outputSize)
+
+      try {
+        val ciphered = cipher.doFinal(s.data, s.limit)
+
+        s.limit += ciphered
+        buffer.size += ciphered
+      } catch (e: Throwable) {
+        thrown = e
+      }
+
+      if (s.pos == s.limit) {
+        buffer.head = s.pop()
+        SegmentPool.recycle(s)
+      }
+    }
+
+    try {
+      sink.close()
+    } catch (e: Throwable) {
+      if (thrown == null) thrown = e
+    }
+
+    closed = true
+
+    if (thrown != null) throw thrown
+  }
+}
+
+fun Sink.cipherSink(cipher: Cipher): CipherSink =
+  CipherSink(this, cipher)

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -22,6 +22,9 @@ package okio
 import java.io.IOException
 import javax.crypto.Cipher
 
+/**
+ * A sources that uses a [Cipher] to process data read from another source.
+ */
 class CipherSink internal constructor(private val sink: BufferedSink, private val cipher: Cipher) : Sink {
   constructor(sink: Sink, cipher: Cipher) : this(sink.buffer(), cipher)
 
@@ -124,5 +127,10 @@ class CipherSink internal constructor(private val sink: BufferedSink, private va
   }
 }
 
+/**
+ * Returns a [CipherSink] that processes data to this [Sink] using [cipher] while writing.
+ *
+ * @see CipherSink
+ */
 inline fun Sink.cipherSink(cipher: Cipher): CipherSink =
   CipherSink(this, cipher)

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -22,7 +22,7 @@ package okio
 import java.io.IOException
 import javax.crypto.Cipher
 
-private class CipherSink internal constructor(
+private class CipherSink(
   private val sink: BufferedSink,
   private val cipher: Cipher
 ) : Sink {

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -130,6 +130,9 @@ private class CipherSink(
 /**
  * Returns a [Sink] that processes data using this [Cipher] while writing to
  * [sink].
+ *
+ * @throws IllegalArgumentException
+ *  If this isn't a block cipher.
  */
 fun Cipher.sink(sink: Sink): Sink =
   CipherSink(sink, this)

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -27,6 +27,7 @@ class CipherSink internal constructor(private val sink: BufferedSink, private va
       val buffer = sink.buffer
       val s = buffer.writableSegment(outputSize)
       val ciphered = cipher.update(head.data, head.pos, toCipher, s.data, s.limit)
+
       s.limit += ciphered
       buffer.size += ciphered
 
@@ -37,6 +38,7 @@ class CipherSink internal constructor(private val sink: BufferedSink, private va
 
       source.size -= toCipher
       head.pos += toCipher
+
       if (head.pos == head.limit) {
         source.head = head.pop()
         SegmentPool.recycle(head)

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -31,7 +31,10 @@ class CipherSink internal constructor(private val sink: BufferedSink, private va
     val head = source.head!!
     val size = minOf(remaining, head.limit - head.pos).toInt()
     val buffer = sink.buffer
-    val s = buffer.writableSegment(size) // For block cipher, output size cannot exceed input size in update
+
+    // For block cipher, output size cannot exceed input size in update
+    val s = buffer.writableSegment(size)
+
     val ciphered = cipher.update(head.data, head.pos, size, s.data, s.limit)
 
     s.limit += ciphered
@@ -75,10 +78,14 @@ class CipherSink internal constructor(private val sink: BufferedSink, private va
   }
 
   private fun doFinal(): Throwable? {
-    var thrown: Throwable? = null
+    val outputSize = cipher.getOutputSize(0)
+    if (outputSize == 0) return null
 
+    var thrown: Throwable? = null
     val buffer = sink.buffer
-    val s = buffer.writableSegment(blockSize)
+
+    // For block cipher, output size cannot block size in doFinal
+    val s = buffer.writableSegment(outputSize)
 
     try {
       val ciphered = cipher.doFinal(s.data, s.limit)

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -61,6 +61,20 @@ class CipherSink internal constructor(private val sink: BufferedSink, private va
   override fun close() {
     if (closed) return
 
+    var thrown = doFinal()
+
+    try {
+      sink.close()
+    } catch (e: Throwable) {
+      if (thrown == null) thrown = e
+    }
+
+    closed = true
+
+    if (thrown != null) throw thrown
+  }
+
+  private fun doFinal(): Throwable? {
     var thrown: Throwable? = null
 
     val buffer = sink.buffer
@@ -80,15 +94,7 @@ class CipherSink internal constructor(private val sink: BufferedSink, private va
       SegmentPool.recycle(s)
     }
 
-    try {
-      sink.close()
-    } catch (e: Throwable) {
-      if (thrown == null) thrown = e
-    }
-
-    closed = true
-
-    if (thrown != null) throw thrown
+    return thrown
   }
 }
 

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-@file:JvmName("-CipherSinkExtensions")
-@file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
+@file:JvmMultifileClass
+@file:JvmName("Okio")
 
 package okio
 
 import java.io.IOException
 import javax.crypto.Cipher
 
-/**
- * A sources that uses a [Cipher] to process data read from another source.
- */
-class CipherSink internal constructor(private val sink: BufferedSink, private val cipher: Cipher) : Sink {
+private class CipherSink internal constructor(
+  private val sink: BufferedSink,
+  private val cipher: Cipher
+) : Sink {
   constructor(sink: Sink, cipher: Cipher) : this(sink.buffer(), cipher)
 
   private val blockSize = cipher.blockSize
@@ -128,9 +128,8 @@ class CipherSink internal constructor(private val sink: BufferedSink, private va
 }
 
 /**
- * Returns a [CipherSink] that processes data to this [Sink] using [cipher] while writing.
- *
- * @see CipherSink
+ * Returns a [Sink] that processes data using this [Cipher] while writing to
+ * [sink].
  */
-inline fun Sink.cipherSink(cipher: Cipher): CipherSink =
-  CipherSink(this, cipher)
+fun Cipher.sink(sink: Sink): Sink =
+  CipherSink(sink, this)

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -63,23 +63,21 @@ class CipherSink internal constructor(private val sink: BufferedSink, private va
 
     var thrown: Throwable? = null
 
-    if (blockSize != 0) {
-      val buffer = sink.buffer
-      val s = buffer.writableSegment(blockSize)
+    val buffer = sink.buffer
+    val s = buffer.writableSegment(blockSize)
 
-      try {
-        val ciphered = cipher.doFinal(s.data, s.limit)
+    try {
+      val ciphered = cipher.doFinal(s.data, s.limit)
 
-        s.limit += ciphered
-        buffer.size += ciphered
-      } catch (e: Throwable) {
-        thrown = e
-      }
+      s.limit += ciphered
+      buffer.size += ciphered
+    } catch (e: Throwable) {
+      thrown = e
+    }
 
-      if (s.pos == s.limit) {
-        buffer.head = s.pop()
-        SegmentPool.recycle(s)
-      }
+    if (s.pos == s.limit) {
+      buffer.head = s.pop()
+      SegmentPool.recycle(s)
     }
 
     try {

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("-CipherSinkExtensions")
+@file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
+
 package okio
 
 import java.io.IOException
@@ -105,5 +124,5 @@ class CipherSink internal constructor(private val sink: BufferedSink, private va
   }
 }
 
-fun Sink.cipherSink(cipher: Cipher): CipherSink =
+inline fun Sink.cipherSink(cipher: Cipher): CipherSink =
   CipherSink(this, cipher)

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -1,0 +1,73 @@
+package okio
+
+import java.io.IOException
+import javax.crypto.Cipher
+
+class CipherSource internal constructor(private val source: BufferedSource, private val cipher: Cipher) : Source {
+  constructor(source: Source, cipher: Cipher) : this(source.buffer(), cipher)
+
+  private val buffer = Buffer()
+  private var final = false
+  private var closed = false
+
+  @Throws(IOException::class)
+  override fun read(sink: Buffer, byteCount: Long): Long {
+    require(byteCount >= 0) { "byteCount < 0: $byteCount" }
+    check(!closed) { "closed" }
+    if (byteCount == 0L) return 0
+    if (final) return buffer.read(sink, byteCount)
+
+    while (buffer.size == 0L) {
+      if (source.exhausted()) {
+        final = true
+        return readFinal(sink, byteCount)
+      }
+
+      val head = source.buffer.head!!
+      val size = head.limit - head.pos
+      val toCipher = cipher.getOutputSize(size)
+      val s = buffer.writableSegment(toCipher)
+      val ciphered =
+        cipher.update(head.data, head.pos, head.limit, s.data, s.pos)
+
+      source.skip(size.toLong())
+
+      s.limit += ciphered
+      buffer.size += ciphered
+
+      if (s.pos == s.limit) {
+        buffer.head = head.pop()
+        SegmentPool.recycle(s)
+      }
+    }
+
+    return buffer.read(sink, byteCount)
+  }
+
+  private fun readFinal(sink: Buffer, byteCount: Long): Long {
+    val toCipher = cipher.getOutputSize(0)
+    val s = buffer.writableSegment(toCipher)
+    val ciphered = cipher.doFinal(s.data, s.pos)
+    s.limit += ciphered
+    buffer.size += ciphered
+
+    if (s.pos == s.limit) {
+      buffer.head = s.pop()
+      SegmentPool.recycle(s)
+    }
+
+    return buffer.read(sink, byteCount)
+  }
+
+  override fun timeout(): Timeout =
+    source.timeout()
+
+  @Throws(IOException::class)
+  override fun close() {
+    closed = true
+    source.close()
+  }
+}
+
+fun Source.cipherSource(cipher: Cipher): CipherSource =
+  CipherSource(this, cipher)

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -115,7 +115,7 @@ private class CipherSource(
 /**
  * Returns a [Source] that processes data using this [Cipher] while reading
  * from [source].
- * 
+ *
  * @throws IllegalArgumentException
  *  If this isn't a block cipher.
  */

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -22,7 +22,7 @@ package okio
 import java.io.IOException
 import javax.crypto.Cipher
 
-private class CipherSource internal constructor(
+private class CipherSource(
   private val source: BufferedSource,
   private val cipher: Cipher
 ) : Source {

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("-CipherSourceExtensions")
+@file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
+
 package okio
 
 import java.io.IOException
@@ -90,5 +109,5 @@ class CipherSource internal constructor(private val source: BufferedSource, priv
   }
 }
 
-fun Source.cipherSource(cipher: Cipher): CipherSource =
+inline fun Source.cipherSource(cipher: Cipher): CipherSource =
   CipherSource(this, cipher)

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -115,6 +115,9 @@ private class CipherSource(
 /**
  * Returns a [Source] that processes data using this [Cipher] while reading
  * from [source].
+ * 
+ * @throws IllegalArgumentException
+ *  If this isn't a block cipher.
  */
 fun Cipher.source(source: Source): Source =
   CipherSource(source, this)

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -71,7 +71,7 @@ private class CipherSource internal constructor(
     val s = buffer.writableSegment(size)
 
     val ciphered =
-      cipher.update(head.data, head.pos, head.limit, s.data, s.pos)
+      cipher.update(head.data, head.pos, size, s.data, s.pos)
 
     source.skip(size.toLong())
 

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -50,7 +50,7 @@ class CipherSource internal constructor(private val source: BufferedSource, priv
     buffer.size += ciphered
 
     if (s.pos == s.limit) {
-      buffer.head = head.pop()
+      buffer.head = s.pop()
       SegmentPool.recycle(s)
     }
   }

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-@file:JvmName("-CipherSourceExtensions")
-@file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
+@file:JvmMultifileClass
+@file:JvmName("Okio")
 
 package okio
 
 import java.io.IOException
 import javax.crypto.Cipher
 
-/**
- * A sink that uses a [Cipher] to process data written to another source.
- */
-class CipherSource internal constructor(private val source: BufferedSource, private val cipher: Cipher) : Source {
+private class CipherSource internal constructor(
+  private val source: BufferedSource,
+  private val cipher: Cipher
+) : Source {
   constructor(source: Source, cipher: Cipher) : this(source.buffer(), cipher)
 
   private val blockSize = cipher.blockSize
@@ -113,9 +113,8 @@ class CipherSource internal constructor(private val source: BufferedSource, priv
 }
 
 /**
- * Returns a [CipherSource] that processes this [Source] using [cipher] while reading.
- *
- * @see InflaterSource
+ * Returns a [Source] that processes data using this [Cipher] while reading
+ * from [source].
  */
-inline fun Source.cipherSource(cipher: Cipher): CipherSource =
-  CipherSource(this, cipher)
+fun Cipher.source(source: Source): Source =
+  CipherSource(source, this)

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -22,6 +22,9 @@ package okio
 import java.io.IOException
 import javax.crypto.Cipher
 
+/**
+ * A sink that uses a [Cipher] to process data written to another source.
+ */
 class CipherSource internal constructor(private val source: BufferedSource, private val cipher: Cipher) : Source {
   constructor(source: Source, cipher: Cipher) : this(source.buffer(), cipher)
 
@@ -109,5 +112,10 @@ class CipherSource internal constructor(private val source: BufferedSource, priv
   }
 }
 
+/**
+ * Returns a [CipherSource] that processes this [Source] using [cipher] while reading.
+ *
+ * @see InflaterSource
+ */
 inline fun Source.cipherSource(cipher: Cipher): CipherSource =
   CipherSource(this, cipher)

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -88,7 +88,7 @@ private class CipherSource internal constructor(
     val outputSize = cipher.getOutputSize(0)
     if (outputSize == 0) return
 
-    // For block cipher, output size cannot block size in doFinal
+    // For block cipher, output size cannot exceed block size in doFinal
     val s = buffer.writableSegment(outputSize)
 
     val ciphered = cipher.doFinal(s.data, s.pos)

--- a/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
@@ -1,12 +1,13 @@
 package okio
 
 import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
+import kotlin.random.Random
 
 class CipherFactory(
-  private val key: ByteArray,
-  private val keyAlgorithm: String = "AES",
-  private val transformation: String = "AES/ECB/PKCS5Padding"
+  private val transformation: String,
+  private val init: Cipher.(mode: Int) -> Unit
 ) {
   val encrypt: Cipher
     get() = create(Cipher.ENCRYPT_MODE)
@@ -16,6 +17,45 @@ class CipherFactory(
 
   private fun create(mode: Int): Cipher =
     Cipher.getInstance(transformation).apply {
-      init(mode, SecretKeySpec(key, keyAlgorithm))
+      init(mode)
     }
+}
+
+data class CipherAlgorithm(
+  val transformation: String,
+  val keyLength: Int,
+  val ivLength: Int? = null
+) {
+  fun createCipherFactory(random: Random): CipherFactory {
+    val key = random.nextBytes(keyLength)
+    val secretKeySpec = SecretKeySpec(key, transformation.substringBefore('/'))
+    return if (ivLength == null) {
+      CipherFactory(transformation) { mode ->
+        init(mode, secretKeySpec)
+      }
+    } else {
+      val iv = random.nextBytes(ivLength)
+      val ivParameterSpec = IvParameterSpec(iv)
+      CipherFactory(transformation) { mode ->
+        init(mode, secretKeySpec, ivParameterSpec)
+      }
+    }
+  }
+
+  companion object {
+    fun getBlockCipherAlgorithms() = listOf(
+      CipherAlgorithm("AES/CBC/NoPadding", 16, 16),
+      CipherAlgorithm("AES/CBC/PKCS5Padding", 16, 16),
+      CipherAlgorithm("AES/ECB/NoPadding", 16),
+      CipherAlgorithm("AES/ECB/PKCS5Padding", 16),
+      CipherAlgorithm("DES/CBC/NoPadding", 8, 8),
+      CipherAlgorithm("DES/CBC/PKCS5Padding", 8, 8),
+      CipherAlgorithm("DES/ECB/NoPadding", 8),
+      CipherAlgorithm("DES/ECB/PKCS5Padding", 8),
+      CipherAlgorithm("DESede/CBC/NoPadding", 24, 8),
+      CipherAlgorithm("DESede/CBC/PKCS5Padding", 24, 8),
+      CipherAlgorithm("DESede/ECB/NoPadding", 24),
+      CipherAlgorithm("DESede/ECB/PKCS5Padding", 24)
+    )
+  }
 }

--- a/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
@@ -1,20 +1,13 @@
 package okio
 
-import java.security.Key
 import javax.crypto.Cipher
 import javax.crypto.spec.SecretKeySpec
 
 class CipherFactory(
-  private val key: Key,
+  private val key: ByteArray,
+  private val keyAlgorithm: String = "AES",
   private val transformation: String = "AES/ECB/PKCS5Padding"
 ) {
-
-  constructor(
-    key: ByteArray,
-    keyAlgorithm: String = "AES",
-    transformation: String = "AES/ECB/PKCS5Padding"
-  ) : this(SecretKeySpec(key, keyAlgorithm), transformation)
-
   val encrypt: Cipher
     get() = create(Cipher.ENCRYPT_MODE)
 
@@ -23,6 +16,6 @@ class CipherFactory(
 
   private fun create(mode: Int): Cipher =
     Cipher.getInstance(transformation).apply {
-      init(mode, key)
+      init(mode, SecretKeySpec(key, keyAlgorithm))
     }
 }

--- a/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
@@ -1,13 +1,20 @@
 package okio
 
+import java.security.Key
 import javax.crypto.Cipher
 import javax.crypto.spec.SecretKeySpec
 
 class CipherFactory(
-  private val key: ByteArray,
-  private val keyAlgorithm: String = "AES",
+  private val key: Key,
   private val transformation: String = "AES/ECB/PKCS5Padding"
 ) {
+
+  constructor(
+    key: ByteArray,
+    keyAlgorithm: String = "AES",
+    transformation: String = "AES/ECB/PKCS5Padding"
+  ) : this(SecretKeySpec(key, keyAlgorithm), transformation)
+
   val encrypt: Cipher
     get() = create(Cipher.ENCRYPT_MODE)
 
@@ -16,6 +23,6 @@ class CipherFactory(
 
   private fun create(mode: Int): Cipher =
     Cipher.getInstance(transformation).apply {
-      init(mode, SecretKeySpec(key, keyAlgorithm))
+      init(mode, key)
     }
 }

--- a/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
@@ -1,0 +1,21 @@
+package okio
+
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+
+class CipherFactory(
+  private val key: ByteArray,
+  private val keyAlgorithm: String = "AES",
+  private val transformation: String = "AES/ECB/PKCS5Padding"
+) {
+  val encrypt: Cipher
+    get() = create(Cipher.ENCRYPT_MODE)
+
+  val decrypt: Cipher
+    get() = create(Cipher.DECRYPT_MODE)
+
+  private fun create(mode: Int): Cipher =
+    Cipher.getInstance(transformation).apply {
+      init(mode, SecretKeySpec(key, keyAlgorithm))
+    }
+}

--- a/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
@@ -42,6 +42,9 @@ data class CipherAlgorithm(
     }
   }
 
+  override fun toString(): String =
+    transformation
+
   companion object {
     fun getBlockCipherAlgorithms() = listOf(
       CipherAlgorithm("AES/CBC/NoPadding", 16, 16),

--- a/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
@@ -9,20 +9,25 @@ class CipherFactory(
   private val transformation: String,
   private val init: Cipher.(mode: Int) -> Unit
 ) {
+  val blockSize
+    get() = cipher.blockSize
+
   val encrypt: Cipher
     get() = create(Cipher.ENCRYPT_MODE)
 
   val decrypt: Cipher
     get() = create(Cipher.DECRYPT_MODE)
 
+  private val cipher: Cipher
+    get() = Cipher.getInstance(transformation)
+
   private fun create(mode: Int): Cipher =
-    Cipher.getInstance(transformation).apply {
-      init(mode)
-    }
+    cipher.apply { init(mode) }
 }
 
 data class CipherAlgorithm(
   val transformation: String,
+  val padding: Boolean,
   val keyLength: Int,
   val ivLength: Int? = null
 ) {
@@ -47,18 +52,18 @@ data class CipherAlgorithm(
 
   companion object {
     fun getBlockCipherAlgorithms() = listOf(
-      CipherAlgorithm("AES/CBC/NoPadding", 16, 16),
-      CipherAlgorithm("AES/CBC/PKCS5Padding", 16, 16),
-      CipherAlgorithm("AES/ECB/NoPadding", 16),
-      CipherAlgorithm("AES/ECB/PKCS5Padding", 16),
-      CipherAlgorithm("DES/CBC/NoPadding", 8, 8),
-      CipherAlgorithm("DES/CBC/PKCS5Padding", 8, 8),
-      CipherAlgorithm("DES/ECB/NoPadding", 8),
-      CipherAlgorithm("DES/ECB/PKCS5Padding", 8),
-      CipherAlgorithm("DESede/CBC/NoPadding", 24, 8),
-      CipherAlgorithm("DESede/CBC/PKCS5Padding", 24, 8),
-      CipherAlgorithm("DESede/ECB/NoPadding", 24),
-      CipherAlgorithm("DESede/ECB/PKCS5Padding", 24)
+      CipherAlgorithm("AES/CBC/NoPadding", false, 16, 16),
+      CipherAlgorithm("AES/CBC/PKCS5Padding", true, 16, 16),
+      CipherAlgorithm("AES/ECB/NoPadding", false, 16),
+      CipherAlgorithm("AES/ECB/PKCS5Padding", true, 16),
+      CipherAlgorithm("DES/CBC/NoPadding", false, 8, 8),
+      CipherAlgorithm("DES/CBC/PKCS5Padding", true, 8, 8),
+      CipherAlgorithm("DES/ECB/NoPadding", false, 8),
+      CipherAlgorithm("DES/ECB/PKCS5Padding", true, 8),
+      CipherAlgorithm("DESede/CBC/NoPadding", false, 24, 8),
+      CipherAlgorithm("DESede/CBC/PKCS5Padding", true, 24, 8),
+      CipherAlgorithm("DESede/ECB/NoPadding", false, 24),
+      CipherAlgorithm("DESede/ECB/PKCS5Padding", true, 24)
     )
   }
 }

--- a/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
@@ -6,7 +6,7 @@ import kotlin.random.Random
 class CipherSinkTest {
 
   @Test
-  fun encryptWithClose() {
+  fun encrypt() {
     val random = Random(1588326457426L)
     val data = random.nextBytes(32)
     val key = random.nextBytes(16)
@@ -21,7 +21,22 @@ class CipherSinkTest {
   }
 
   @Test
-  fun decryptWithClose() {
+  fun encryptSingleByteWrite() {
+    val random = Random(1588326457426L)
+    val data = random.nextBytes(32)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+
+    val buffer = Buffer()
+    buffer.cipherSink(cipherFactory.encrypt).buffer().use { data.forEach { byte -> it.writeByte(byte.toInt()) }}
+    val actualEncryptedData = buffer.readByteArray()
+
+    val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
+    assertArrayEquals(expectedEncryptedData, actualEncryptedData)
+  }
+
+  @Test
+  fun decrypt() {
     val random = Random(1588326610176L)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
@@ -30,6 +45,21 @@ class CipherSinkTest {
 
     val buffer = Buffer()
     buffer.cipherSink(cipherFactory.decrypt).buffer().use { it.write(encryptedData) }
+    val actualData = buffer.readByteArray()
+
+    assertArrayEquals(expectedData, actualData)
+  }
+
+  @Test
+  fun decryptSingleByteWrite() {
+    val random = Random(1588326610176L)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+    val expectedData = random.nextBytes(32)
+    val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
+
+    val buffer = Buffer()
+    buffer.cipherSink(cipherFactory.decrypt).buffer().use { encryptedData.forEach { byte -> it.writeByte(byte.toInt()) } }
     val actualData = buffer.readByteArray()
 
     assertArrayEquals(expectedData, actualData)

--- a/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
@@ -1,0 +1,62 @@
+package okio
+
+import org.junit.Test
+import java.security.Key
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import kotlin.random.Random
+
+class CipherSinkTest {
+
+  @Test
+  fun encryptWithClose() {
+    val random = Random(1588326457426L)
+    val data = random.nextBytes(32)
+    val iv = random.nextBytes(16)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(iv, key)
+
+    val buffer = Buffer()
+    buffer.cipherSink(cipherFactory.encrypt).buffer().use { it.write(data) }
+    val actualEncryptedData = buffer.readByteArray()
+
+    val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
+    assertArrayEquals(expectedEncryptedData, actualEncryptedData)
+  }
+
+  @Test
+  fun decryptWithClose() {
+    val random = Random(1588326610176L)
+    val iv = random.nextBytes(16)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(iv, key)
+    val expectedData = random.nextBytes(32)
+    val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
+
+    val buffer = Buffer()
+    buffer.cipherSink(cipherFactory.decrypt).buffer().use { it.write(encryptedData) }
+    val actualData = buffer.readByteArray()
+    actualData[actualData.size - 1] = 0
+
+    assertArrayEquals(expectedData, actualData)
+  }
+}
+
+private class CipherFactory(
+  private val initializationVector: ByteArray,
+  private val key: ByteArray,
+  private val keyAlgorithm: String = "AES",
+  private val transformation: String = "AES/ECB/PKCS5Padding"
+) {
+  val encrypt: Cipher
+    get() = create(Cipher.ENCRYPT_MODE)
+
+  val decrypt: Cipher
+    get() = create(Cipher.DECRYPT_MODE)
+
+  private fun create(mode: Int): Cipher =
+    Cipher.getInstance(transformation).apply {
+      init(mode, SecretKeySpec(key, keyAlgorithm), IvParameterSpec(initializationVector))
+    }
+}

--- a/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
@@ -21,7 +21,7 @@ class CipherSinkTest(private val cipherAlgorithm: CipherAlgorithm) {
     val data = random.nextBytes(32)
 
     val buffer = Buffer()
-    buffer.cipherSink(cipherFactory.encrypt).buffer().use { it.write(data) }
+    cipherFactory.encrypt.sink(buffer).buffer().use { it.write(data) }
     val actualEncryptedData = buffer.readByteArray()
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
@@ -35,7 +35,7 @@ class CipherSinkTest(private val cipherAlgorithm: CipherAlgorithm) {
     val data = ByteArray(0)
 
     val buffer = Buffer()
-    buffer.cipherSink(cipherFactory.encrypt).buffer().use { }
+    cipherFactory.encrypt.sink(buffer).buffer().close()
     val actualEncryptedData = buffer.readByteArray()
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
@@ -49,7 +49,7 @@ class CipherSinkTest(private val cipherAlgorithm: CipherAlgorithm) {
     val data = random.nextBytes(Segment.SIZE * 16 + Segment.SIZE / 2)
 
     val buffer = Buffer()
-    buffer.cipherSink(cipherFactory.encrypt).buffer().use { it.write(data) }
+    cipherFactory.encrypt.sink(buffer).buffer().use { it.write(data) }
     val actualEncryptedData = buffer.readByteArray()
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
@@ -63,7 +63,7 @@ class CipherSinkTest(private val cipherAlgorithm: CipherAlgorithm) {
     val data = random.nextBytes(32)
 
     val buffer = Buffer()
-    buffer.cipherSink(cipherFactory.encrypt).buffer().use { data.forEach { byte -> it.writeByte(byte.toInt()) } }
+    cipherFactory.encrypt.sink(buffer).buffer().use { data.forEach { byte -> it.writeByte(byte.toInt()) } }
     val actualEncryptedData = buffer.readByteArray()
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
@@ -78,7 +78,7 @@ class CipherSinkTest(private val cipherAlgorithm: CipherAlgorithm) {
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 
     val buffer = Buffer()
-    buffer.cipherSink(cipherFactory.decrypt).buffer().use { it.write(encryptedData) }
+    cipherFactory.decrypt.sink(buffer).buffer().use { it.write(encryptedData) }
     val actualData = buffer.readByteArray()
 
     assertArrayEquals(expectedData, actualData)
@@ -92,7 +92,7 @@ class CipherSinkTest(private val cipherAlgorithm: CipherAlgorithm) {
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 
     val buffer = Buffer()
-    buffer.cipherSink(cipherFactory.decrypt).buffer().use { it.write(encryptedData) }
+    cipherFactory.decrypt.sink(buffer).buffer().use { it.write(encryptedData) }
     val actualData = buffer.readByteArray()
 
     assertArrayEquals(expectedData, actualData)
@@ -106,7 +106,7 @@ class CipherSinkTest(private val cipherAlgorithm: CipherAlgorithm) {
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 
     val buffer = Buffer()
-    buffer.cipherSink(cipherFactory.decrypt).buffer().use { it.write(encryptedData) }
+    cipherFactory.decrypt.sink(buffer).buffer().use { it.write(encryptedData) }
     val actualData = buffer.readByteArray()
 
     assertArrayEquals(expectedData, actualData)
@@ -120,7 +120,7 @@ class CipherSinkTest(private val cipherAlgorithm: CipherAlgorithm) {
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 
     val buffer = Buffer()
-    buffer.cipherSink(cipherFactory.decrypt).buffer()
+    cipherFactory.decrypt.sink(buffer).buffer()
       .use { encryptedData.forEach { byte -> it.writeByte(byte.toInt()) } }
     val actualData = buffer.readByteArray()
 

--- a/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
@@ -28,7 +28,7 @@ class CipherSinkTest {
     val data = ByteArray(0)
 
     val buffer = Buffer()
-    buffer.cipherSink(cipherFactory.encrypt).buffer()
+    buffer.cipherSink(cipherFactory.encrypt).buffer().use {  }
     val actualEncryptedData = buffer.readByteArray()
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)

--- a/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
@@ -7,7 +7,7 @@ class CipherSinkTest {
 
   @Test
   fun encrypt() {
-    val random = Random(1588326457426L)
+    val random = Random(8912860393601532863)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val data = random.nextBytes(32)
@@ -22,7 +22,7 @@ class CipherSinkTest {
 
   @Test
   fun encryptEmpty() {
-    val random = Random(1588326457426L)
+    val random = Random(3014415396541767201)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val data = ByteArray(0)
@@ -37,7 +37,7 @@ class CipherSinkTest {
 
   @Test
   fun encryptLarge() {
-    val random = Random(1588326457426L)
+    val random = Random(4800508322764694019)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val data = random.nextBytes(Segment.SIZE * 16 + Segment.SIZE / 2)
@@ -52,7 +52,7 @@ class CipherSinkTest {
 
   @Test
   fun encryptSingleByteWrite() {
-    val random = Random(1588326457426L)
+    val random = Random(4374178522096702290)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val data = random.nextBytes(32)
@@ -67,7 +67,7 @@ class CipherSinkTest {
 
   @Test
   fun decrypt() {
-    val random = Random(1588326610176L)
+    val random = Random(488375923060579687)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val expectedData = random.nextBytes(32)
@@ -82,7 +82,7 @@ class CipherSinkTest {
 
   @Test
   fun decryptEmpty() {
-    val random = Random(1588326610176L)
+    val random = Random(-9063010151894844496)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val expectedData = ByteArray(0)
@@ -97,7 +97,7 @@ class CipherSinkTest {
 
   @Test
   fun decryptLarge() {
-    val random = Random(1588326610176L)
+    val random = Random(993064087526004362)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val expectedData = random.nextBytes(Segment.SIZE * 16 + Segment.SIZE / 2)
@@ -112,7 +112,7 @@ class CipherSinkTest {
 
   @Test
   fun decryptSingleByteWrite() {
-    val random = Random(1588326610176L)
+    val random = Random(2621474675920878975)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val expectedData = random.nextBytes(32)

--- a/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
@@ -8,9 +8,39 @@ class CipherSinkTest {
   @Test
   fun encrypt() {
     val random = Random(1588326457426L)
-    val data = random.nextBytes(32)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
+    val data = random.nextBytes(32)
+
+    val buffer = Buffer()
+    buffer.cipherSink(cipherFactory.encrypt).buffer().use { it.write(data) }
+    val actualEncryptedData = buffer.readByteArray()
+
+    val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
+    assertArrayEquals(expectedEncryptedData, actualEncryptedData)
+  }
+
+  @Test
+  fun encryptEmpty() {
+    val random = Random(1588326457426L)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+    val data = ByteArray(0)
+
+    val buffer = Buffer()
+    buffer.cipherSink(cipherFactory.encrypt).buffer()
+    val actualEncryptedData = buffer.readByteArray()
+
+    val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
+    assertArrayEquals(expectedEncryptedData, actualEncryptedData)
+  }
+
+  @Test
+  fun encryptLarge() {
+    val random = Random(1588326457426L)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+    val data = random.nextBytes(Segment.SIZE * 16 + Segment.SIZE / 2)
 
     val buffer = Buffer()
     buffer.cipherSink(cipherFactory.encrypt).buffer().use { it.write(data) }
@@ -23,9 +53,9 @@ class CipherSinkTest {
   @Test
   fun encryptSingleByteWrite() {
     val random = Random(1588326457426L)
-    val data = random.nextBytes(32)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
+    val data = random.nextBytes(32)
 
     val buffer = Buffer()
     buffer.cipherSink(cipherFactory.encrypt).buffer().use { data.forEach { byte -> it.writeByte(byte.toInt()) }}
@@ -41,6 +71,36 @@ class CipherSinkTest {
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val expectedData = random.nextBytes(32)
+    val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
+
+    val buffer = Buffer()
+    buffer.cipherSink(cipherFactory.decrypt).buffer().use { it.write(encryptedData) }
+    val actualData = buffer.readByteArray()
+
+    assertArrayEquals(expectedData, actualData)
+  }
+
+  @Test
+  fun decryptEmpty() {
+    val random = Random(1588326610176L)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+    val expectedData = ByteArray(0)
+    val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
+
+    val buffer = Buffer()
+    buffer.cipherSink(cipherFactory.decrypt).buffer().use { it.write(encryptedData) }
+    val actualData = buffer.readByteArray()
+
+    assertArrayEquals(expectedData, actualData)
+  }
+
+  @Test
+  fun decryptLarge() {
+    val random = Random(1588326610176L)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+    val expectedData = random.nextBytes(Segment.SIZE * 16 + Segment.SIZE / 2)
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 
     val buffer = Buffer()

--- a/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
@@ -13,7 +13,7 @@ class CipherSinkTest(private val cipherAlgorithm: CipherAlgorithm) {
     val parameters: List<CipherAlgorithm>
       get() = CipherAlgorithm.getBlockCipherAlgorithms()
   }
-  
+
   @Test
   fun encrypt() {
     val random = Random(8912860393601532863)

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -8,9 +8,39 @@ class CipherSourceTest {
   @Test
   fun encrypt() {
     val random = Random(1588326457426L)
-    val data = random.nextBytes(32)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
+    val data = random.nextBytes(32)
+
+    val buffer = Buffer().apply { write(data) }
+    val actualEncryptedData =
+      buffer.cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
+
+    val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
+    assertArrayEquals(expectedEncryptedData, actualEncryptedData)
+  }
+
+  @Test
+  fun encryptEmpty() {
+    val random = Random(1588326457426L)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+    val data = ByteArray(0)
+
+    val buffer = Buffer()
+    val actualEncryptedData =
+      buffer.cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
+
+    val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
+    assertArrayEquals(expectedEncryptedData, actualEncryptedData)
+  }
+
+  @Test
+  fun encryptLarge() {
+    val random = Random(1588326457426L)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+    val data = random.nextBytes(Segment.SIZE * 16 + Segment.SIZE / 2)
 
     val buffer = Buffer().apply { write(data) }
     val actualEncryptedData =
@@ -23,9 +53,9 @@ class CipherSourceTest {
   @Test
   fun encryptSingleByteSource() {
     val random = Random(1588326457426L)
-    val data = random.nextBytes(32)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
+    val data = random.nextBytes(32)
 
     val buffer = Buffer().apply { write(data) }
     val actualEncryptedData =
@@ -41,6 +71,36 @@ class CipherSourceTest {
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val expectedData = random.nextBytes(32)
+    val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
+
+    val buffer = Buffer().apply { write(encryptedData) }
+    val actualData =
+      buffer.cipherSource(cipherFactory.decrypt).buffer().use { it.readByteArray() }
+
+    assertArrayEquals(expectedData, actualData)
+  }
+
+  @Test
+  fun decryptEmpty() {
+    val random = Random(1588326610176L)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+    val expectedData = ByteArray(0)
+    val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
+
+    val buffer = Buffer().apply { write(encryptedData) }
+    val actualData =
+      buffer.cipherSource(cipherFactory.decrypt).buffer().use { it.readByteArray() }
+
+    assertArrayEquals(expectedData, actualData)
+  }
+
+  @Test
+  fun decryptLarge() {
+    val random = Random(1588326610176L)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+    val expectedData = random.nextBytes(Segment.SIZE * 16 + Segment.SIZE / 2)
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 
     val buffer = Buffer().apply { write(encryptedData) }

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -1,8 +1,6 @@
 package okio
 
 import org.junit.Test
-import java.security.KeyPairGenerator
-import java.security.SecureRandom
 import kotlin.random.Random
 
 class CipherSourceTest {
@@ -12,26 +10,6 @@ class CipherSourceTest {
     val random = Random(787679144228763091)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
-    val data = random.nextBytes(32)
-
-    val buffer = Buffer().apply { write(data) }
-    val actualEncryptedData =
-      buffer.cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
-
-    val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
-    assertArrayEquals(expectedEncryptedData, actualEncryptedData)
-  }
-
-  @Test
-  fun encryptRsa() {
-    val random = Random(787679144228763091)
-    val secureRandom = SecureRandom(random.nextBytes(16))
-    val keyPairGenerator = KeyPairGenerator.getInstance("RSA").apply {
-      initialize(1024, secureRandom)
-    }
-    val keyPair = keyPairGenerator.generateKeyPair()
-    val publicKey = keyPair.public
-    val cipherFactory = CipherFactory(publicKey, "RSA/ECB/PKCS1Padding")
     val data = random.nextBytes(32)
 
     val buffer = Buffer().apply { write(data) }

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -7,7 +7,7 @@ class CipherSourceTest {
 
   @Test
   fun encrypt() {
-    val random = Random(1588326457426L)
+    val random = Random(787679144228763091)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val data = random.nextBytes(32)
@@ -22,7 +22,7 @@ class CipherSourceTest {
 
   @Test
   fun encryptEmpty() {
-    val random = Random(1588326457426L)
+    val random = Random(1057830944394705953)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val data = ByteArray(0)
@@ -37,7 +37,7 @@ class CipherSourceTest {
 
   @Test
   fun encryptLarge() {
-    val random = Random(1588326457426L)
+    val random = Random(8185922876836480815)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val data = random.nextBytes(Segment.SIZE * 16 + Segment.SIZE / 2)
@@ -52,7 +52,7 @@ class CipherSourceTest {
 
   @Test
   fun encryptSingleByteSource() {
-    val random = Random(1588326457426L)
+    val random = Random(6085265142433950622)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val data = random.nextBytes(32)
@@ -67,7 +67,7 @@ class CipherSourceTest {
 
   @Test
   fun decrypt() {
-    val random = Random(1588326610176L)
+    val random = Random(8067587635762239433)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val expectedData = random.nextBytes(32)
@@ -82,7 +82,7 @@ class CipherSourceTest {
 
   @Test
   fun decryptEmpty() {
-    val random = Random(1588326610176L)
+    val random = Random(8722996896871347396)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val expectedData = ByteArray(0)
@@ -97,7 +97,7 @@ class CipherSourceTest {
 
   @Test
   fun decryptLarge() {
-    val random = Random(1588326610176L)
+    val random = Random(4007116131070653181)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val expectedData = random.nextBytes(Segment.SIZE * 16 + Segment.SIZE / 2)
@@ -112,7 +112,7 @@ class CipherSourceTest {
 
   @Test
   fun decryptSingleByteSource() {
-    val random = Random(1588326610176L)
+    val random = Random(1555017938547616655)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
     val expectedData = random.nextBytes(32)

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -1,15 +1,23 @@
 package okio
 
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import kotlin.random.Random
 
-class CipherSourceTest {
+@RunWith(Parameterized::class)
+class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
+  companion object {
+    @get:Parameterized.Parameters(name = "{0}")
+    @get:JvmStatic
+    val parameters: List<CipherAlgorithm>
+      get() = CipherAlgorithm.getBlockCipherAlgorithms()
+  }
 
   @Test
   fun encrypt() {
     val random = Random(787679144228763091)
-    val key = random.nextBytes(16)
-    val cipherFactory = CipherFactory(key)
+    val cipherFactory = cipherAlgorithm.createCipherFactory(random)
     val data = random.nextBytes(32)
 
     val buffer = Buffer().apply { write(data) }
@@ -23,8 +31,7 @@ class CipherSourceTest {
   @Test
   fun encryptEmpty() {
     val random = Random(1057830944394705953)
-    val key = random.nextBytes(16)
-    val cipherFactory = CipherFactory(key)
+    val cipherFactory = cipherAlgorithm.createCipherFactory(random)
     val data = ByteArray(0)
 
     val buffer = Buffer()
@@ -38,8 +45,7 @@ class CipherSourceTest {
   @Test
   fun encryptLarge() {
     val random = Random(8185922876836480815)
-    val key = random.nextBytes(16)
-    val cipherFactory = CipherFactory(key)
+    val cipherFactory = cipherAlgorithm.createCipherFactory(random)
     val data = random.nextBytes(Segment.SIZE * 16 + Segment.SIZE / 2)
 
     val buffer = Buffer().apply { write(data) }
@@ -53,8 +59,7 @@ class CipherSourceTest {
   @Test
   fun encryptSingleByteSource() {
     val random = Random(6085265142433950622)
-    val key = random.nextBytes(16)
-    val cipherFactory = CipherFactory(key)
+    val cipherFactory = cipherAlgorithm.createCipherFactory(random)
     val data = random.nextBytes(32)
 
     val buffer = Buffer().apply { write(data) }
@@ -68,8 +73,7 @@ class CipherSourceTest {
   @Test
   fun decrypt() {
     val random = Random(8067587635762239433)
-    val key = random.nextBytes(16)
-    val cipherFactory = CipherFactory(key)
+    val cipherFactory = cipherAlgorithm.createCipherFactory(random)
     val expectedData = random.nextBytes(32)
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 
@@ -83,8 +87,7 @@ class CipherSourceTest {
   @Test
   fun decryptEmpty() {
     val random = Random(8722996896871347396)
-    val key = random.nextBytes(16)
-    val cipherFactory = CipherFactory(key)
+    val cipherFactory = cipherAlgorithm.createCipherFactory(random)
     val expectedData = ByteArray(0)
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 
@@ -98,8 +101,7 @@ class CipherSourceTest {
   @Test
   fun decryptLarge() {
     val random = Random(4007116131070653181)
-    val key = random.nextBytes(16)
-    val cipherFactory = CipherFactory(key)
+    val cipherFactory = cipherAlgorithm.createCipherFactory(random)
     val expectedData = random.nextBytes(Segment.SIZE * 16 + Segment.SIZE / 2)
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 
@@ -113,8 +115,7 @@ class CipherSourceTest {
   @Test
   fun decryptSingleByteSource() {
     val random = Random(1555017938547616655)
-    val key = random.nextBytes(16)
-    val cipherFactory = CipherFactory(key)
+    val cipherFactory = cipherAlgorithm.createCipherFactory(random)
     val expectedData = random.nextBytes(32)
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -1,6 +1,8 @@
 package okio
 
 import org.junit.Test
+import java.security.KeyPairGenerator
+import java.security.SecureRandom
 import kotlin.random.Random
 
 class CipherSourceTest {
@@ -10,6 +12,26 @@ class CipherSourceTest {
     val random = Random(787679144228763091)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
+    val data = random.nextBytes(32)
+
+    val buffer = Buffer().apply { write(data) }
+    val actualEncryptedData =
+      buffer.cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
+
+    val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
+    assertArrayEquals(expectedEncryptedData, actualEncryptedData)
+  }
+
+  @Test
+  fun encryptRsa() {
+    val random = Random(787679144228763091)
+    val secureRandom = SecureRandom(random.nextBytes(16))
+    val keyPairGenerator = KeyPairGenerator.getInstance("RSA").apply {
+      initialize(1024, secureRandom)
+    }
+    val keyPair = keyPairGenerator.generateKeyPair()
+    val publicKey = keyPair.public
+    val cipherFactory = CipherFactory(publicKey, "RSA/ECB/PKCS1Padding")
     val data = random.nextBytes(32)
 
     val buffer = Buffer().apply { write(data) }

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -22,7 +22,7 @@ class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
 
     val buffer = Buffer().apply { write(data) }
     val actualEncryptedData =
-      buffer.cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
+      cipherFactory.encrypt.source(buffer).buffer().use { it.readByteArray() }
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
     assertArrayEquals(expectedEncryptedData, actualEncryptedData)
@@ -36,7 +36,7 @@ class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
 
     val buffer = Buffer()
     val actualEncryptedData =
-      buffer.cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
+      cipherFactory.encrypt.source(buffer).buffer().use { it.readByteArray() }
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
     assertArrayEquals(expectedEncryptedData, actualEncryptedData)
@@ -50,7 +50,7 @@ class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
 
     val buffer = Buffer().apply { write(data) }
     val actualEncryptedData =
-      buffer.cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
+      cipherFactory.encrypt.source(buffer).buffer().use { it.readByteArray() }
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
     assertArrayEquals(expectedEncryptedData, actualEncryptedData)
@@ -64,7 +64,7 @@ class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
 
     val buffer = Buffer().apply { write(data) }
     val actualEncryptedData =
-      buffer.emitSingleBytes().cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
+      cipherFactory.encrypt.source(buffer.emitSingleBytes()).buffer().use { it.readByteArray() }
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
     assertArrayEquals(expectedEncryptedData, actualEncryptedData)
@@ -79,7 +79,7 @@ class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
 
     val buffer = Buffer().apply { write(encryptedData) }
     val actualData =
-      buffer.cipherSource(cipherFactory.decrypt).buffer().use { it.readByteArray() }
+      cipherFactory.decrypt.source(buffer).buffer().use { it.readByteArray() }
 
     assertArrayEquals(expectedData, actualData)
   }
@@ -93,7 +93,7 @@ class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
 
     val buffer = Buffer().apply { write(encryptedData) }
     val actualData =
-      buffer.cipherSource(cipherFactory.decrypt).buffer().use { it.readByteArray() }
+      cipherFactory.decrypt.source(buffer).buffer().use { it.readByteArray() }
 
     assertArrayEquals(expectedData, actualData)
   }
@@ -107,7 +107,7 @@ class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
 
     val buffer = Buffer().apply { write(encryptedData) }
     val actualData =
-      buffer.cipherSource(cipherFactory.decrypt).buffer().use { it.readByteArray() }
+      cipherFactory.decrypt.source(buffer).buffer().use { it.readByteArray() }
 
     assertArrayEquals(expectedData, actualData)
   }
@@ -121,7 +121,7 @@ class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
 
     val buffer = Buffer().apply { write(encryptedData) }
     val actualData =
-      buffer.emitSingleBytes().cipherSource(cipherFactory.decrypt).buffer().use { it.readByteArray() }
+      cipherFactory.decrypt.source(buffer.emitSingleBytes()).buffer().use { it.readByteArray() }
 
     assertArrayEquals(expectedData, actualData)
   }

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -6,21 +6,37 @@ import kotlin.random.Random
 class CipherSourceTest {
 
   @Test
-  fun encryptWithClose() {
+  fun encrypt() {
     val random = Random(1588326457426L)
     val data = random.nextBytes(32)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
 
     val buffer = Buffer().apply { write(data) }
-    val actualEncryptedData = buffer.cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
+    val actualEncryptedData =
+      buffer.cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
     assertArrayEquals(expectedEncryptedData, actualEncryptedData)
   }
 
   @Test
-  fun decryptWithClose() {
+  fun encryptSingleByteSource() {
+    val random = Random(1588326457426L)
+    val data = random.nextBytes(32)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+
+    val buffer = Buffer().apply { write(data) }
+    val actualEncryptedData =
+      buffer.emitSingleBytes().cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
+
+    val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
+    assertArrayEquals(expectedEncryptedData, actualEncryptedData)
+  }
+
+  @Test
+  fun decrypt() {
     val random = Random(1588326610176L)
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
@@ -28,8 +44,44 @@ class CipherSourceTest {
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 
     val buffer = Buffer().apply { write(encryptedData) }
-    val actualData = buffer.cipherSource(cipherFactory.decrypt).buffer().use { it.readByteArray() }
+    val actualData =
+      buffer.cipherSource(cipherFactory.decrypt).buffer().use { it.readByteArray() }
 
     assertArrayEquals(expectedData, actualData)
+  }
+
+  @Test
+  fun decryptSingleByteSource() {
+    val random = Random(1588326610176L)
+    val key = random.nextBytes(16)
+    val cipherFactory = CipherFactory(key)
+    val expectedData = random.nextBytes(32)
+    val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
+
+    val buffer = Buffer().apply { write(encryptedData) }
+    val actualData =
+      buffer.emitSingleBytes().cipherSource(cipherFactory.decrypt).buffer().use { it.readByteArray() }
+
+    assertArrayEquals(expectedData, actualData)
+  }
+}
+
+private fun BufferedSource.emitSingleBytes(): Source =
+  SingleByteSource(this)
+
+private class SingleByteSource(private val source: BufferedSource) : Source {
+  override fun read(sink: Buffer, byteCount: Long): Long =
+    if (source.exhausted()) {
+      -1
+    } else {
+      sink.writeByte(source.readByte().toInt())
+      1
+    }
+
+  override fun timeout(): Timeout =
+    source.timeout()
+
+  override fun close() {
+    source.close()
   }
 }

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -127,22 +127,10 @@ class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
   }
 }
 
-private fun BufferedSource.emitSingleBytes(): Source =
+private fun Source.emitSingleBytes(): Source =
   SingleByteSource(this)
 
-private class SingleByteSource(private val source: BufferedSource) : Source {
+private class SingleByteSource(source: Source) : ForwardingSource(source) {
   override fun read(sink: Buffer, byteCount: Long): Long =
-    if (source.exhausted()) {
-      -1
-    } else {
-      sink.writeByte(source.readByte().toInt())
-      1
-    }
-
-  override fun timeout(): Timeout =
-    source.timeout()
-
-  override fun close() {
-    source.close()
-  }
+    delegate.read(sink, 1L)
 }

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -64,7 +64,7 @@ class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
 
     val buffer = Buffer().apply { write(data) }
     val actualEncryptedData =
-      cipherFactory.encrypt.source(buffer.emitSingleBytes()).buffer().use { it.readByteArray() }
+      cipherFactory.encrypt.source(buffer.emitSingleBytes().buffer()).buffer().use { it.readByteArray() }
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
     assertArrayEquals(expectedEncryptedData, actualEncryptedData)
@@ -137,7 +137,7 @@ class CipherSourceTest(private val cipherAlgorithm: CipherAlgorithm) {
 
     val buffer = Buffer().apply { write(encryptedData) }
     val actualData =
-      cipherFactory.decrypt.source(buffer.emitSingleBytes()).buffer().use { it.readByteArray() }
+      cipherFactory.decrypt.source(buffer.emitSingleBytes().buffer()).buffer().use { it.readByteArray() }
 
     assertArrayEquals(expectedData, actualData)
   }

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -3,7 +3,7 @@ package okio
 import org.junit.Test
 import kotlin.random.Random
 
-class CipherSinkTest {
+class CipherSourceTest {
 
   @Test
   fun encryptWithClose() {
@@ -12,9 +12,8 @@ class CipherSinkTest {
     val key = random.nextBytes(16)
     val cipherFactory = CipherFactory(key)
 
-    val buffer = Buffer()
-    buffer.cipherSink(cipherFactory.encrypt).buffer().use { it.write(data) }
-    val actualEncryptedData = buffer.readByteArray()
+    val buffer = Buffer().apply { write(data) }
+    val actualEncryptedData = buffer.cipherSource(cipherFactory.encrypt).buffer().use { it.readByteArray() }
 
     val expectedEncryptedData = cipherFactory.encrypt.doFinal(data)
     assertArrayEquals(expectedEncryptedData, actualEncryptedData)
@@ -28,9 +27,8 @@ class CipherSinkTest {
     val expectedData = random.nextBytes(32)
     val encryptedData = cipherFactory.encrypt.doFinal(expectedData)
 
-    val buffer = Buffer()
-    buffer.cipherSink(cipherFactory.decrypt).buffer().use { it.write(encryptedData) }
-    val actualData = buffer.readByteArray()
+    val buffer = Buffer().apply { write(encryptedData) }
+    val actualData = buffer.cipherSource(cipherFactory.decrypt).buffer().use { it.readByteArray() }
 
     assertArrayEquals(expectedData, actualData)
   }


### PR DESCRIPTION
I know #260 was closed, but I don't really understand the issue, given that the initialization of the cipher is outside of the responsibility of the stream implementation. Let me know if I this is a fool's errand, but I figure this was at least worth a shot. This would be very useful for applications which treat large amounts of ciphered data, because the usage of internal segments would be a big improvement for memory usage, not to mention the simple fact of having cryptography properly included in the okio ecosystem for piping.