### PR TITLE
Fix atomicMove on Windows

### DIFF
--- a/okio-files/src/commonTest/kotlin/okio/files/AbstractFilesystemTest.kt
+++ b/okio-files/src/commonTest/kotlin/okio/files/AbstractFilesystemTest.kt
@@ -28,7 +28,6 @@ import okio.buffer
 import okio.use
 import kotlin.random.Random
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -184,7 +183,6 @@ abstract class AbstractFilesystemTest(
   }
 
   @Test
-  @Ignore // TODO(jwilson): Windows has different behavior for this test. Fix and re-enable.
   fun `atomicMove clobber existing file`() {
     val source = base / "source"
     source.writeUtf8("hello, world!")
@@ -217,13 +215,12 @@ abstract class AbstractFilesystemTest(
   }
 
   @Test
-  @Ignore // somehow the behaviour is different on windows
   fun `atomicMove source is directory and target is file`() {
     val source = base / "source"
     filesystem.createDirectory(source)
     val target = base / "target"
     target.writeUtf8("hello, world!")
-    assertFailsWith<IOException> {
+    expectIOExceptionOnEverythingButWindows {
       filesystem.atomicMove(source, target)
     }
   }
@@ -407,6 +404,15 @@ abstract class AbstractFilesystemTest(
       assertFalse(windowsLimitations)
     } catch (_: IOException) {
       assertTrue(windowsLimitations)
+    }
+  }
+
+  private fun expectIOExceptionOnEverythingButWindows(block: () -> Unit) {
+    try {
+      block()
+      assertTrue(windowsLimitations)
+    } catch (e: IOException) {
+      assertFalse(windowsLimitations)
     }
   }
 

--- a/okio-files/src/mingwX64Main/kotlin/okio/posixVariant.kt
+++ b/okio-files/src/mingwX64Main/kotlin/okio/posixVariant.kt
@@ -32,6 +32,8 @@ import platform.posix.free
 import platform.posix.mkdir
 import platform.posix.remove
 import platform.posix.rmdir
+import platform.windows.MOVEFILE_REPLACE_EXISTING
+import platform.windows.MoveFileExA
 
 internal actual val VARIANT_DIRECTORY_SEPARATOR = "\\"
 
@@ -79,5 +81,11 @@ internal actual fun PosixSystemFilesystem.variantMetadata(path: Path): FileMetad
       lastModifiedAtMillis = stat.st_mtime * 1000L,
       lastAccessedAtMillis = stat.st_atime * 1000L
     )
+  }
+}
+
+internal actual fun PosixSystemFilesystem.variantMove(source: Path, target: Path) {
+  if (MoveFileExA(source.toString(), target.toString(), MOVEFILE_REPLACE_EXISTING) == 0) {
+    throw IOException(lastErrorString())
   }
 }

--- a/okio-files/src/mingwX64Main/kotlin/okio/windows.kt
+++ b/okio-files/src/mingwX64Main/kotlin/okio/windows.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import kotlinx.cinterop.ByteVarOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import platform.windows.FORMAT_MESSAGE_FROM_SYSTEM
+import platform.windows.FORMAT_MESSAGE_IGNORE_INSERTS
+import platform.windows.FormatMessageA
+import platform.windows.GetLastError
+import platform.windows.LANG_NEUTRAL
+import platform.windows.SUBLANG_DEFAULT
+
+internal fun lastErrorString(): String {
+  val lastError = GetLastError()
+  memScoped {
+    val messageMaxSize = 2048
+    val message = allocArray<ByteVarOf<Byte>>(messageMaxSize)
+    FormatMessageA(
+      dwFlags = (FORMAT_MESSAGE_FROM_SYSTEM or FORMAT_MESSAGE_IGNORE_INSERTS).toUInt(),
+      lpSource = null,
+      dwMessageId = lastError,
+      dwLanguageId = (SUBLANG_DEFAULT * 1024 + LANG_NEUTRAL).toUInt(), // MAKELANGID macro.
+      lpBuffer = message,
+      nSize = messageMaxSize.toUInt(),
+      Arguments = null
+    )
+    return Buffer().writeNullTerminated(message).readUtf8().trim()
+  }
+}

--- a/okio-files/src/posixMain/kotlin/okio/PosixSystemFilesystem.kt
+++ b/okio-files/src/posixMain/kotlin/okio/PosixSystemFilesystem.kt
@@ -26,7 +26,6 @@ import platform.posix.errno
 import platform.posix.fopen
 import platform.posix.opendir
 import platform.posix.readdir
-import platform.posix.rename
 import platform.posix.set_posix_errno
 
 internal object PosixSystemFilesystem : Filesystem() {
@@ -92,10 +91,7 @@ internal object PosixSystemFilesystem : Filesystem() {
     source: Path,
     target: Path
   ) {
-    val result = rename(source.toString(), target.toString())
-    if (result != 0) {
-      throw IOException(errnoString(errno))
-    }
+    variantMove(source, target)
   }
 
   override fun delete(path: Path) {

--- a/okio-files/src/posixMain/kotlin/okio/posixVariant.kt
+++ b/okio-files/src/posixMain/kotlin/okio/posixVariant.kt
@@ -24,3 +24,5 @@ internal expect fun PosixSystemFilesystem.variantMkdir(dir: Path): Int
 internal expect fun PosixSystemFilesystem.variantCanonicalize(path: Path): Path
 
 internal expect fun PosixSystemFilesystem.variantMetadata(path: Path): FileMetadata
+
+internal expect fun PosixSystemFilesystem.variantMove(source: Path, target: Path)

--- a/okio-files/src/unixMain/kotlin/okio/posixVariant.kt
+++ b/okio-files/src/unixMain/kotlin/okio/posixVariant.kt
@@ -21,6 +21,7 @@ import platform.posix.free
 import platform.posix.mkdir
 import platform.posix.realpath
 import platform.posix.remove
+import platform.posix.rename
 import platform.posix.timespec
 
 internal actual val VARIANT_DIRECTORY_SEPARATOR = "/"
@@ -44,6 +45,16 @@ internal actual fun PosixSystemFilesystem.variantCanonicalize(path: Path): Path 
     return Buffer().writeNullTerminated(fullpath).toPath()
   } finally {
     free(fullpath)
+  }
+}
+
+internal actual fun PosixSystemFilesystem.variantMove(
+  source: Path,
+  target: Path
+) {
+  val result = rename(source.toString(), target.toString())
+  if (result != 0) {
+    throw IOException(errnoString(errno))
   }
 }
 


### PR DESCRIPTION
This now uses the Windows API and its corresponding error
reporting instead of the much nicer POSIX one.