### PR TITLE
Fix a bug where FakeFilesystem.appendingSink cleared the file

### DIFF
--- a/okio-testing/src/commonMain/kotlin/okio/FakeFilesystem.kt
+++ b/okio-testing/src/commonMain/kotlin/okio/FakeFilesystem.kt
@@ -129,8 +129,8 @@ class FakeFilesystem(
     val regularFile = File(createdAt = existing?.createdAt ?: now)
     val result = FakeFileSink(canonicalPath, regularFile)
     if (append && existing is File) {
-      val existingBytes = Buffer().write(existing.data)
-      result.write(existingBytes, existingBytes.size)
+      result.buffer.write(existing.data)
+      regularFile.data = existing.data
     }
     elements[canonicalPath] = regularFile
     regularFile.access(now = now, modified = true)
@@ -284,7 +284,7 @@ class FakeFilesystem(
     private val path: Path,
     private val file: File
   ) : Sink {
-    private var buffer = Buffer()
+    val buffer = Buffer()
     private var closed = false
 
     override fun write(source: Buffer, byteCount: Long) {

--- a/okio/src/commonTest/kotlin/okio/AbstractFilesystemTest.kt
+++ b/okio/src/commonTest/kotlin/okio/AbstractFilesystemTest.kt
@@ -40,7 +40,7 @@ abstract class AbstractFilesystemTest(
   val windowsLimitations: Boolean,
   temporaryDirectory: Path
 ) {
-  val base: Path = temporaryDirectory / "FileSystemTest-${randomToken()}"
+  val base: Path = temporaryDirectory / "${this::class.simpleName}-${randomToken()}"
   private val isJs = filesystem::class.simpleName?.startsWith("NodeJs") ?: false
 
   @BeforeTest
@@ -125,6 +125,16 @@ abstract class AbstractFilesystemTest(
     sink.close()
     assertTrue(path in filesystem.list(base))
     assertEquals("hello, world!\nthis is added later!", path.readUtf8())
+  }
+
+  @Test
+  fun appendingSinkDoesNotImpactExistingFile() {
+    val path = base / "appending-sink-does-not-impact-existing-file"
+    path.writeUtf8("hello, world!\n")
+    val sink = filesystem.appendingSink(path)
+    assertEquals("hello, world!\n", path.readUtf8())
+    sink.close()
+    assertEquals("hello, world!\n", path.readUtf8())
   }
 
   @Test


### PR DESCRIPTION
It was restored on flush, but it should have been readable before that.