### PR TITLE
FakeFilesystem.checkNoOpenFiles() has better information

### DIFF
--- a/okio/src/commonMain/kotlin/okio/-Platform.kt
+++ b/okio/src/commonMain/kotlin/okio/-Platform.kt
@@ -25,6 +25,8 @@ expect class ArrayIndexOutOfBoundsException(message: String?) : IndexOutOfBounds
 
 internal expect inline fun <R> synchronized(lock: Any, block: () -> R): R
 
-expect open class IOException(message: String? = null) : Exception
+expect open class IOException(message: String?, cause: Throwable?) : Exception {
+  constructor(message: String? = null)
+}
 
 expect open class EOFException(message: String? = null) : IOException

--- a/okio/src/nonJvmMain/kotlin/okio/-Platform.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/-Platform.kt
@@ -29,6 +29,11 @@ actual open class ArrayIndexOutOfBoundsException actual constructor(
 
 internal actual inline fun <R> synchronized(lock: Any, block: () -> R): R = block()
 
-actual open class IOException actual constructor(message: String?) : Exception(message)
+actual open class IOException actual constructor(
+  message: String?,
+  cause: Throwable?
+) : Exception(message, cause) {
+  actual constructor(message: String?) : this(message, null)
+}
 
 actual open class EOFException actual constructor(message: String?) : IOException(message)


### PR DESCRIPTION
Including a stacktrace captured when the file was opened should
help to diagnose what fix is necessary.