### PR TITLE
Optimize SHA-1.

### DIFF
--- a/okio/jvm/jmh/src/jmh/java/com/squareup/okio/benchmarks/MessageDigestBenchmark.java
+++ b/okio/jvm/jmh/src/jmh/java/com/squareup/okio/benchmarks/MessageDigestBenchmark.java
@@ -1,14 +1,38 @@
+/*
+ * Copyright (C) 2020 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.okio.benchmarks;
-
-import okio.internal.OkioMessageDigest;
-import okio.internal.OkioMessageDigestKt;
-import org.openjdk.jmh.Main;
-import org.openjdk.jmh.annotations.*;
 
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.TimeUnit;
+import okio.internal.OkioMessageDigest;
+import okio.internal.OkioMessageDigestKt;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 @Fork(1)
 @Warmup(iterations = 5, time = 1)
@@ -18,34 +42,34 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class MessageDigestBenchmark {
 
-    MessageDigest jvmMessageDigest;
-    OkioMessageDigest okioMessageDigest;
+  MessageDigest jvmMessageDigest;
+  OkioMessageDigest okioMessageDigest;
 
-    @Param({"100", "1048576"})
-    public int messageSize;
+  @Param({ "100", "1048576" })
+  public int messageSize;
 
-    @Param({"SHA-1", "SHA-256", "SHA-512", "MD5"})
-    public String algorithm;
+  @Param({ "SHA-1", "SHA-256", "SHA-512", "MD5" })
+  public String algorithm;
 
-    private byte[] message;
+  private byte[] message;
 
-    @Setup public void setup() throws NoSuchAlgorithmException {
-        jvmMessageDigest = MessageDigest.getInstance(algorithm);
-        okioMessageDigest = OkioMessageDigestKt.newMessageDigest(algorithm);
-        message = new byte[messageSize];
-    }
+  @Setup public void setup() throws NoSuchAlgorithmException {
+    jvmMessageDigest = MessageDigest.getInstance(algorithm);
+    okioMessageDigest = OkioMessageDigestKt.newMessageDigest(algorithm);
+    message = new byte[messageSize];
+  }
 
-    @Benchmark public void jvm() {
-        jvmMessageDigest.update(message);
-        jvmMessageDigest.digest();
-    }
+  @Benchmark public void jvm() {
+    jvmMessageDigest.update(message);
+    jvmMessageDigest.digest();
+  }
 
-    @Benchmark public void okio() {
-        okioMessageDigest.update(message);
-        okioMessageDigest.digest();
-    }
+  @Benchmark public void okio() {
+    okioMessageDigest.update(message, 0, messageSize);
+    okioMessageDigest.digest();
+  }
 
-    public static void main(String[] args) throws IOException {
-        Main.main(new String[] { MessageDigestBenchmark.class.getName() });
-    }
+  public static void main(String[] args) throws IOException {
+    Main.main(new String[] { MessageDigestBenchmark.class.getName() });
+  }
 }

--- a/okio/src/commonMain/kotlin/okio/internal/AbstractMessageDigest.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/AbstractMessageDigest.kt
@@ -22,8 +22,13 @@ internal abstract class AbstractMessageDigest : OkioMessageDigest {
   private var unprocessed = Bytes.EMPTY
   protected abstract var currentDigest: HashDigest
 
-  override fun update(input: ByteArray) {
-    for (chunk in (unprocessed + input.toBytes()).chunked(64)) {
+  override fun update(
+    input: ByteArray,
+    offset: Int,
+    byteCount: Int
+  ) {
+    val bytes = unprocessed + input.toBytes().slice(offset until offset + byteCount)
+    for (chunk in bytes.chunked(64)) {
       when (chunk.size) {
         64 -> {
           currentDigest = processChunk(chunk, currentDigest)

--- a/okio/src/commonMain/kotlin/okio/internal/HashUtil.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/HashUtil.kt
@@ -36,6 +36,10 @@ internal infix fun UInt.leftRotate(bitCount: Int): UInt {
   return ((this shl bitCount) or (this shr (UInt.SIZE_BITS - bitCount))) and UInt.MAX_VALUE
 }
 
+internal inline infix fun Int.leftRotate(bitCount: Int): Int {
+  return (this shl bitCount) or (this ushr (32 - bitCount))
+}
+
 /**
  * Right rotate an unsigned 32 bit integer by [bitCount] bits
  */

--- a/okio/src/commonMain/kotlin/okio/internal/MD5MessageDigest.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/MD5MessageDigest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Square, Inc.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio.internal
 
 private val s = intArrayOf(
@@ -23,6 +22,7 @@ private val s = intArrayOf(
   6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21
 )
 
+@ExperimentalUnsignedTypes
 private val k = uintArrayOf(
   0xd76aa478u, 0xe8c7b756u, 0x242070dbu, 0xc1bdceeeu,
   0xf57c0fafu, 0x4787c62au, 0xa8304613u, 0xfd469501u,
@@ -42,8 +42,8 @@ private val k = uintArrayOf(
   0xf7537e82u, 0xbd3af235u, 0x2ad7d2bbu, 0xeb86d391u
 )
 
+@ExperimentalUnsignedTypes
 internal class MD5MessageDigest : OkioMessageDigest {
-
   private var messageLength = 0L
   private var unprocessed = Bytes.EMPTY
   private var currentDigest = HashDigest(
@@ -53,8 +53,13 @@ internal class MD5MessageDigest : OkioMessageDigest {
     0x10325476u
   )
 
-  override fun update(input: ByteArray) {
-    for (chunk in (unprocessed + input.toBytes()).chunked(64)) {
+  override fun update(
+    input: ByteArray,
+    offset: Int,
+    byteCount: Int
+  ) {
+    val bytes = unprocessed + input.toBytes().slice(offset until offset + byteCount)
+    for (chunk in bytes.chunked(64)) {
       when (chunk.size) {
         64 -> {
           currentDigest = processChunk(chunk, currentDigest)

--- a/okio/src/commonMain/kotlin/okio/internal/OkioMessageDigest.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/OkioMessageDigest.kt
@@ -1,8 +1,22 @@
+/*
+ * Copyright (C) 2020 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okio.internal
 
 interface OkioMessageDigest {
-
-  fun update(input: ByteArray)
+  fun update(input: ByteArray, offset: Int, byteCount: Int)
 
   fun digest(): ByteArray
 }

--- a/okio/src/commonMain/kotlin/okio/internal/Sha1MessageDigest.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/Sha1MessageDigest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Square, Inc.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,63 +13,176 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio.internal
 
-internal class Sha1MessageDigest : AbstractMessageDigest() {
+@ExperimentalUnsignedTypes
+internal class Sha1MessageDigest : OkioMessageDigest {
+  private var messageLength = 0L
+  private val unprocessed = ByteArray(64)
+  private var unprocessedLimit = 0
+  private val words = IntArray(80)
 
-  override var currentDigest = HashDigest(
-    0x67452301u,
-    0xEFCDAB89u,
-    0x98BADCFEu,
-    0x10325476u,
-    0xC3D2E1F0u
-  )
+  private var h0: Int = 0x67452301
+  private var h1: Int = 0xEFCDAB89u.toInt()
+  private var h2: Int = 0x98BADCFEu.toInt()
+  private var h3: Int = 0x10325476
+  private var h4: Int = 0xC3D2E1F0u.toInt()
 
-  override fun processChunk(chunk: Bytes, currentDigest: HashDigest): HashDigest {
-    require(chunk.size == 64)
+  override fun update(
+    input: ByteArray,
+    offset: Int,
+    byteCount: Int
+  ) {
+    messageLength += byteCount
+    var pos = offset
+    val limit = pos + byteCount
+    val unprocessed = this.unprocessed
+    val unprocessedLimit = this.unprocessedLimit
 
-    val words = UIntArray(80)
-    chunk.chunked(4).forEachIndexed { index, bytes ->
-      words[index] = bytes.toBigEndianUInt()
-    }
-
-    for (i in 16 until 80) {
-      words[i] = (words[i - 3] xor words[i - 8] xor words[i - 14] xor words[i - 16]) leftRotate 1
-    }
-
-    var (a, b, c, d, e) = currentDigest
-
-    for (i in 0 until 80) {
-      val (f, k) = when (i) {
-        in 0..19 -> (d xor (b and (c xor d))) to 0x5A827999.toUInt()
-        in 20..39 -> (b xor c xor d) to 0x6ED9EBA1.toUInt()
-        in 40..59 -> ((b and c) or (b and d) or (c and d)) to 0x8F1BBCDC.toUInt()
-        in 60..79 -> (b xor c xor d) to 0xCA62C1D6.toUInt()
-        else -> error("Index is wonky, this should never happen")
+    if (unprocessedLimit > 0) {
+      if (unprocessedLimit + byteCount < 64) {
+        // Not enough bytes for a chunk.
+        input.copyInto(unprocessed, unprocessedLimit, pos, limit)
+        this.unprocessedLimit = unprocessedLimit + byteCount
+        return
       }
 
-      val updatedDigest = HashDigest(
-        ((a leftRotate 5) + f + e + k + words[i]) and UInt.MAX_VALUE,
-        a,
-        b leftRotate 30,
-        c,
-        d
-      )
-
-      a = updatedDigest[0]
-      b = updatedDigest[1]
-      c = updatedDigest[2]
-      d = updatedDigest[3]
-      e = updatedDigest[4]
+      // Process a chunk combining leftover bytes and the input.
+      val consumeByteCount = 64 - unprocessedLimit
+      input.copyInto(unprocessed, unprocessedLimit, pos, pos + consumeByteCount)
+      processChunk(unprocessed, 0)
+      this.unprocessedLimit = 0
+      pos += consumeByteCount
     }
 
-    return HashDigest(
-      (currentDigest[0] + a),
-      (currentDigest[1] + b),
-      (currentDigest[2] + c),
-      (currentDigest[3] + d),
-      (currentDigest[4] + e)
+    while (pos < limit) {
+      val nextPos = pos + 64
+
+      if (nextPos > limit) {
+        // Not enough bytes for a chunk.
+        input.copyInto(unprocessed, 0, pos, limit)
+        this.unprocessedLimit = limit - pos
+        return
+      }
+
+      // Process a chunk.
+      processChunk(input, pos)
+      pos = nextPos
+    }
+  }
+
+  private fun processChunk(input: ByteArray, pos: Int) {
+    val words = this.words
+
+    var pos = pos
+    for (w in 0 until 16) {
+      words[w] =
+        ((input[pos++].toInt() and 0xff) shl 24) or
+        ((input[pos++].toInt() and 0xff) shl 16) or
+        ((input[pos++].toInt() and 0xff) shl 8) or
+        ((input[pos++].toInt() and 0xff))
+    }
+
+    for (w in 16 until 80) {
+      words[w] = (words[w - 3] xor words[w - 8] xor words[w - 14] xor words[w - 16]) leftRotate 1
+    }
+
+    var a = h0
+    var b = h1
+    var c = h2
+    var d = h3
+    var e = h4
+
+    for (i in 0 until 80) {
+      val a2 = when {
+        i < 20 -> {
+          val f = d xor (b and (c xor d))
+          val k = 0x5A827999
+          (a leftRotate 5) + f + e + k + words[i]
+        }
+        i < 40 -> {
+          val f = b xor c xor d
+          val k = 0x6ED9EBA1
+          (a leftRotate 5) + f + e + k + words[i]
+        }
+        i < 60 -> {
+          val f = (b and c) or (b and d) or (c and d)
+          val k = 0x8F1BBCDCu.toInt()
+          (a leftRotate 5) + f + e + k + words[i]
+        }
+        else -> {
+          val f = b xor c xor d
+          val k = 0xCA62C1D6u.toInt()
+          (a leftRotate 5) + f + e + k + words[i]
+        }
+      }
+
+      e = d
+      d = c
+      c = b leftRotate 30
+      b = a
+      a = a2
+    }
+
+    h0 += a
+    h1 += b
+    h2 += c
+    h3 += d
+    h4 += e
+  }
+
+  /* ktlint-disable */
+  override fun digest(): ByteArray {
+    val unprocessed = this.unprocessed
+    var unprocessedLimit = this.unprocessedLimit
+    val messageLengthBits = messageLength * 8
+
+    unprocessed[unprocessedLimit++] = 0x80.toByte()
+    if (unprocessedLimit > 56) {
+      unprocessed.fill(0, unprocessedLimit, 64)
+      processChunk(unprocessed, 0)
+      unprocessed.fill(0, 0, unprocessedLimit)
+    } else {
+      unprocessed.fill(0, unprocessedLimit, 56)
+    }
+    unprocessed[56] = (messageLengthBits ushr 56).toByte()
+    unprocessed[57] = (messageLengthBits ushr 48).toByte()
+    unprocessed[58] = (messageLengthBits ushr 40).toByte()
+    unprocessed[59] = (messageLengthBits ushr 32).toByte()
+    unprocessed[60] = (messageLengthBits ushr 24).toByte()
+    unprocessed[61] = (messageLengthBits ushr 16).toByte()
+    unprocessed[62] = (messageLengthBits ushr  8).toByte()
+    unprocessed[63] = (messageLengthBits        ).toByte()
+    processChunk(unprocessed, 0)
+
+    val a = h0
+    val b = h1
+    val c = h2
+    val d = h3
+    val e = h4
+
+    return byteArrayOf(
+      (a shr 24).toByte(),
+      (a shr 16).toByte(),
+      (a shr  8).toByte(),
+      (a       ).toByte(),
+      (b shr 24).toByte(),
+      (b shr 16).toByte(),
+      (b shr  8).toByte(),
+      (b       ).toByte(),
+      (c shr 24).toByte(),
+      (c shr 16).toByte(),
+      (c shr  8).toByte(),
+      (c       ).toByte(),
+      (d shr 24).toByte(),
+      (d shr 16).toByte(),
+      (d shr  8).toByte(),
+      (d       ).toByte(),
+      (e shr 24).toByte(),
+      (e shr 16).toByte(),
+      (e shr  8).toByte(),
+      (e       ).toByte()
     )
   }
+  /* ktlint-enable */
 }

--- a/okio/src/commonMain/kotlin/okio/internal/Sha256MessageDigest.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/Sha256MessageDigest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Square, Inc.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package okio.internal
 
+@ExperimentalUnsignedTypes
 private val k = uintArrayOf(
   0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u,
   0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u,
@@ -35,6 +36,7 @@ private val k = uintArrayOf(
   0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u
 )
 
+@ExperimentalUnsignedTypes
 internal class Sha256MessageDigest : AbstractMessageDigest() {
 
   override var currentDigest = HashDigest(

--- a/okio/src/commonMain/kotlin/okio/internal/Sha512MessageDigest.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/Sha512MessageDigest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Square, Inc.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio.internal
 
+@ExperimentalUnsignedTypes
 private val k = ulongArrayOf(
   0x428a2f98d728ae22UL, 0x7137449123ef65cdUL, 0xb5c0fbcfec4d3b2fUL, 0xe9b5dba58189dbbcUL, 0x3956c25bf348b538UL,
   0x59f111f1b605d019UL, 0x923f82a4af194f9bUL, 0xab1c5ed5da6d8118UL, 0xd807aa98a3030242UL, 0x12835b0145706fbeUL,
@@ -35,6 +35,7 @@ private val k = ulongArrayOf(
   0x431d67c49c100d4cUL, 0x4cc5d4becb3e42b6UL, 0x597f299cfc657e2aUL, 0x5fcb6fab3ad6faecUL, 0x6c44198c4a475817UL
 )
 
+@ExperimentalUnsignedTypes
 internal class Sha512MessageDigest : OkioMessageDigest {
 
   private var messageLength: Long = 0
@@ -50,8 +51,13 @@ internal class Sha512MessageDigest : OkioMessageDigest {
     0x5be0cd19137e2179UL
   )
 
-  override fun update(input: ByteArray) {
-    for (chunk in (unprocessed + input.toBytes()).chunked(128)) {
+  override fun update(
+    input: ByteArray,
+    offset: Int,
+    byteCount: Int
+  ) {
+    val bytes = unprocessed + input.toBytes().slice(offset until offset + byteCount)
+    for (chunk in bytes.chunked(128)) {
       when (chunk.size) {
         128 -> {
           currentDigest = processChunk(chunk, currentDigest)
@@ -128,6 +134,7 @@ internal class Sha512MessageDigest : OkioMessageDigest {
   }
 }
 
+@ExperimentalUnsignedTypes
 private class ULongHashDigest(vararg val hashValues: ULong) {
 
   fun toByteArray() = ByteArray(hashValues.size * 8) { index ->

--- a/okio/src/commonTest/kotlin/okio/OkioMessageDigestTest.kt
+++ b/okio/src/commonTest/kotlin/okio/OkioMessageDigestTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Square, Inc.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
-import okio.internal.newMessageDigest
+import okio.internal.OkioMessageDigest
 import okio.internal.commonAsUtf8ToByteArray
+import okio.internal.newMessageDigest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -233,4 +233,8 @@ class OkioMessageDigestTest {
   }
 
   // endregion
+
+  private fun OkioMessageDigest.update(byteArray: ByteArray) {
+    return update(byteArray, 0, byteArray.size)
+  }
 }


### PR DESCRIPTION
```
Benchmark                    (algorithm)  (messageSize)  Mode  Cnt     Score     Error  Units
MessageDigestBenchmark.jvm         SHA-1            100  avgt    3     0.408 ±   0.152  us/op
MessageDigestBenchmark.jvm         SHA-1        1048576  avgt    3  2867.138 ± 326.541  us/op
MessageDigestBenchmark.okio        SHA-1            100  avgt    3     0.546 ±   0.029  us/op
MessageDigestBenchmark.okio        SHA-1        1048576  avgt    3  2968.167 ± 430.262  us/op
```