### PR TITLE
Extract FakeFileSystem into a new okio-testing module

### DIFF
--- a/okio-files/build.gradle
+++ b/okio-files/build.gradle
@@ -13,7 +13,6 @@ kotlin {
     commonMain {
       dependencies {
         api deps.kotlin.stdLib.common
-        api deps.kotlin.time
         api project(":okio")
       }
     }
@@ -21,6 +20,8 @@ kotlin {
       dependencies {
         implementation deps.kotlin.test.common
         implementation deps.kotlin.test.annotations
+        implementation deps.kotlin.time
+        implementation project(":okio-testing")
       }
     }
     jvmMain {

--- a/okio-files/src/commonMain/kotlin/okio/Filesystem.kt
+++ b/okio-files/src/commonMain/kotlin/okio/Filesystem.kt
@@ -107,7 +107,13 @@ abstract class Filesystem {
    * @throws IOException if [source] cannot be read or if [target] cannot be written.
    */
   @Throws(IOException::class)
-  abstract fun copy(source: Path, target: Path)
+  open fun copy(source: Path, target: Path) {
+    source(source).use { bytesIn ->
+      sink(target).buffer().use { bytesOut ->
+        bytesOut.writeAll(bytesIn)
+      }
+    }
+  }
 
   /**
    * Deletes the file or directory at [path].

--- a/okio-files/src/commonMain/kotlin/okio/common.kt
+++ b/okio-files/src/commonMain/kotlin/okio/common.kt
@@ -15,17 +15,6 @@
  */
 package okio
 
-internal fun Filesystem.commonCopy(
-  source: Path,
-  target: Path
-) {
-  source(source).use { bytesIn ->
-    sink(target).buffer().use { bytesOut ->
-      bytesOut.writeAll(bytesIn)
-    }
-  }
-}
-
 internal inline fun <S : Source, T> S.use(block: (S) -> T): T {
   var result: T? = null
   var thrown: Throwable? = null

--- a/okio-files/src/commonTest/kotlin/okio/files/FakeFilesystemTest.kt
+++ b/okio-files/src/commonTest/kotlin/okio/files/FakeFilesystemTest.kt
@@ -17,9 +17,6 @@ package okio.files
 
 import okio.FakeFilesystem
 import okio.Path.Companion.toPath
-import okio.createdAt
-import okio.lastAccessedAt
-import okio.lastModifiedAt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/okio-files/src/commonTest/kotlin/okio/files/FileSystemTest.kt
+++ b/okio-files/src/commonTest/kotlin/okio/files/FileSystemTest.kt
@@ -25,9 +25,6 @@ import okio.IOException
 import okio.Path
 import okio.Path.Companion.toPath
 import okio.buffer
-import okio.createdAt
-import okio.lastAccessedAt
-import okio.lastModifiedAt
 import kotlin.random.Random
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore

--- a/okio-files/src/commonTest/kotlin/okio/files/time.kt
+++ b/okio-files/src/commonTest/kotlin/okio/files/time.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.files
+
+import kotlinx.datetime.Instant
+import okio.FileMetadata
+
+internal val FileMetadata.createdAt: Instant?
+  get() {
+    val createdAt = createdAtMillis ?: return null
+    return Instant.fromEpochMilliseconds(createdAt)
+  }
+
+internal val FileMetadata.lastModifiedAt: Instant?
+  get() {
+    val lastModifiedAt = lastModifiedAtMillis ?: return null
+    return Instant.fromEpochMilliseconds(lastModifiedAt)
+  }
+
+internal val FileMetadata.lastAccessedAt: Instant?
+  get() {
+    val lastAccessedAt = lastAccessedAtMillis ?: return null
+    return Instant.fromEpochMilliseconds(lastAccessedAt)
+  }

--- a/okio-files/src/jvmMain/kotlin/okio/JvmSystemFilesystem.kt
+++ b/okio-files/src/jvmMain/kotlin/okio/JvmSystemFilesystem.kt
@@ -84,13 +84,6 @@ object JvmSystemFilesystem : Filesystem() {
     }
   }
 
-  override fun copy(
-    source: Path,
-    target: Path
-  ) {
-    commonCopy(source, target)
-  }
-
   override fun delete(path: Path) {
     val deleted = path.toFile().delete()
     if (!deleted) throw IOException("failed to delete $path")

--- a/okio-files/src/posixMain/kotlin/okio/PosixSystemFilesystem.kt
+++ b/okio-files/src/posixMain/kotlin/okio/PosixSystemFilesystem.kt
@@ -98,13 +98,6 @@ internal object PosixSystemFilesystem : Filesystem() {
     }
   }
 
-  override fun copy(
-    source: Path,
-    target: Path
-  ) {
-    commonCopy(source, target)
-  }
-
   override fun delete(path: Path) {
     variantDelete(path)
   }

--- a/okio-testing/README.md
+++ b/okio-testing/README.md
@@ -1,0 +1,4 @@
+Okio Testing (pre-release)
+--------------------------
+
+This module contains test implementations of Okio types.

--- a/okio-testing/build.gradle
+++ b/okio-testing/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+
+kotlin {
+  jvm {
+    withJava()
+  }
+  if (kmpNativeEnabled) {
+    macosX64()
+    linuxX64()
+    mingwX64()
+  }
+  sourceSets {
+    commonMain {
+      dependencies {
+        api deps.kotlin.stdLib.common
+        api deps.kotlin.time
+        api project(":okio")
+        api project(":okio-files")
+      }
+    }
+  }
+}

--- a/okio-testing/gradle.properties
+++ b/okio-testing/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=okio-testing
+POM_NAME=Okio Testing

--- a/okio-testing/src/commonMain/kotlin/okio/FakeFilesystem.kt
+++ b/okio-testing/src/commonMain/kotlin/okio/FakeFilesystem.kt
@@ -137,10 +137,6 @@ class FakeFilesystem(
     elements[canonicalTarget] = removed
   }
 
-  override fun copy(source: Path, target: Path) {
-    commonCopy(source, target)
-  }
-
   override fun delete(path: Path) {
     val canonicalPath = root / path
 

--- a/okio-testing/src/commonMain/kotlin/okio/time.kt
+++ b/okio-testing/src/commonMain/kotlin/okio/time.kt
@@ -17,7 +17,7 @@ package okio
 
 import kotlinx.datetime.Instant
 
-fun FileMetadata(
+internal fun FileMetadata(
   isRegularFile: Boolean = false,
   isDirectory: Boolean = false,
   size: Long? = null,
@@ -34,21 +34,3 @@ fun FileMetadata(
     lastAccessedAtMillis = lastAccessedAt?.toEpochMilliseconds()
   )
 }
-
-val FileMetadata.createdAt: Instant?
-  get() {
-    val createdAt = createdAtMillis ?: return null
-    return Instant.fromEpochMilliseconds(createdAt)
-  }
-
-val FileMetadata.lastModifiedAt: Instant?
-  get() {
-    val lastModifiedAt = lastModifiedAtMillis ?: return null
-    return Instant.fromEpochMilliseconds(lastModifiedAt)
-  }
-
-val FileMetadata.lastAccessedAt: Instant?
-  get() {
-    val lastAccessedAt = lastAccessedAtMillis ?: return null
-    return Instant.fromEpochMilliseconds(lastAccessedAt)
-  }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include ':okio'
 include ':okio-files'
+include ':okio-testing'
 include ':okio:jvm:japicmp'
 include ':okio:jvm:jmh'
 include ':samples'


### PR DESCRIPTION
I want FakeFileSystem to depend on experimental APIs in kotlinx.datetime.
And I want to fold okio-files into the main okio module, where a dependency
on kotlinx.datetime would be too much.