### PR TITLE
Read JVM artifact name from POM instead of hardcoding okio

### DIFF
--- a/gradle/gradle-mvn-mpp-push.gradle
+++ b/gradle/gradle-mvn-mpp-push.gradle
@@ -110,7 +110,7 @@ publishing {
       artifactId = POM_ARTIFACT_ID + '-multiplatform'
     }
     jvm {
-      artifactId = 'okio'
+      artifactId = POM_ARTIFACT_ID
     }
   }
 


### PR DESCRIPTION
This makes the same change as #842 but for the jvm artifact instead of the multiplatform one.