### PR TITLE
New APIs: ByteString.toIndex() and ByteString.toFraction()

### DIFF
--- a/okio/src/jsMain/kotlin/okio/ByteString.kt
+++ b/okio/src/jsMain/kotlin/okio/ByteString.kt
@@ -38,6 +38,8 @@ import okio.internal.commonToAsciiLowercase
 import okio.internal.commonToAsciiUppercase
 import okio.internal.commonToByteArray
 import okio.internal.commonToByteString
+import okio.internal.commonToFraction
+import okio.internal.commonToIndex
 import okio.internal.commonToString
 import okio.internal.commonUtf8
 import okio.internal.commonWrite
@@ -118,6 +120,10 @@ internal actual constructor(
   actual override fun hashCode() = commonHashCode()
 
   actual override fun compareTo(other: ByteString) = commonCompareTo(other)
+
+  actual fun toIndex(size: Int) = commonToIndex(size)
+
+  actual fun toFraction() = commonToFraction()
 
   /**
    * Returns a human-readable string that describes the contents of this byte string. Typically this

--- a/okio/src/jvmMain/kotlin/okio/ByteString.kt
+++ b/okio/src/jvmMain/kotlin/okio/ByteString.kt
@@ -38,6 +38,8 @@ import okio.internal.commonToAsciiLowercase
 import okio.internal.commonToAsciiUppercase
 import okio.internal.commonToByteArray
 import okio.internal.commonToByteString
+import okio.internal.commonToFraction
+import okio.internal.commonToIndex
 import okio.internal.commonToString
 import okio.internal.commonUtf8
 import okio.internal.commonWrite
@@ -180,6 +182,10 @@ internal actual constructor(
   actual override fun hashCode() = commonHashCode()
 
   actual override fun compareTo(other: ByteString) = commonCompareTo(other)
+
+  actual fun toIndex(size: Int) = commonToIndex(size)
+
+  actual fun toFraction() = commonToFraction()
 
   actual override fun toString() = commonToString()
 

--- a/okio/src/nativeMain/kotlin/okio/ByteString.kt
+++ b/okio/src/nativeMain/kotlin/okio/ByteString.kt
@@ -39,6 +39,8 @@ import okio.internal.commonToAsciiLowercase
 import okio.internal.commonToAsciiUppercase
 import okio.internal.commonToByteArray
 import okio.internal.commonToByteString
+import okio.internal.commonToFraction
+import okio.internal.commonToIndex
 import okio.internal.commonToString
 import okio.internal.commonUtf8
 import okio.internal.commonWrite
@@ -124,6 +126,10 @@ internal actual constructor(
   actual override fun hashCode() = commonHashCode()
 
   actual override fun compareTo(other: ByteString) = commonCompareTo(other)
+
+  actual fun toIndex(size: Int) = commonToIndex(size)
+
+  actual fun toFraction() = commonToFraction()
 
   /**
    * Returns a human-readable string that describes the contents of this byte string. Typically this


### PR DESCRIPTION
The first one may be useful with hashing to put byte strings in
partitioning buckets for scaling. For example, to divide a dataset
into 32 partitions, hash the key then use toIndex(32) to map the
key to its partition.

The second one may be useful with dynamic experiments and A/B
tests. For example, to assign a control group to 5% of customers
hash the customer key then check if toFraction() is less than 0.05.