### PR TITLE
Windows Paths

### DIFF
--- a/okio-files/src/commonMain/kotlin/okio/Filesystem.kt
+++ b/okio-files/src/commonMain/kotlin/okio/Filesystem.kt
@@ -36,6 +36,7 @@ abstract class Filesystem {
    *
    * @throws IOException if [path] does not exist or its metadata cannot be read.
    */
+  @Throws(IOException::class)
   abstract fun metadata(path: Path): FileMetadata
 
   /**


### PR DESCRIPTION
The big challenge in this design is how to offer different behavior
for Windows vs. UNIX paths without a lot of baggage in the API.
Developers shouldn't have to choose a PathScheme or something!
So instead we just use the first slash character (`/` or `\`) as
a hint.