### PR TITLE
Support Windows limitations in FakeFileSystem

### DIFF
--- a/okio-files/src/commonTest/kotlin/okio/files/FakeFilesystemTest.kt
+++ b/okio-files/src/commonTest/kotlin/okio/files/FakeFilesystemTest.kt
@@ -24,13 +24,27 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.minutes
 
 @ExperimentalTime
-class FakeFilesystemTest private constructor(clock: FakeClock) : FileSystemTest(
-  clock = clock,
-  filesystem = FakeFilesystem(clock),
-  temporaryDirectory = "/".toPath()
-) {
-  constructor() : this(FakeClock())
+class FakeWindowsFilesystemTest : FakeFilesystemTest(
+  clock = FakeClock(),
+  windowsLimitations = true
+)
 
+@ExperimentalTime
+class FakeUnixFilesystemTest : FakeFilesystemTest(
+  clock = FakeClock(),
+  windowsLimitations = false
+)
+
+@ExperimentalTime
+abstract class FakeFilesystemTest internal constructor(
+  clock: FakeClock,
+  windowsLimitations: Boolean
+) : AbstractFilesystemTest(
+  clock = clock,
+  filesystem = FakeFilesystem(clock, windowsLimitations),
+  windowsLimitations = windowsLimitations,
+  temporaryDirectory = "/".toPath(),
+) {
   private val fakeFilesystem: FakeFilesystem = filesystem as FakeFilesystem
   private val fakeClock: FakeClock = clock
 

--- a/okio-files/src/commonTest/kotlin/okio/files/SystemFilesystemTest.kt
+++ b/okio-files/src/commonTest/kotlin/okio/files/SystemFilesystemTest.kt
@@ -16,12 +16,14 @@
 package okio.files
 
 import kotlinx.datetime.Clock
+import okio.DIRECTORY_SEPARATOR
 import okio.Filesystem
 import kotlin.time.ExperimentalTime
 
 @ExperimentalTime
-class SystemFilesystemTest : FileSystemTest(
+class SystemFilesystemTest : AbstractFilesystemTest(
   clock = Clock.System,
   filesystem = Filesystem.SYSTEM,
+  windowsLimitations = DIRECTORY_SEPARATOR == "\\",
   temporaryDirectory = Filesystem.SYSTEM_TEMPORARY_DIRECTORY
 )


### PR DESCRIPTION
This moves tests from OkHttp's WindowsFileSystem, the fake that
will be obsoleted by this.