### PR TITLE
Fix Android cipher issue

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -67,6 +67,8 @@ class CipherSink(
       SegmentPool.recycle(s)
     }
 
+    sink.emitCompleteSegments()
+
     // Mark those bytes as read.
     source.size -= size
     head.pos += size


### PR DESCRIPTION
The Android implementation of ciphers has a weird behaviour, which I would qualify as a bug. On updates to the ciphers, it throws a `ShortBufferException` if the output array is smaller than the value that it estimates through its internal call to `getOutputSizeForUpdate`, which is itself erroneous because it returns a value which is too high. 

Here's an example illustrating the issue. The error is thrown even though the requested size isn't actually needed.

```kotlin
@Test
fun testEncrypt() {
    val key = Random.nextBytes(32)
    val cipher = Cipher.getInstance("AES/CBC/PKCS7Padding").apply {
        init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"))
    }

    val input = Random.nextBytes(32)
    val output = ByteArray(16)
    var outputOffset = 0
    outputOffset += cipher.update(input, 0, 1, output, outputOffset) 
    // Here, outputOffset == 0, which is normal since no complete block has been processed
    outputOffset += cipher.update(input, 1, 16, output, outputOffset) 
    // throws `javax.crypto.ShortBufferException: output buffer too small during update: 16 < 32`
    // However if the output array is of length 32, outputOffset == 16, which is normal since a single complete block has been processed
}
```

This fix therefore removes from okio's `CipherSource` and `CipherSink` code the assumption that the output size is smaller or equal to the input size. The input size is shrunk until the output size is enough to work within a segment. Since the step used during the shrink is the block size, it should only take one step for that constraint to be met. 