### PR TITLE
publish okio-files

### DIFF
--- a/okio-files/build.gradle
+++ b/okio-files/build.gradle
@@ -61,3 +61,11 @@ kotlin {
     }
   }
 }
+
+apply from: "$rootDir/gradle/gradle-mvn-mpp-push.gradle"
+
+// Disable Dokka for now, there's an error while parsing tables
+// See https://github.com/Kotlin/dokka/issues/1592
+dokkaGfm.configure {
+  enabled = false
+}


### PR DESCRIPTION
Add `gradle-mvn-mpp-push` to `okio-files` so the artifacts end up in snapshots.

Currently, dokka is disabled because of https://github.com/Kotlin/dokka/issues/1592