### PR TITLE
Extensions for hashing source & sink

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/HashingSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/HashingSink.kt
@@ -41,9 +41,19 @@ class HashingSink : ForwardingSink {
   private val messageDigest: MessageDigest?
   private val mac: Mac?
 
+  internal constructor(sink: Sink, digest: MessageDigest) : super(sink) {
+    this.messageDigest = digest
+    this.mac = null
+  }
+
   internal constructor(sink: Sink, algorithm: String) : super(sink) {
     this.messageDigest = MessageDigest.getInstance(algorithm)
     this.mac = null
+  }
+
+  internal constructor(sink: Sink, mac: Mac) : super(sink) {
+    this.mac = mac
+    this.messageDigest = null
   }
 
   internal constructor(sink: Sink, key: ByteString, algorithm: String) : super(sink) {

--- a/okio/src/jvmMain/kotlin/okio/HashingSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/HashingSink.kt
@@ -46,26 +46,23 @@ class HashingSink : ForwardingSink {
     this.mac = null
   }
 
-  internal constructor(sink: Sink, algorithm: String) : super(sink) {
-    this.messageDigest = MessageDigest.getInstance(algorithm)
-    this.mac = null
-  }
+  internal constructor(sink: Sink, algorithm: String) : this(sink, MessageDigest.getInstance(algorithm))
 
   internal constructor(sink: Sink, mac: Mac) : super(sink) {
     this.mac = mac
     this.messageDigest = null
   }
 
-  internal constructor(sink: Sink, key: ByteString, algorithm: String) : super(sink) {
+  internal constructor(sink: Sink, key: ByteString, algorithm: String) : this(
+    sink,
     try {
-      this.mac = Mac.getInstance(algorithm).apply {
+      Mac.getInstance(algorithm).apply {
         init(SecretKeySpec(key.toByteArray(), algorithm))
       }
-      this.messageDigest = null
     } catch (e: InvalidKeyException) {
       throw IllegalArgumentException(e)
     }
-  }
+  )
 
   @Throws(IOException::class)
   override fun write(source: Buffer, byteCount: Long) {

--- a/okio/src/jvmMain/kotlin/okio/HashingSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/HashingSource.kt
@@ -42,9 +42,19 @@ class HashingSource : ForwardingSource {
   private val messageDigest: MessageDigest?
   private val mac: Mac?
 
+  internal constructor(source: Source, digest: MessageDigest) : super(source) {
+    this.messageDigest = digest
+    this.mac = null
+  }
+
   internal constructor(source: Source, algorithm: String) : super(source) {
     messageDigest = MessageDigest.getInstance(algorithm)
     mac = null
+  }
+
+  internal constructor(source: Source, mac: Mac) : super(source) {
+    this.mac = mac
+    this.messageDigest = null
   }
 
   internal constructor(source: Source, key: ByteString, algorithm: String) : super(source) {

--- a/okio/src/jvmMain/kotlin/okio/HashingSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/HashingSource.kt
@@ -47,26 +47,23 @@ class HashingSource : ForwardingSource {
     this.mac = null
   }
 
-  internal constructor(source: Source, algorithm: String) : super(source) {
-    messageDigest = MessageDigest.getInstance(algorithm)
-    mac = null
-  }
+  internal constructor(source: Source, algorithm: String) : this(source, MessageDigest.getInstance(algorithm))
 
   internal constructor(source: Source, mac: Mac) : super(source) {
     this.mac = mac
     this.messageDigest = null
   }
 
-  internal constructor(source: Source, key: ByteString, algorithm: String) : super(source) {
+  internal constructor(source: Source, key: ByteString, algorithm: String) : this(
+    source,
     try {
-      mac = Mac.getInstance(algorithm).apply {
+      Mac.getInstance(algorithm).apply {
         init(SecretKeySpec(key.toByteArray(), algorithm))
       }
-      messageDigest = null
     } catch (e: InvalidKeyException) {
       throw IllegalArgumentException(e)
     }
-  }
+  )
 
   @Throws(IOException::class)
   override fun read(sink: Buffer, byteCount: Long): Long {

--- a/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
@@ -32,9 +32,11 @@ import java.net.SocketTimeoutException
 import java.nio.file.Files
 import java.nio.file.OpenOption
 import java.nio.file.Path
+import java.security.MessageDigest
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.crypto.Cipher
+import javax.crypto.Mac
 
 /** Returns a sink that writes to `out`. */
 fun OutputStream.sink(): Sink = OutputStreamSink(this, Timeout())
@@ -203,6 +205,26 @@ fun Sink.cipherSink(cipher: Cipher): CipherSink = CipherSink(this.buffer(), ciph
  * @throws IllegalArgumentException if [cipher] isn't a block cipher.
  */
 fun Source.cipherSource(cipher: Cipher): CipherSource = CipherSource(this.buffer(), cipher)
+
+/**
+ * Returns a sink that uses [mac] to hash [this].
+ */
+fun Sink.macSink(mac: Mac): HashingSink = HashingSink(this, mac)
+
+/**
+ * Returns a source that uses [mac] to hash [this].
+ */
+fun Source.macSource(mac: Mac): HashingSource = HashingSource(this, mac)
+
+/**
+ * Returns a sink that uses [digest] to hash [this].
+ */
+fun Sink.digestSink(digest: MessageDigest): HashingSink = HashingSink(this, digest)
+
+/**
+ * Returns a source that uses [digest] to hash [this].
+ */
+fun Source.digestSource(digest: MessageDigest): HashingSource = HashingSource(this, digest)
 
 /**
  * Returns true if this error is due to a firmware bug fixed after Android 4.2.2.

--- a/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
@@ -209,22 +209,22 @@ fun Source.cipherSource(cipher: Cipher): CipherSource = CipherSource(this.buffer
 /**
  * Returns a sink that uses [mac] to hash [this].
  */
-fun Sink.macSink(mac: Mac): HashingSink = HashingSink(this, mac)
+fun Sink.hashingSink(mac: Mac): HashingSink = HashingSink(this, mac)
 
 /**
  * Returns a source that uses [mac] to hash [this].
  */
-fun Source.macSource(mac: Mac): HashingSource = HashingSource(this, mac)
+fun Source.hashingSource(mac: Mac): HashingSource = HashingSource(this, mac)
 
 /**
  * Returns a sink that uses [digest] to hash [this].
  */
-fun Sink.digestSink(digest: MessageDigest): HashingSink = HashingSink(this, digest)
+fun Sink.hashingSink(digest: MessageDigest): HashingSink = HashingSink(this, digest)
 
 /**
  * Returns a source that uses [digest] to hash [this].
  */
-fun Source.digestSource(digest: MessageDigest): HashingSource = HashingSource(this, digest)
+fun Source.hashingSource(digest: MessageDigest): HashingSource = HashingSource(this, digest)
 
 /**
  * Returns true if this error is due to a firmware bug fixed after Android 4.2.2.


### PR DESCRIPTION
Hello 👋 me again with more crypto stuff 😅

This MR adds similar extensions to `cipherSource` and `cipherSink` for the hashing source and sink. 

More importantly though, it exposes the `Mac` and `MessageDigest` classes directly to be able to create the hashing source or sink directly with a pre-initialized instance, rather than using one of the predefined ones. This allows more extensibility to use with other algorithms that the platform may support, but it's also more flexible to perform operations on the mac or digest instances themselves. In a way, it's also consistent with the new API for using cipher source and sink. 

My use-case is a cipher spec where the `Mac` instance needs to be initialized with a an initialization vector, before being computed for all the data. This isn't possible with the current API. Granted, it's a bit of a unorthodox spec, but I'm sure there are other cases where this kind of flexibility could be needed. 