### PR TITLE
Fix SegmentedByteString substring write

### DIFF
--- a/okio/src/commonMain/kotlin/okio/internal/SegmentedByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/SegmentedByteString.kt
@@ -158,7 +158,7 @@ internal inline fun SegmentedByteString.commonWrite(buffer: Buffer, offset: Int,
       buffer.head!!.prev!!.push(segment)
     }
   }
-  buffer.size += size
+  buffer.size += byteCount
 }
 
 internal inline fun SegmentedByteString.commonRangeEquals(

--- a/okio/src/commonTest/kotlin/okio/BufferedSinkTest.kt
+++ b/okio/src/commonTest/kotlin/okio/BufferedSinkTest.kt
@@ -129,6 +129,18 @@ abstract class AbstractBufferedSinkTest internal constructor(
     assertEquals("72616ec999".decodeHex(), data.readByteString())
   }
 
+  @Test fun writeSegmentedByteString() {
+    sink.write(Buffer().write("təˈranəˌsôr".encodeUtf8()).snapshot())
+    sink.flush()
+    assertEquals("74c999cb8872616ec999cb8c73c3b472".decodeHex(), data.readByteString())
+  }
+
+  @Test fun writeSegmentedByteStringOffset() {
+    sink.write(Buffer().write("təˈranəˌsôr".encodeUtf8()).snapshot(), 5, 5)
+    sink.flush()
+    assertEquals("72616ec999".decodeHex(), data.readByteString())
+  }
+
   @Test fun writeStringUtf8() {
     sink.writeUtf8("təˈranəˌsôr")
     sink.flush()

--- a/okio/src/jvmTest/java/okio/BufferedSinkTest.java
+++ b/okio/src/jvmTest/java/okio/BufferedSinkTest.java
@@ -177,6 +177,18 @@ public final class BufferedSinkTest {
     assertEquals(ByteString.decodeHex("72616ec999"), data.readByteString());
   }
 
+  @Test public void writeSegmentedByteString() throws IOException {
+    sink.write(new Buffer().write(ByteString.encodeUtf8("təˈranəˌsôr")).snapshot());
+    sink.flush();
+    assertEquals(ByteString.decodeHex("74c999cb8872616ec999cb8c73c3b472"), data.readByteString());
+  }
+
+  @Test public void writeSegmentedByteStringOffset() throws IOException {
+    sink.write(new Buffer().write(ByteString.encodeUtf8("təˈranəˌsôr")).snapshot(), 5, 5);
+    sink.flush();
+    assertEquals(ByteString.decodeHex("72616ec999"), data.readByteString());
+  }
+
   @Test public void writeStringUtf8() throws IOException {
     sink.writeUtf8("təˈranəˌsôr");
     sink.flush();


### PR DESCRIPTION
Only occurs when performing a partial write of a SegmentedByteString into a Buffer. Partial write of a ByteString was added in 2.4.1 by #651 (yep, my bad 😬 ).