### PR TITLE
Introduce Timeout.waitUntil(monitor, condition: () -> Boolean)

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/Pipe.kt
+++ b/okio/src/jvmMain/kotlin/okio/Pipe.kt
@@ -57,10 +57,7 @@ class Pipe(internal val maxBufferSize: Long) {
 
         while (byteCount > 0) {
           timeout.waitUntil(buffer) {
-            maxBufferSize - buffer.size > 0L // The source has drained the buffer
-              || canceled
-              || sourceClosed
-              || foldedSink != null // fold was called
+            maxBufferSize - buffer.size > 0L || canceled || sourceClosed || foldedSink != null
           }
 
           foldedSink?.let {

--- a/okio/src/jvmMain/kotlin/okio/Timeout.kt
+++ b/okio/src/jvmMain/kotlin/okio/Timeout.kt
@@ -215,7 +215,7 @@ actual open class Timeout {
           (monitor as Object).wait()
         } else {
           val waitNanos = waitUntilNanos - System.nanoTime()
-          if ( waitNanos < 0) {
+          if (waitNanos < 0) {
             throw InterruptedIOException("timeout")
           }
           val waitMillis = waitNanos / 1000000L
@@ -226,7 +226,6 @@ actual open class Timeout {
       }
     }
   }
-
 
   /**
    * Applies the minimum intersection between this timeout and `other`, run `block`, then finally

--- a/okio/src/jvmTest/java/okio/PipeTest.java
+++ b/okio/src/jvmTest/java/okio/PipeTest.java
@@ -102,8 +102,6 @@ public final class PipeTest {
   }
 
   @Test public void sinkTimeout() throws Exception {
-    TestUtil.INSTANCE.assumeNotWindows();
-
     Pipe pipe = new Pipe(3);
     pipe.sink().timeout().timeout(1000, TimeUnit.MILLISECONDS);
     pipe.sink().write(new Buffer().writeUtf8("abc"), 3L);
@@ -122,8 +120,6 @@ public final class PipeTest {
   }
 
   @Test public void sourceTimeout() throws Exception {
-    TestUtil.INSTANCE.assumeNotWindows();
-
     Pipe pipe = new Pipe(3L);
     pipe.source().timeout().timeout(1000, TimeUnit.MILLISECONDS);
     double start = now();


### PR DESCRIPTION
Similar to `waitUntilNotified` except it accounts for spurious wake ups and bad timer resolutions. 

Use it in `Pipe` where the bad timer resolution on Windows could make the `Pipe` wait way longer than it should because the `wait` would return a few nanoseconds early very often and the read/write loop would continue looping, waiting several times the nominal Timeout value