### PR TITLE
Make CipherSink and CipherSource into public types

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
@@ -34,6 +34,7 @@ import java.nio.file.OpenOption
 import java.nio.file.Path
 import java.util.logging.Level
 import java.util.logging.Logger
+import javax.crypto.Cipher
 
 /** Returns a sink that writes to `out`. */
 fun OutputStream.sink(): Sink = OutputStreamSink(this, Timeout())
@@ -188,6 +189,20 @@ fun Path.sink(vararg options: OpenOption): Sink =
 @IgnoreJRERequirement // Can only be invoked on Java 7+.
 fun Path.source(vararg options: OpenOption): Source =
     Files.newInputStream(this, *options).source()
+
+/**
+ * Returns a sink that uses [cipher] to encrypt or decrypt [this].
+ *
+ * @throws IllegalArgumentException if [cipher] isn't a block cipher.
+ */
+fun Sink.cipherSink(cipher: Cipher): CipherSink = CipherSink(this.buffer(), cipher)
+
+/**
+ * Returns a source that uses [cipher] to encrypt or decrypt [this].
+ *
+ * @throws IllegalArgumentException if [cipher] isn't a block cipher.
+ */
+fun Source.cipherSource(cipher: Cipher): CipherSource = CipherSource(this.buffer(), cipher)
 
 /**
  * Returns true if this error is due to a firmware bug fixed after Android 4.2.2.

--- a/okio/src/jvmTest/kotlin/okio/CipherAlgorithm.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherAlgorithm.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import kotlin.random.Random
+
+data class CipherAlgorithm(
+  val transformation: String,
+  val padding: Boolean,
+  val keyLength: Int,
+  val ivLength: Int? = null
+) {
+  fun createCipherFactory(random: Random): CipherFactory {
+    val key = random.nextBytes(keyLength)
+    val secretKeySpec = SecretKeySpec(key, transformation.substringBefore('/'))
+    return if (ivLength == null) {
+      CipherFactory(transformation) { mode ->
+        init(mode, secretKeySpec)
+      }
+    } else {
+      val iv = random.nextBytes(ivLength)
+      val ivParameterSpec = IvParameterSpec(iv)
+      CipherFactory(transformation) { mode ->
+        init(mode, secretKeySpec, ivParameterSpec)
+      }
+    }
+  }
+
+  override fun toString() = transformation
+
+  companion object {
+    val BLOCK_CIPHER_ALGORITHMS
+      get() = listOf(
+        CipherAlgorithm("AES/CBC/NoPadding", false, 16, 16),
+        CipherAlgorithm("AES/CBC/PKCS5Padding", true, 16, 16),
+        CipherAlgorithm("AES/ECB/NoPadding", false, 16),
+        CipherAlgorithm("AES/ECB/PKCS5Padding", true, 16),
+        CipherAlgorithm("DES/CBC/NoPadding", false, 8, 8),
+        CipherAlgorithm("DES/CBC/PKCS5Padding", true, 8, 8),
+        CipherAlgorithm("DES/ECB/NoPadding", false, 8),
+        CipherAlgorithm("DES/ECB/PKCS5Padding", true, 8),
+        CipherAlgorithm("DESede/CBC/NoPadding", false, 24, 8),
+        CipherAlgorithm("DESede/CBC/PKCS5Padding", true, 24, 8),
+        CipherAlgorithm("DESede/ECB/NoPadding", false, 24),
+        CipherAlgorithm("DESede/ECB/PKCS5Padding", true, 24)
+      )
+  }
+}

--- a/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
@@ -1,16 +1,28 @@
+/*
+ * Copyright (C) 2020 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okio
 
 import javax.crypto.Cipher
-import javax.crypto.spec.IvParameterSpec
-import javax.crypto.spec.SecretKeySpec
-import kotlin.random.Random
 
 class CipherFactory(
   private val transformation: String,
   private val init: Cipher.(mode: Int) -> Unit
 ) {
   val blockSize
-    get() = cipher.blockSize
+    get() = newCipher().blockSize
 
   val encrypt: Cipher
     get() = create(Cipher.ENCRYPT_MODE)
@@ -18,52 +30,7 @@ class CipherFactory(
   val decrypt: Cipher
     get() = create(Cipher.DECRYPT_MODE)
 
-  private val cipher: Cipher
-    get() = Cipher.getInstance(transformation)
+  private fun newCipher(): Cipher = Cipher.getInstance(transformation)
 
-  private fun create(mode: Int): Cipher =
-    cipher.apply { init(mode) }
-}
-
-data class CipherAlgorithm(
-  val transformation: String,
-  val padding: Boolean,
-  val keyLength: Int,
-  val ivLength: Int? = null
-) {
-  fun createCipherFactory(random: Random): CipherFactory {
-    val key = random.nextBytes(keyLength)
-    val secretKeySpec = SecretKeySpec(key, transformation.substringBefore('/'))
-    return if (ivLength == null) {
-      CipherFactory(transformation) { mode ->
-        init(mode, secretKeySpec)
-      }
-    } else {
-      val iv = random.nextBytes(ivLength)
-      val ivParameterSpec = IvParameterSpec(iv)
-      CipherFactory(transformation) { mode ->
-        init(mode, secretKeySpec, ivParameterSpec)
-      }
-    }
-  }
-
-  override fun toString(): String =
-    transformation
-
-  companion object {
-    fun getBlockCipherAlgorithms() = listOf(
-      CipherAlgorithm("AES/CBC/NoPadding", false, 16, 16),
-      CipherAlgorithm("AES/CBC/PKCS5Padding", true, 16, 16),
-      CipherAlgorithm("AES/ECB/NoPadding", false, 16),
-      CipherAlgorithm("AES/ECB/PKCS5Padding", true, 16),
-      CipherAlgorithm("DES/CBC/NoPadding", false, 8, 8),
-      CipherAlgorithm("DES/CBC/PKCS5Padding", true, 8, 8),
-      CipherAlgorithm("DES/ECB/NoPadding", false, 8),
-      CipherAlgorithm("DES/ECB/PKCS5Padding", true, 8),
-      CipherAlgorithm("DESede/CBC/NoPadding", false, 24, 8),
-      CipherAlgorithm("DESede/CBC/PKCS5Padding", true, 24, 8),
-      CipherAlgorithm("DESede/ECB/NoPadding", false, 24),
-      CipherAlgorithm("DESede/ECB/PKCS5Padding", true, 24)
-    )
-  }
+  private fun create(mode: Int): Cipher = newCipher().apply { init(mode) }
 }


### PR DESCRIPTION
This is a hedge against needing to add new public APIs on these
types. We needed it for InflaterSource so we could have a method
that would consume bytes without necessarily returning any.