### PR TITLE
Take the allocations out of our SHA-256 implementation

### DIFF
--- a/okio/src/commonMain/kotlin/okio/internal/Sha256MessageDigest.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/Sha256MessageDigest.kt
@@ -16,63 +16,139 @@
 
 package okio.internal
 
+import okio.and
+
 @ExperimentalUnsignedTypes
-private val k = uintArrayOf(
-  0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u,
-  0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u,
-  0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u,
-  0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u, 0xc19bf174u,
-  0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu,
-  0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau,
-  0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u,
-  0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u,
-  0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu, 0x53380d13u,
-  0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
-  0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u,
-  0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u,
-  0x19a4c116u, 0x1e376c08u, 0x2748774cu, 0x34b0bcb5u,
-  0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
-  0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u,
-  0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u
+private val k = intArrayOf(
+  0x428a2f98u.toInt(), 0x71374491u.toInt(), 0xb5c0fbcfu.toInt(), 0xe9b5dba5u.toInt(),
+  0x3956c25bu.toInt(), 0x59f111f1u.toInt(), 0x923f82a4u.toInt(), 0xab1c5ed5u.toInt(),
+  0xd807aa98u.toInt(), 0x12835b01u.toInt(), 0x243185beu.toInt(), 0x550c7dc3u.toInt(),
+  0x72be5d74u.toInt(), 0x80deb1feu.toInt(), 0x9bdc06a7u.toInt(), 0xc19bf174u.toInt(),
+  0xe49b69c1u.toInt(), 0xefbe4786u.toInt(), 0x0fc19dc6u.toInt(), 0x240ca1ccu.toInt(),
+  0x2de92c6fu.toInt(), 0x4a7484aau.toInt(), 0x5cb0a9dcu.toInt(), 0x76f988dau.toInt(),
+  0x983e5152u.toInt(), 0xa831c66du.toInt(), 0xb00327c8u.toInt(), 0xbf597fc7u.toInt(),
+  0xc6e00bf3u.toInt(), 0xd5a79147u.toInt(), 0x06ca6351u.toInt(), 0x14292967u.toInt(),
+  0x27b70a85u.toInt(), 0x2e1b2138u.toInt(), 0x4d2c6dfcu.toInt(), 0x53380d13u.toInt(),
+  0x650a7354u.toInt(), 0x766a0abbu.toInt(), 0x81c2c92eu.toInt(), 0x92722c85u.toInt(),
+  0xa2bfe8a1u.toInt(), 0xa81a664bu.toInt(), 0xc24b8b70u.toInt(), 0xc76c51a3u.toInt(),
+  0xd192e819u.toInt(), 0xd6990624u.toInt(), 0xf40e3585u.toInt(), 0x106aa070u.toInt(),
+  0x19a4c116u.toInt(), 0x1e376c08u.toInt(), 0x2748774cu.toInt(), 0x34b0bcb5u.toInt(),
+  0x391c0cb3u.toInt(), 0x4ed8aa4au.toInt(), 0x5b9cca4fu.toInt(), 0x682e6ff3u.toInt(),
+  0x748f82eeu.toInt(), 0x78a5636fu.toInt(), 0x84c87814u.toInt(), 0x8cc70208u.toInt(),
+  0x90befffau.toInt(), 0xa4506cebu.toInt(), 0xbef9a3f7u.toInt(), 0xc67178f2u.toInt()
 )
 
 @ExperimentalUnsignedTypes
-internal class Sha256MessageDigest : AbstractMessageDigest() {
+internal class Sha256MessageDigest : OkioMessageDigest {
+  private var messageLength = 0L
+  private val unprocessed = ByteArray(64)
+  private var unprocessedLimit = 0
+  private val words = IntArray(64)
 
-  override var currentDigest = HashDigest(
-    0x6a09e667u,
-    0xbb67ae85u,
-    0x3c6ef372u,
-    0xa54ff53au,
-    0x510e527fu,
-    0x9b05688cu,
-    0x1f83d9abu,
-    0x5be0cd19u
-  )
+  private var h0 = 0x6a09e667u.toInt()
+  private var h1 = 0xbb67ae85u.toInt()
+  private var h2 = 0x3c6ef372u.toInt()
+  private var h3 = 0xa54ff53au.toInt()
+  private var h4 = 0x510e527fu.toInt()
+  private var h5 = 0x9b05688cu.toInt()
+  private var h6 = 0x1f83d9abu.toInt()
+  private var h7 = 0x5be0cd19u.toInt()
 
-  override fun processChunk(chunk: Bytes, currentDigest: HashDigest): HashDigest {
-    require(chunk.size == 64)
+  override fun update(
+    input: ByteArray,
+    offset: Int,
+    byteCount: Int
+  ) {
+    messageLength += byteCount
+    var pos = offset
+    val limit = pos + byteCount
+    val unprocessed = this.unprocessed
+    val unprocessedLimit = this.unprocessedLimit
 
-    val w = UIntArray(64)
-    chunk.chunked(4).forEachIndexed { index, bytes ->
-      w[index] = bytes.toBigEndianUInt()
+    if (unprocessedLimit > 0) {
+      if (unprocessedLimit + byteCount < 64) {
+        // Not enough bytes for a chunk.
+        input.copyInto(unprocessed, unprocessedLimit, pos, limit)
+        this.unprocessedLimit = unprocessedLimit + byteCount
+        return
+      }
+
+      // Process a chunk combining leftover bytes and the input.
+      val consumeByteCount = 64 - unprocessedLimit
+      input.copyInto(unprocessed, unprocessedLimit, pos, pos + consumeByteCount)
+      processChunk(unprocessed, 0)
+      this.unprocessedLimit = 0
+      pos += consumeByteCount
     }
 
-    for (i in 16 until 64) {
-      val s0 = (w[i - 15] rightRotate 7) xor (w[i - 15] rightRotate 18) xor (w[i - 15] shr 3)
-      val s1 = (w[i - 2] rightRotate 17) xor (w[i - 2] rightRotate 19) xor (w[i - 2] shr 10)
-      w[i] = w[i - 16] + s0 + w[i - 7] + s1
+    while (pos < limit) {
+      val nextPos = pos + 64
+
+      if (nextPos > limit) {
+        // Not enough bytes for a chunk.
+        input.copyInto(unprocessed, 0, pos, limit)
+        this.unprocessedLimit = limit - pos
+        return
+      }
+
+      // Process a chunk.
+      processChunk(input, pos)
+      pos = nextPos
+    }
+  }
+
+  private fun processChunk(input: ByteArray, pos: Int) {
+    val words = this.words
+
+    var pos = pos
+    for (w in 0 until 16) {
+      words[w] = ((input[pos++] and 0xff) shl 24) or
+        ((input[pos++] and 0xff) shl 16) or
+        ((input[pos++] and 0xff) shl 8) or
+        ((input[pos++] and 0xff))
     }
 
-    var (a, b, c, d, e, f, g, h) = currentDigest
+    for (w in 16 until 64) {
+      val w15 = words[w - 15]
+      val s0 = ((w15 ushr 7) or (w15 shl 25)) xor ((w15 ushr 18) or (w15 shl 14)) xor (w15 ushr 3)
+      val w2 = words[w - 2]
+      val s1 = ((w2 ushr 17) or (w2 shl 15)) xor ((w2 ushr 19) or (w2 shl 13)) xor (w2 ushr 10)
+      val w16 = words[w - 16]
+      val w7 = words[w - 7]
+      words[w] = w16 + s0 + w7 + s1
+    }
+
+    hash(words)
+  }
+
+  private fun hash(
+    words: IntArray
+  ) {
+    val localK = k
+    var a = h0
+    var b = h1
+    var c = h2
+    var d = h3
+    var e = h4
+    var f = h5
+    var g = h6
+    var h = h7
+
     for (i in 0 until 64) {
-      val s0 = (a rightRotate 2) xor (a rightRotate 13) xor (a rightRotate 22)
-      val s1 = (e rightRotate 6) xor (e rightRotate 11) xor (e rightRotate 25)
+      val s0 = ((a ushr 2) or (a shl 30)) xor
+        ((a ushr 13) or (a shl 19)) xor
+        ((a ushr 22) or (a shl 10))
+      val s1 = ((e ushr 6) or (e shl 26)) xor
+        ((e ushr 11) or (e shl 21)) xor
+        ((e ushr 25) or (e shl 7))
 
-      val ch = (e and f) xor (e.inv() and g)
-      val maj = (a and b) xor (a and c) xor (b and c)
+      val ch = (e and f) xor
+        (e.inv() and g)
+      val maj = (a and b) xor
+        (a and c) xor
+        (b and c)
 
-      val t1 = h + s1 + ch + k[i] + w[i]
+      val t1 = h + s1 + ch + localK[i] + words[i]
       val t2 = s0 + maj
 
       h = g
@@ -85,15 +161,83 @@ internal class Sha256MessageDigest : AbstractMessageDigest() {
       a = t1 + t2
     }
 
-    return HashDigest(
-      (currentDigest[0] + a),
-      (currentDigest[1] + b),
-      (currentDigest[2] + c),
-      (currentDigest[3] + d),
-      (currentDigest[4] + e),
-      (currentDigest[5] + f),
-      (currentDigest[6] + g),
-      (currentDigest[7] + h)
+    h0 += a
+    h1 += b
+    h2 += c
+    h3 += d
+    h4 += e
+    h5 += f
+    h6 += g
+    h7 += h
+  }
+
+  /* ktlint-disable */
+  override fun digest(): ByteArray {
+    val unprocessed = this.unprocessed
+    var unprocessedLimit = this.unprocessedLimit
+    val messageLengthBits = messageLength * 8
+
+    unprocessed[unprocessedLimit++] = 0x80.toByte()
+    if (unprocessedLimit > 56) {
+      unprocessed.fill(0, unprocessedLimit, 64)
+      processChunk(unprocessed, 0)
+      unprocessed.fill(0, 0, unprocessedLimit)
+    } else {
+      unprocessed.fill(0, unprocessedLimit, 56)
+    }
+    unprocessed[56] = (messageLengthBits ushr 56).toByte()
+    unprocessed[57] = (messageLengthBits ushr 48).toByte()
+    unprocessed[58] = (messageLengthBits ushr 40).toByte()
+    unprocessed[59] = (messageLengthBits ushr 32).toByte()
+    unprocessed[60] = (messageLengthBits ushr 24).toByte()
+    unprocessed[61] = (messageLengthBits ushr 16).toByte()
+    unprocessed[62] = (messageLengthBits ushr  8).toByte()
+    unprocessed[63] = (messageLengthBits        ).toByte()
+    processChunk(unprocessed, 0)
+
+    val a = h0
+    val b = h1
+    val c = h2
+    val d = h3
+    val e = h4
+    val f = h5
+    val g = h6
+    val h = h7
+
+    return byteArrayOf(
+      (a shr 24).toByte(),
+      (a shr 16).toByte(),
+      (a shr  8).toByte(),
+      (a       ).toByte(),
+      (b shr 24).toByte(),
+      (b shr 16).toByte(),
+      (b shr  8).toByte(),
+      (b       ).toByte(),
+      (c shr 24).toByte(),
+      (c shr 16).toByte(),
+      (c shr  8).toByte(),
+      (c       ).toByte(),
+      (d shr 24).toByte(),
+      (d shr 16).toByte(),
+      (d shr  8).toByte(),
+      (d       ).toByte(),
+      (e shr 24).toByte(),
+      (e shr 16).toByte(),
+      (e shr  8).toByte(),
+      (e       ).toByte(),
+      (f shr 24).toByte(),
+      (f shr 16).toByte(),
+      (f shr  8).toByte(),
+      (f       ).toByte(),
+      (g shr 24).toByte(),
+      (g shr 16).toByte(),
+      (g shr  8).toByte(),
+      (g       ).toByte(),
+      (h shr 24).toByte(),
+      (h shr 16).toByte(),
+      (h shr  8).toByte(),
+      (h       ).toByte()
     )
   }
+  /* ktlint-enable */
 }


### PR DESCRIPTION
Performance is still quite a ways off OpenJDK.

```
Benchmark                    (algorithm)  (messageSize)  Mode  Cnt     Score     Error  Units
MessageDigestBenchmark.jvm       SHA-256            100  avgt    3     0.364 ±   0.085  us/op
MessageDigestBenchmark.jvm       SHA-256        1048576  avgt    3  2620.091 ± 645.504  us/op
MessageDigestBenchmark.okio      SHA-256            100  avgt    3     0.793 ±   0.137  us/op
MessageDigestBenchmark.okio      SHA-256        1048576  avgt    3  4468.063 ± 327.770  us/op
```