### PR TITLE
Fix parent paths for Windows paths like C:\Windows

### DIFF
--- a/okio-files/src/commonTest/kotlin/okio/files/FakeFilesystemTest.kt
+++ b/okio-files/src/commonTest/kotlin/okio/files/FakeFilesystemTest.kt
@@ -16,6 +16,7 @@
 package okio.files
 
 import okio.FakeFilesystem
+import okio.Path
 import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -26,24 +27,27 @@ import kotlin.time.minutes
 @ExperimentalTime
 class FakeWindowsFilesystemTest : FakeFilesystemTest(
   clock = FakeClock(),
-  windowsLimitations = true
+  windowsLimitations = true,
+  temporaryDirectory = "C:\\".toPath(),
 )
 
 @ExperimentalTime
 class FakeUnixFilesystemTest : FakeFilesystemTest(
   clock = FakeClock(),
-  windowsLimitations = false
+  windowsLimitations = false,
+  temporaryDirectory = "/".toPath(),
 )
 
 @ExperimentalTime
 abstract class FakeFilesystemTest internal constructor(
   clock: FakeClock,
-  windowsLimitations: Boolean
+  windowsLimitations: Boolean,
+  temporaryDirectory: Path
 ) : AbstractFilesystemTest(
   clock = clock,
   filesystem = FakeFilesystem(clock, windowsLimitations),
   windowsLimitations = windowsLimitations,
-  temporaryDirectory = "/".toPath(),
+  temporaryDirectory = temporaryDirectory
 ) {
   private val fakeFilesystem: FakeFilesystem = filesystem as FakeFilesystem
   private val fakeClock: FakeClock = clock

--- a/okio-files/src/commonTest/kotlin/okio/files/PathTest.kt
+++ b/okio-files/src/commonTest/kotlin/okio/files/PathTest.kt
@@ -234,6 +234,20 @@ class PathTest {
   }
 
   @Test
+  fun `absolute volume letter path parent`() {
+    assertEquals(null, "C:\\".toPath("\\").parent)
+    assertEquals("C:\\".toPath("\\"), "C:\\Windows".toPath("\\").parent)
+    assertEquals("C:\\Windows".toPath("\\"), "C:\\Windows\\system32".toPath("\\").parent)
+  }
+
+  @Test
+  fun `relative volume letter path parent`() {
+    assertEquals(null, "C:".toPath("\\").parent)
+    assertEquals("C:".toPath("\\"), "C:hello".toPath("\\").parent)
+    assertEquals("C:hello".toPath("\\"), "C:hello\\world".toPath("\\").parent)
+  }
+
+  @Test
   fun `windows absolute path`() {
     assertEquals("\\Program Files", "\\Program Files".toPath().toString())
     assertEquals("\\Program Files\\Photoshop".toPath(), "\\Program Files".toPath() / "Photoshop")


### PR DESCRIPTION
Also support roots like C:\ in FakeFileSystem. These roots are created
on-demand.