### PR TITLE
FileSystem.atomicMove()

### DIFF
--- a/okio-files/src/commonMain/kotlin/okio/Filesystem.kt
+++ b/okio-files/src/commonMain/kotlin/okio/Filesystem.kt
@@ -26,7 +26,7 @@ abstract class Filesystem {
    *     failure accessing the current working directory.
    */
   @Throws(IOException::class)
-  abstract fun cwd(): Path
+  abstract fun baseDirectory(): Path
 
   /**
    * Returns the children of the directory identified by [dir].
@@ -67,7 +67,24 @@ abstract class Filesystem {
    *     loop of symbolic links, or if any name is too long.
    */
   @Throws(IOException::class)
-  abstract fun mkdir(dir: Path)
+  abstract fun createDirectory(dir: Path)
+
+  /**
+   * Moves [source] to [target] in-place if the underlying file system supports it. If [target]
+   * exists, it is first removed. If `source == target`, this operation does nothing. This may be
+   * used to move a file or a directory.
+   *
+   * If the file cannot be moved atomically, no move is performed and this method throws an
+   * [IOException]. Typically atomic moves are not possible if the paths are on different
+   * logical devices (filesystems).
+   *
+   * @throws IOException if the move cannot be performed, or cannot be performed atomically. Moves
+   *     fail if the source doesn't exist, if the target is not writable, if the target already
+   *     exists and cannot be replaced, or if the move would cause physical or quota limits to be
+   *     exceeded. This list of potential problems is not exhaustive.
+   */
+  @Throws(IOException::class)
+  abstract fun atomicMove(source: Path, target: Path)
 
   companion object {
     /**

--- a/okio-files/src/commonMain/kotlin/okio/Path.kt
+++ b/okio-files/src/commonMain/kotlin/okio/Path.kt
@@ -27,7 +27,7 @@ import okio.ByteString.Companion.encodeUtf8
  *   directory.
  * * **Relative paths** are not prefixed with `/`. On their own, relative paths do not identify a
  *   location on a filesystem; they must be resolved against an absolute path first. When a relative
- *   path is used to access a [Filesystem], it is resolved against [Filesystem.cwd].
+ *   path is used to access a [Filesystem], it is resolved against [Filesystem.baseDirectory].
  *
  * After the optional leading `/`, the rest of the path is a sequence of segments separated by `/`
  * characters. Segments satisfy these rules:

--- a/okio-files/src/jvmMain/kotlin/okio/Jvm.kt
+++ b/okio-files/src/jvmMain/kotlin/okio/Jvm.kt
@@ -16,6 +16,9 @@
 package okio
 
 import java.io.File
+import java.nio.file.Paths
+import java.nio.file.Path as NioPath
 
-internal val Path.file: File
-  get() = File(toString())
+internal fun Path.toFile(): File = File(toString())
+
+internal fun Path.toNioPath(): NioPath = Paths.get(toString())

--- a/okio-files/src/jvmMain/kotlin/okio/JvmSystemFilesystem.kt
+++ b/okio-files/src/jvmMain/kotlin/okio/JvmSystemFilesystem.kt
@@ -41,7 +41,7 @@ object JvmSystemFilesystem : Filesystem() {
   }
 
   override fun createDirectory(dir: Path) {
-    if (!dir.toFile().mkdir()) throw IOException("failed to mkdir $dir")
+    if (!dir.toFile().mkdir()) throw IOException("failed to create directory $dir")
   }
 
   override fun atomicMove(source: Path, target: Path) {

--- a/okio-files/src/jvmMain/kotlin/okio/JvmSystemFilesystem.kt
+++ b/okio-files/src/jvmMain/kotlin/okio/JvmSystemFilesystem.kt
@@ -16,28 +16,39 @@
 package okio
 
 import okio.Path.Companion.toPath
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
 object JvmSystemFilesystem : Filesystem() {
-  override fun cwd(): Path {
+  override fun baseDirectory(): Path {
     val userDir = System.getProperty("user.dir")
       ?: throw IOException("user.dir system property missing?!")
     return userDir.toPath()
   }
 
   override fun list(dir: Path): List<Path> {
-    val entries = dir.file.list() ?: throw IOException("failed to list $dir")
+    val entries = dir.toFile().list() ?: throw IOException("failed to list $dir")
     return entries.map { dir / it }
   }
 
   override fun source(file: Path): Source {
-    return file.file.source()
+    return file.toFile().source()
   }
 
   override fun sink(file: Path): Sink {
-    return file.file.sink()
+    return file.toFile().sink()
   }
 
-  override fun mkdir(dir: Path) {
-    if (!dir.file.mkdir()) throw IOException("failed to mkdir $dir")
+  override fun createDirectory(dir: Path) {
+    if (!dir.toFile().mkdir()) throw IOException("failed to mkdir $dir")
+  }
+
+  override fun atomicMove(source: Path, target: Path) {
+    try {
+      Files.move(source.toNioPath(), target.toNioPath(), ATOMIC_MOVE, REPLACE_EXISTING)
+    } catch (e: UnsupportedOperationException) {
+      throw IOException("atomic_move not supported")
+    }
   }
 }

--- a/okio-files/src/jvmMain/kotlin/okio/JvmSystemFilesystem.kt
+++ b/okio-files/src/jvmMain/kotlin/okio/JvmSystemFilesystem.kt
@@ -48,7 +48,7 @@ object JvmSystemFilesystem : Filesystem() {
     try {
       Files.move(source.toNioPath(), target.toNioPath(), ATOMIC_MOVE, REPLACE_EXISTING)
     } catch (e: UnsupportedOperationException) {
-      throw IOException("atomic_move not supported")
+      throw IOException("atomic move not supported")
     }
   }
 }

--- a/okio-files/src/jvmTest/kotlin/okio/files/JvmSystemFilesystemTest.kt
+++ b/okio-files/src/jvmTest/kotlin/okio/files/JvmSystemFilesystemTest.kt
@@ -22,7 +22,8 @@ import kotlin.test.Test
 
 class JvmSystemFilesystemTest {
   @Test
-  fun `cwd consistent with java io File`() {
-    assertThat(Filesystem.SYSTEM.cwd().toString()).isEqualTo(File("").absoluteFile.toString())
+  fun `base directory consistent with java io File`() {
+    assertThat(Filesystem.SYSTEM.baseDirectory().toString())
+      .isEqualTo(File("").absoluteFile.toString())
   }
 }


### PR DESCRIPTION
I didn't implement the full move operation that works across filesystems.
That would be some straightforward code to copy a source file to a target
file using our existing source() and sink() abstractions. But it would also
require some not-straightforward code to copy other metadata such as file
permissions, created and modified dates, and extended attributes. That
method has awkward behavior in partial failures; the source file exists
and the target file does too, but possibly partially.

In real application code my preferred way of doing this would be a
copy to a temporary file on the target filesystem followed by an
atomic move of the temp file on that filesystem. This way if the
move fails partially the target file doesn't exist. Unfortunately
that strategy isn't appropriate for Okio because it potentially
leaves a temporary file behind with no mechanism to clean it up.

Punting to the developer is okay for now; we may want to offer
a userspace  sample or built-in function that
does some or all of the above.