### PR TITLE
fix okio.Timeout#throwIfReached() thread's interrupted status check

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/Timeout.kt
+++ b/okio/src/jvmMain/kotlin/okio/Timeout.kt
@@ -94,7 +94,7 @@ actual open class Timeout {
   @Throws(IOException::class)
   open fun throwIfReached() {
     if (Thread.currentThread().isInterrupted) {
-      //if the current thread has been interrupted
+      // If the current thread has been interrupted.
       throw InterruptedIOException("interrupted")
     }
 

--- a/okio/src/jvmMain/kotlin/okio/Timeout.kt
+++ b/okio/src/jvmMain/kotlin/okio/Timeout.kt
@@ -93,7 +93,7 @@ actual open class Timeout {
    */
   @Throws(IOException::class)
   open fun throwIfReached() {
-    if (Thread.isInterrupted()) {
+    if (Thread.currentThread().isInterrupted) {
       //if the current thread has been interrupted
       throw InterruptedIOException("interrupted")
     }

--- a/okio/src/jvmMain/kotlin/okio/Timeout.kt
+++ b/okio/src/jvmMain/kotlin/okio/Timeout.kt
@@ -93,8 +93,8 @@ actual open class Timeout {
    */
   @Throws(IOException::class)
   open fun throwIfReached() {
-    if (Thread.interrupted()) {
-      Thread.currentThread().interrupt() // Retain interrupted status.
+    if (Thread.isInterrupted()) {
+      //if the current thread has been interrupted
       throw InterruptedIOException("interrupted")
     }
 


### PR DESCRIPTION
[fixed Issue#789](https://github.com/square/okio/issues/789)