### PR TITLE
Initial native implementation of Filesystem

### DIFF
--- a/okio-files/build.gradle
+++ b/okio-files/build.gradle
@@ -4,6 +4,9 @@ kotlin {
   jvm {
     withJava()
   }
+  if (kmpNativeEnabled) {
+    macosX64()
+  }
   sourceSets {
     commonMain {
       dependencies {
@@ -28,6 +31,11 @@ kotlin {
         implementation deps.test.assertj
         implementation deps.kotlin.test.jdk
       }
+    }
+    macosX64Main {
+      dependsOn commonMain
+    }
+    configure([macosX64Main]) {
     }
   }
 }

--- a/okio-files/src/commonMain/kotlin/okio/Filesystem.kt
+++ b/okio-files/src/commonMain/kotlin/okio/Filesystem.kt
@@ -20,8 +20,13 @@ abstract class Filesystem {
    * The current process's working directory. This is the result of the `getcwd` command on POSIX
    * and the `user.dir` System property in Java. This is an absolute path that all relative paths
    * are resolved against when using this filesystem.
+   *
+   * @throws IOException if the current process doesn't have access to the current working
+   *     directory, if it's been deleted since the current process started, or there is another
+   *     failure accessing the current working directory.
    */
-  abstract val cwd: Path
+  @Throws(IOException::class)
+  abstract fun cwd(): Path
 
   companion object {
     /**

--- a/okio-files/src/commonMain/kotlin/okio/Path.kt
+++ b/okio-files/src/commonMain/kotlin/okio/Path.kt
@@ -124,7 +124,8 @@ class Path private constructor(
 
     fun String.toPath(): Path = Buffer().writeUtf8(this).toPath()
 
-    private fun Buffer.toPath(): Path {
+    /** Consume the buffer and return it as a path. */
+    internal fun Buffer.toPath(): Path {
       val absolute = !exhausted() && get(0) == '/'.toByte()
       if (absolute) {
         readByte()

--- a/okio-files/src/commonTest/kotlin/okio/files/FileSystemTest.kt
+++ b/okio-files/src/commonTest/kotlin/okio/files/FileSystemTest.kt
@@ -16,13 +16,12 @@
 package okio.files
 
 import okio.Filesystem
-import org.assertj.core.api.Assertions.assertThat
-import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 
-class JvmSystemFilesystemTest {
+class FileSystemTest {
   @Test
-  fun `cwd consistent with java io File`() {
-    assertThat(Filesystem.SYSTEM.cwd().toString()).isEqualTo(File("").absoluteFile.toString())
+  fun `cwd is not null`() {
+    assertNotNull(Filesystem.SYSTEM.cwd())
   }
 }

--- a/okio-files/src/jvmMain/kotlin/okio/JvmSystemFilesystem.kt
+++ b/okio-files/src/jvmMain/kotlin/okio/JvmSystemFilesystem.kt
@@ -18,9 +18,9 @@ package okio
 import okio.Path.Companion.toPath
 
 object JvmSystemFilesystem : Filesystem() {
-  override val cwd: Path
-    get() {
-      val userDir = System.getProperty("user.dir") ?: error("user.dir system property missing?!")
-      return userDir.toPath()
-    }
+  override fun cwd(): Path {
+    val userDir = System.getProperty("user.dir")
+      ?: throw IOException("user.dir system property missing?!")
+    return userDir.toPath()
+  }
 }

--- a/okio-files/src/macosX64Main/kotlin/okio/Platform.kt
+++ b/okio-files/src/macosX64Main/kotlin/okio/Platform.kt
@@ -13,16 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okio.files
+package okio
 
-import okio.Filesystem
-import org.assertj.core.api.Assertions.assertThat
-import java.io.File
-import kotlin.test.Test
-
-class JvmSystemFilesystemTest {
-  @Test
-  fun `cwd consistent with java io File`() {
-    assertThat(Filesystem.SYSTEM.cwd().toString()).isEqualTo(File("").absoluteFile.toString())
-  }
-}
+internal actual val PLATFORM_FILESYSTEM: Filesystem = PosixSystemFilesystem

--- a/okio-files/src/macosX64Main/kotlin/okio/PosixSystemFilesystem.kt
+++ b/okio-files/src/macosX64Main/kotlin/okio/PosixSystemFilesystem.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import kotlinx.cinterop.ByteVarOf
+import kotlinx.cinterop.CPointer
+import okio.Path.Companion.toPath
+import platform.posix.EACCES
+import platform.posix.ENOENT
+import platform.posix.ENOMEM
+import platform.posix.PATH_MAX
+import platform.posix.errno
+import platform.posix.free
+import platform.posix.getcwd
+
+object PosixSystemFilesystem : Filesystem() {
+  override fun cwd(): Path {
+    val pathMax = PATH_MAX
+    val bytes: CPointer<ByteVarOf<Byte>>? = getcwd(null, pathMax.toULong())
+    try {
+      if (bytes == null) {
+        when (errno) {
+          ENOENT -> throw IOException("ENOENT: the current working directory no longer exists")
+          EACCES -> throw IOException("EACCES: cannot access the current working directory")
+          ENOMEM -> throw OutOfMemoryError()
+          else -> error("unexpected errno $errno")
+        }
+      }
+      return Buffer().writeNullTerminated(bytes).toPath()
+    } finally {
+      free(bytes)
+    }
+  }
+}

--- a/okio-files/src/macosX64Main/kotlin/okio/cinterop.kt
+++ b/okio-files/src/macosX64Main/kotlin/okio/cinterop.kt
@@ -13,16 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okio.files
+package okio
 
-import okio.Filesystem
-import org.assertj.core.api.Assertions.assertThat
-import java.io.File
-import kotlin.test.Test
+import kotlinx.cinterop.ByteVarOf
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.get
 
-class JvmSystemFilesystemTest {
-  @Test
-  fun `cwd consistent with java io File`() {
-    assertThat(Filesystem.SYSTEM.cwd().toString()).isEqualTo(File("").absoluteFile.toString())
+internal fun Buffer.writeNullTerminated(bytes: CPointer<ByteVarOf<Byte>>): Buffer = apply {
+  val result = Buffer()
+  var pos = 0
+  while (true) {
+    val byte = bytes[pos++].toInt()
+    if (byte == 0) {
+      break
+    } else {
+      result.writeByte(byte)
+    }
   }
 }


### PR DESCRIPTION
I'm working in IntelliJ and it's been happier to track a single
target platform than several. I'll expand this to Linux and iOS
in a follow-up PR.

This satisfies egorand's recommendation of making cwd() a function
rather than a val. Annoyingly the native implementation can fail
in ways far more plausible than the JVM implementation.