### PR TITLE
Fix `okio-multiplatform` publication

### DIFF
--- a/gradle/gradle-mvn-mpp-push.gradle
+++ b/gradle/gradle-mvn-mpp-push.gradle
@@ -107,7 +107,7 @@ publishing {
   // Use default artifact name for the JVM target
   publications {
     kotlinMultiplatform {
-      artifactId = 'okio-multiplatform'
+      artifactId = POM_ARTIFACT_ID + '-multiplatform'
     }
     jvm {
       artifactId = 'okio'


### PR DESCRIPTION
Use `okio-files-multiplatform` for the okio-files multiplatform artifact so that it does not overwrite the regular `okio-multiplatform` artifact

Many thanks to @PaulWoitaschek for flagging this!