### PR TITLE
Path API for multiplatform

### DIFF
--- a/okio-files/README.md
+++ b/okio-files/README.md
@@ -1,0 +1,6 @@
+Okio Files (pre-release)
+------------------------
+
+This module contains the work-in-progress of Okio's multiplatform files API. When this work is
+finished we will move these APIs into the main okio module and delete this module.
+

--- a/okio-files/build.gradle
+++ b/okio-files/build.gradle
@@ -1,0 +1,33 @@
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+
+kotlin {
+  jvm {
+    withJava()
+  }
+  sourceSets {
+    commonMain {
+      dependencies {
+        api deps.kotlin.stdLib.common
+        api project(":okio")
+      }
+    }
+    commonTest {
+      dependencies {
+        implementation deps.kotlin.test.common
+        implementation deps.kotlin.test.annotations
+      }
+    }
+    jvmMain {
+      dependencies {
+        api deps.kotlin.stdLib.jdk6
+      }
+    }
+    jvmTest {
+      dependencies {
+        implementation deps.test.junit
+        implementation deps.test.assertj
+        implementation deps.kotlin.test.jdk
+      }
+    }
+  }
+}

--- a/okio-files/gradle.properties
+++ b/okio-files/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=okio-files
+POM_NAME=Okio Files

--- a/okio-files/src/commonMain/kotlin/okio/Filesystem.kt
+++ b/okio-files/src/commonMain/kotlin/okio/Filesystem.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+abstract class Filesystem {
+  /**
+   * The current process's working directory. This is the result of the `getcwd` command on POSIX
+   * and the `user.dir` System property in Java. This is an absolute path that all relative paths
+   * are resolved against when using this filesystem.
+   */
+  abstract val cwd: Path
+}

--- a/okio-files/src/commonMain/kotlin/okio/Path.kt
+++ b/okio-files/src/commonMain/kotlin/okio/Path.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import okio.ByteString.Companion.EMPTY
+import okio.ByteString.Companion.encodeUtf8
+
+/**
+ * A hierarchical address on a filesystem. A path is an identifier only; a [Filesystem] is required
+ * to access the file that a path refers to, if any.
+ *
+ * Paths may be absolute or relative:
+ *
+ * * **Absolute paths** are prefixed with `/` and identify a location independent of any working
+ *   directory.
+ * * **Relative paths** are not prefixed with `/`. On their own, relative paths do not identify a
+ *   location on a filesystem; they must be resolved against an absolute path first. When a relative
+ *   path is used to access a [Filesystem], it is resolved against [Filesystem.cwd].
+ *
+ * After the optional leading `/`, the rest of the path is a sequence of segments separated by `/`
+ * characters. Segments satisfy these rules:
+ *
+ *  * Segments are always non-empty.
+ *  * Segments may not be `.`.
+ *  * Segments with the value `..` only occur in relative paths, where these must precede all other
+ *    segments.
+ *
+ * The only path that ends with `/` is the filesystem root, `/`. The empty path `""` is a relative
+ * path that resolves to whichever path it is resolved against.
+ *
+ * Sample Paths
+ * ------------
+ *
+ * | Path                   | Type       | Parent              |
+ * | :--------------------- | :--------- | :------------------ |
+ * | `/Users/jessewilson`   | Absolute   | `/Users`            |
+ * | `/Users`               | Absolute   | `/`                 |
+ * | `/`                    | Absolute   | null                |
+ * | `src/main/java`        | Relative   | `src/main`          |
+ * | `src/main`             | Relative   | `src`               |
+ * | `src`                  | Relative   | (empty)             |
+ * | (empty)                | Relative   | null                |
+ * | `../../src/main/java`  | Relative   | ` ../../src/main`   |
+ * | `../../src/main`       | Relative   | ` ../../src`        |
+ * | `../../src`            | Relative   | ` ../..`            |
+ * | `../..`                | Relative   | null                |
+ */
+class Path private constructor(
+  private val bytes: ByteString
+) {
+  val isAbsolute: Boolean
+    get() = bytes.startsWith(SLASH)
+
+  val isRelative: Boolean
+    get() = !isAbsolute
+
+  /**
+   * Returns the path immediately enclosing this path. This returns null if this is either the
+   * filesystem root (`/`), the empty path, or a traversal up from the empty path.
+   */
+  val parent: Path?
+    get() {
+      if (bytes == EMPTY || bytes == SLASH || bytes.endsWith(SLASH_DOT_DOT) || bytes == DOT_DOT) {
+        return null // Terminal path.
+      }
+      return when (val lastSlash = bytes.lastIndexOf(SLASH)) {
+        -1 -> Path(EMPTY) // Parent is the current working directory.
+        0 -> Path(bytes.substring(endIndex = 1)) // Parent is the filesystem root '/'.
+        else -> Path(bytes.substring(endIndex = lastSlash))
+      }
+    }
+
+  /** Returns a path that resolves [child] relative to this path. */
+  operator fun div(child: String): Path {
+    val buffer = Buffer()
+    buffer.write(bytes)
+    if (buffer.size > 0) {
+      buffer.write(SLASH)
+    }
+    buffer.writeUtf8(child)
+    return buffer.toPath()
+  }
+
+  override fun equals(other: Any?) = other is Path && other.bytes == bytes
+
+  override fun hashCode() = bytes.hashCode()
+
+  override fun toString() = bytes.utf8()
+
+  companion object {
+    private val SLASH = "/".encodeUtf8()
+    private val DOT = ".".encodeUtf8()
+    private val DOT_DOT = "..".encodeUtf8()
+    private val SLASH_DOT_DOT = "/..".encodeUtf8()
+
+    fun String.toPath(): Path = Buffer().writeUtf8(this).toPath()
+
+    private fun Buffer.toPath(): Path {
+      val absolute = !exhausted() && get(0) == '/'.toByte()
+      if (absolute) {
+        readByte()
+      }
+
+      val canonicalParts = mutableListOf<ByteString>()
+      while (!exhausted()) {
+        val limit = indexOf(SLASH)
+
+        val part: ByteString
+        if (limit == -1L) {
+          part = readByteString()
+        } else {
+          part = readByteString(limit)
+          readByte()
+        }
+
+        if (part == DOT_DOT) {
+          if (!absolute && (canonicalParts.isEmpty() || canonicalParts.last() == DOT_DOT)) {
+            canonicalParts.add(part) // '..' doesn't pop '..' for relative paths.
+          } else {
+            canonicalParts.removeLastOrNull()
+          }
+        } else if (part != DOT && part != ByteString.EMPTY) {
+          canonicalParts.add(part)
+        }
+      }
+
+      val result = Buffer()
+      if (absolute) {
+        result.write(SLASH)
+      }
+      for (i in 0 until canonicalParts.size) {
+        if (i > 0) result.write(SLASH)
+        result.write(canonicalParts[i])
+      }
+
+      return Path(result.readByteString())
+    }
+  }
+}

--- a/okio-files/src/commonTest/kotlin/okio/files/PathTest.kt
+++ b/okio-files/src/commonTest/kotlin/okio/files/PathTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.files
+
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PathTest {
+  @Test
+  fun `basic paths`() {
+    assertEquals("gradlew", "./gradlew".toPath().toString())
+    assertEquals(".gitignore", "./.gitignore".toPath().toString())
+    assertEquals("/home/jesse", "/home/jesse".toPath().toString())
+    assertEquals("/home/jake", "/home/jesse/../jake".toPath().toString())
+    assertEquals("../../etc/passwd", "../../etc/passwd".toPath().toString())
+  }
+
+  @Test
+  fun `parent of absolute path`() {
+    assertEquals("/home", "/home/jesse".toPath().parent?.toString())
+    assertEquals("/", "/home".toPath().parent?.toString())
+    assertNull("/".toPath().parent)
+  }
+
+  @Test
+  fun `parent of relative path`() {
+    assertEquals("src/main", "src/main/java".toPath().parent?.toString())
+    assertEquals("src", "src/main".toPath().parent?.toString())
+    assertEquals("", "src".toPath().parent?.toString())
+    assertNull("".toPath().parent)
+  }
+
+  @Test
+  fun `parent of relative path with single traversal`() {
+    assertEquals("../src/main", "../src/main/java".toPath().parent?.toString())
+    assertEquals("../src", "../src/main".toPath().parent?.toString())
+    assertEquals("..", "../src".toPath().parent?.toString())
+    assertNull("..".toPath().parent)
+  }
+
+  @Test
+  fun `parent of relative path with multiple traversal`() {
+    assertEquals("../../src/main", "../../src/main/java".toPath().parent?.toString())
+    assertEquals("../../src", "../../src/main".toPath().parent?.toString())
+    assertEquals("../..", "../../src".toPath().parent?.toString())
+    assertNull("../..".toPath().parent)
+  }
+
+  @Test
+  fun `absolute path traversal with div operator`() {
+    val root = "/".toPath()
+    assertEquals("/home".toPath(), root / "home")
+    assertEquals("/home/jesse".toPath(), root / "home" / "jesse")
+    assertEquals("/home".toPath(), root / "home" / "jesse" / "..")
+    assertEquals("/home/jake".toPath(), root / "home" / "jesse" / ".." / "jake")
+  }
+
+  @Test
+  fun `relative path traversal with div operator`() {
+    val cwd = "".toPath()
+    assertEquals("home".toPath(), cwd / "home")
+    assertEquals("home/jesse".toPath(), cwd / "home" / "jesse")
+    assertEquals("home".toPath(), cwd / "home" / "jesse" / "..")
+    assertEquals("home/jake".toPath(), cwd / "home" / "jesse" / ".." / "jake")
+  }
+
+  @Test
+  fun `relative path traveral with dots`() {
+    val cwd = "".toPath()
+    assertEquals("..".toPath(), cwd / "..")
+    assertEquals("../..".toPath(), cwd / ".." / "..")
+    assertEquals("../../etc".toPath(), cwd / ".." / ".." / "etc")
+    assertEquals("../../etc/passwd".toPath(), cwd / ".." / ".." / "etc" / "passwd")
+  }
+
+  @Test
+  fun `string to absolute path`() {
+    assertEquals("/", "/".toPath().toString())
+    assertEquals("/a", "/a".toPath().toString())
+    assertEquals("/a", "/a/".toPath().toString())
+    assertEquals("/a/b/c", "/a/b/c".toPath().toString())
+    assertEquals("/a/b/c", "/a/b/c/".toPath().toString())
+  }
+
+  @Test
+  fun `string to absolute path with traversal`() {
+    assertEquals("/", "/..".toPath().toString())
+    assertEquals("/", "/../".toPath().toString())
+    assertEquals("/", "/../..".toPath().toString())
+    assertEquals("/", "/../../".toPath().toString())
+  }
+
+  @Test
+  fun `string to absolute path with empty segments`() {
+    assertEquals("/", "//".toPath().toString())
+    assertEquals("/a", "//a".toPath().toString())
+    assertEquals("/a", "/a//".toPath().toString())
+    assertEquals("/a", "//a//".toPath().toString())
+    assertEquals("/a/b", "/a/b//".toPath().toString())
+  }
+
+  @Test
+  fun `string to absolute path with dots`() {
+    assertEquals("/", "/./".toPath().toString())
+    assertEquals("/a", "/./a".toPath().toString())
+    assertEquals("/a", "/a/./".toPath().toString())
+    assertEquals("/a", "/a//.".toPath().toString())
+    assertEquals("/a", "/./a//".toPath().toString())
+    assertEquals("/a", "/a/.".toPath().toString())
+    assertEquals("/a", "//a/./".toPath().toString())
+    assertEquals("/a", "//a/./.".toPath().toString())
+    assertEquals("/a/b", "/a/./b/".toPath().toString())
+  }
+
+  @Test
+  fun `string to relative path`() {
+    assertEquals("", "".toPath().toString())
+    assertEquals("a", "a/".toPath().toString())
+    assertEquals("a/b", "a/b".toPath().toString())
+    assertEquals("a/b", "a/b/".toPath().toString())
+    assertEquals("a/b/c/d", "a/b/c/d".toPath().toString())
+    assertEquals("a/b/c/d", "a/b/c/d/".toPath().toString())
+  }
+
+  @Test
+  fun `string to relative path with traversal`() {
+    assertEquals("", "a/..".toPath().toString())
+    assertEquals("", "a/../".toPath().toString())
+    assertEquals("..", "a/../..".toPath().toString())
+    assertEquals("..", "a/../../".toPath().toString())
+    assertEquals("../..", "a/../../..".toPath().toString())
+    assertEquals("../../b", "../../b".toPath().toString())
+    assertEquals("../../b", "a/../../../b".toPath().toString())
+    assertEquals("../../c", "a/../../../b/../c".toPath().toString())
+  }
+
+  @Test
+  fun `string to relative path with empty segments`() {
+    assertEquals("a", "a//".toPath().toString())
+    assertEquals("a/b", "a//b".toPath().toString())
+    assertEquals("a/b", "a/b//".toPath().toString())
+    assertEquals("a/b", "a//b//".toPath().toString())
+    assertEquals("a/b/c", "a/b/c//".toPath().toString())
+  }
+
+  @Test
+  fun `string to relative path with dots`() {
+    assertEquals("", ".".toPath().toString())
+    assertEquals("", "./".toPath().toString())
+    assertEquals("", "././".toPath().toString())
+    assertEquals("", "././a/..".toPath().toString())
+    assertEquals("a", "a/./".toPath().toString())
+    assertEquals("a/b", "a/./b".toPath().toString())
+    assertEquals("a/b", "a/b/./".toPath().toString())
+    assertEquals("a/b", "a/b//.".toPath().toString())
+    assertEquals("a/b", "a/./b//".toPath().toString())
+    assertEquals("a/b", "a/b/.".toPath().toString())
+    assertEquals("a/b", "a//b/./".toPath().toString())
+    assertEquals("a/b", "a//b/./.".toPath().toString())
+    assertEquals("a/b/c", "a/b/./c/".toPath().toString())
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include ':okio'
+include ':okio-files'
 include ':okio:jvm:japicmp'
 include ':okio:jvm:jmh'
 include ':samples'


### PR DESCRIPTION
This is a bit more experimental than I would have preferred.
Like Java's File and Path types, this uses a single type to
represent either a relative or absolute path. It attempts to
simplify '..' and '.' operators and remove unnecessary empty
paths.