### PR TITLE
Use custom wordmark in dokkaHtml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
       'kotlin': '1.4.20',
       'jmhPlugin': '0.5.0',
       'animalSnifferPlugin': '1.5.0',
-      'dokka': '1.4.0',
+      'dokka': '1.4.20',
       'jmh': '1.23',
       'animalSniffer': '1.16',
       'junit': '4.12',

--- a/docs/css/dokka-logo.css
+++ b/docs/css/dokka-logo.css
@@ -1,0 +1,6 @@
+#logo {
+    background-image: url(../images/logo-square.png);
+    background-size: auto;
+    padding-top: unset;
+    height: 60px;
+}

--- a/gradle/gradle-mvn-mpp-push.gradle
+++ b/gradle/gradle-mvn-mpp-push.gradle
@@ -11,11 +11,11 @@ def dokkaConfiguration = {
       skipDeprecated.set(true)
       jdkVersion.set(8)
       perPackageOption {
-        prefix.set("com.squareup.okio")
+        matchingRegex.set("com\\.squareup.okio.*")
         suppress.set(true)
       }
       perPackageOption {
-        prefix.set("okio.internal")
+        matchingRegex.set("okio\\.internal.*")
         suppress.set(true)
       }
     }
@@ -24,6 +24,14 @@ def dokkaConfiguration = {
 
 dokkaGfm.configure(dokkaConfiguration)
 dokkaHtml.configure(dokkaConfiguration)
+
+def rootRelativePath(path) {
+  return rootProject.file(path).toString().replace('\\', '/')
+}
+
+dokkaHtml.pluginsMapConfiguration.set([
+  "org.jetbrains.dokka.base.DokkaBase": """{ "customStyleSheets": ["${rootRelativePath("docs/css/dokka-logo.css")}"], "customAssets" : ["${rootRelativePath("docs/images/logo-square.png")}"]}"""
+])
 
 def isReleaseBuild() {
   return VERSION_NAME.contains("SNAPSHOT") == false


### PR DESCRIPTION
The latest version of Dokka allows you to add custom CSS and assets to the generated html, including the wordmark that is added to he top left of every page.

This commit replaces the default Dokka wordmark with `logo-square.png` which is already present in the repo. You'll probably want to use an different image that shows up better on a light background.

![Screenshot_2020-12-15 okio](https://user-images.githubusercontent.com/1109214/102286137-83d65d80-3eec-11eb-800f-3b2c22cb9b73.png)