### PR TITLE
Use multiple linked lists to reduce contention in the segment pool

### DIFF
--- a/okio/src/commonMain/kotlin/okio/Segment.kt
+++ b/okio/src/commonMain/kotlin/okio/Segment.kt
@@ -38,7 +38,12 @@ internal class Segment {
   /** The next byte of application data byte to read in this segment. */
   @JvmField var pos: Int = 0
 
-  /** The first byte of available data ready to be written to. */
+  /**
+   * The first byte of available data ready to be written to.
+   *
+   * If the segment is free and linked in the segment pool, the field contains total
+   * byte count of this and next segments.
+   */
   @JvmField var limit: Int = 0
 
   /** True if other segments or byte strings use the same byte array. */

--- a/okio/src/commonMain/kotlin/okio/Segment.kt
+++ b/okio/src/commonMain/kotlin/okio/Segment.kt
@@ -53,6 +53,9 @@ internal class Segment {
   /** Previous segment in a circularly-linked list.  */
   @JvmField var prev: Segment? = null
 
+  /** If the segment is free **/
+  @JvmField var freeSegmentCount: Long = 0L
+
   constructor() {
     this.data = ByteArray(SIZE)
     this.owner = true

--- a/okio/src/commonMain/kotlin/okio/Segment.kt
+++ b/okio/src/commonMain/kotlin/okio/Segment.kt
@@ -35,26 +35,23 @@ import kotlin.jvm.JvmField
 internal class Segment {
   @JvmField val data: ByteArray
 
-  /** The next byte of application data byte to read in this segment.  */
+  /** The next byte of application data byte to read in this segment. */
   @JvmField var pos: Int = 0
 
-  /** The first byte of available data ready to be written to.  */
+  /** The first byte of available data ready to be written to. */
   @JvmField var limit: Int = 0
 
-  /** True if other segments or byte strings use the same byte array.  */
+  /** True if other segments or byte strings use the same byte array. */
   @JvmField var shared: Boolean = false
 
-  /** True if this segment owns the byte array and can append to it, extending `limit`.  */
+  /** True if this segment owns the byte array and can append to it, extending `limit`. */
   @JvmField var owner: Boolean = false
 
-  /** Next segment in a linked or circularly-linked list.  */
+  /** Next segment in a linked or circularly-linked list. */
   @JvmField var next: Segment? = null
 
-  /** Previous segment in a circularly-linked list.  */
+  /** Previous segment in a circularly-linked list. */
   @JvmField var prev: Segment? = null
-
-  /** If the segment is free **/
-  @JvmField var freeSegmentCount: Long = 0L
 
   constructor() {
     this.data = ByteArray(SIZE)

--- a/okio/src/commonMain/kotlin/okio/SegmentPool.kt
+++ b/okio/src/commonMain/kotlin/okio/SegmentPool.kt
@@ -20,10 +20,13 @@ package okio
  * This pool is a thread-safe static singleton.
  */
 internal expect object SegmentPool {
-  val MAX_SIZE: Long
+  val MAX_SIZE: Int
 
-  /** For testing only. Returns a snapshot of the number of bytes currently in the pool. */
-  val byteCount: Long
+  /**
+   * For testing only. Returns a snapshot of the number of bytes currently in the pool. If the pool
+   * is segmented such as by thread, this returns the byte count accessible to the calling thread.
+   */
+  val byteCount: Int
 
   /** Return a segment for the caller's use. */
   fun take(): Segment

--- a/okio/src/commonTest/kotlin/okio/CommonBufferTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonBufferTest.kt
@@ -88,24 +88,24 @@ class CommonBufferTest {
     val buffer = Buffer()
 
     // Take 2 * MAX_SIZE segments. This will drain the pool, even if other tests filled it.
-    buffer.write(ByteArray(SegmentPool.MAX_SIZE.toInt()))
-    buffer.write(ByteArray(SegmentPool.MAX_SIZE.toInt()))
+    buffer.write(ByteArray(SegmentPool.MAX_SIZE))
+    buffer.write(ByteArray(SegmentPool.MAX_SIZE))
     assertEquals(0, SegmentPool.byteCount)
 
     // Recycle MAX_SIZE segments. They're all in the pool.
-    buffer.skip(SegmentPool.MAX_SIZE)
+    buffer.skip(SegmentPool.MAX_SIZE.toLong())
     assertEquals(SegmentPool.MAX_SIZE, SegmentPool.byteCount)
 
     // Recycle MAX_SIZE more segments. The pool is full so they get garbage collected.
-    buffer.skip(SegmentPool.MAX_SIZE)
+    buffer.skip(SegmentPool.MAX_SIZE.toLong())
     assertEquals(SegmentPool.MAX_SIZE, SegmentPool.byteCount)
 
     // Take MAX_SIZE segments to drain the pool.
-    buffer.write(ByteArray(SegmentPool.MAX_SIZE.toInt()))
+    buffer.write(ByteArray(SegmentPool.MAX_SIZE))
     assertEquals(0, SegmentPool.byteCount)
 
     // Take MAX_SIZE more segments. The pool is drained so these will need to be allocated.
-    buffer.write(ByteArray(SegmentPool.MAX_SIZE.toInt()))
+    buffer.write(ByteArray(SegmentPool.MAX_SIZE))
     assertEquals(0, SegmentPool.byteCount)
   }
 
@@ -253,17 +253,17 @@ class CommonBufferTest {
     buffer.writeUtf8("a")
     buffer.writeUtf8('b'.repeat(Segment.SIZE))
     buffer.writeUtf8("c")
-    assertEquals('a'.toLong(), buffer.get(0).toLong())
-    assertEquals('a'.toLong(), buffer.get(0).toLong()) // getByte doesn't mutate!
-    assertEquals('c'.toLong(), buffer.get(buffer.size - 1).toLong())
-    assertEquals('b'.toLong(), buffer.get(buffer.size - 2).toLong())
-    assertEquals('b'.toLong(), buffer.get(buffer.size - 3).toLong())
+    assertEquals('a'.toLong(), buffer[0].toLong())
+    assertEquals('a'.toLong(), buffer[0].toLong()) // getByte doesn't mutate!
+    assertEquals('c'.toLong(), buffer[buffer.size - 1].toLong())
+    assertEquals('b'.toLong(), buffer[buffer.size - 2].toLong())
+    assertEquals('b'.toLong(), buffer[buffer.size - 3].toLong())
   }
 
   @Test fun getByteOfEmptyBuffer() {
     val buffer = Buffer()
     assertFailsWith<IndexOutOfBoundsException> {
-      buffer.get(0)
+      buffer[0]
     }
   }
 

--- a/okio/src/jsMain/kotlin/okio/SegmentPool.kt
+++ b/okio/src/jsMain/kotlin/okio/SegmentPool.kt
@@ -16,9 +16,9 @@
 package okio
 
 internal actual object SegmentPool {
-  actual val MAX_SIZE: Long = 0L
+  actual val MAX_SIZE: Int = 0
 
-  actual val byteCount: Long = 0L
+  actual val byteCount: Int = 0
 
   actual fun take(): Segment = Segment()
 

--- a/okio/src/nativeMain/kotlin/okio/SegmentPool.kt
+++ b/okio/src/nativeMain/kotlin/okio/SegmentPool.kt
@@ -16,9 +16,9 @@
 package okio
 
 internal actual object SegmentPool {
-  actual val MAX_SIZE: Long = 0L
+  actual val MAX_SIZE: Int = 0
 
-  actual val byteCount: Long = 0L
+  actual val byteCount: Int = 0
 
   actual fun take(): Segment = Segment()
 


### PR DESCRIPTION
This adds a commit to @rewlad's [PR 725](https://github.com/square/okio/pull/725).
