### PR TITLE
Improve APIs for Java consumers

### DIFF
--- a/okio/src/commonMain/kotlin/okio/Filesystem.kt
+++ b/okio/src/commonMain/kotlin/okio/Filesystem.kt
@@ -15,6 +15,9 @@
  */
 package okio
 
+import okio.Filesystem.Companion.SYSTEM
+import kotlin.jvm.JvmField
+
 /**
  * Read and write access to a hierarchical collection of files, addressed by [paths][Path]. This
  * is a natural interface to the [current computer's local filesystem][SYSTEM].
@@ -205,14 +208,6 @@ abstract class Filesystem {
     }
   }
 
-  private fun isDirectory(dir: Path): Boolean {
-    return try {
-      metadata(dir).isDirectory
-    } catch (_: IOException) {
-      false // Maybe the file doesn't exist?
-    }
-  }
-
   /**
    * Moves [source] to [target] in-place if the underlying file system supports it. If [target]
    * exists, it is first removed. If `source == target`, this operation does nothing. This may be
@@ -328,8 +323,8 @@ abstract class Filesystem {
      * The current process's host filesystem. Use this instance directly, or dependency inject a
      * [Filesystem] to make code testable.
      */
-    val SYSTEM: Filesystem
-      get() = PLATFORM_FILESYSTEM
+    @JvmField
+    val SYSTEM: Filesystem = PLATFORM_FILESYSTEM
 
     /**
      * Returns a writable temporary directory on [SYSTEM].
@@ -340,7 +335,7 @@ abstract class Filesystem {
      *  * **Linux, iOS, and macOS**: the path in the `TMPDIR` environment variable.
      *  * **Windows**: the first non-null of `TEMP`, `TMP`, and `USERPROFILE` environment variables.
      */
-    val SYSTEM_TEMPORARY_DIRECTORY: Path
-      get() = PLATFORM_TEMPORARY_DIRECTORY
+    @JvmField
+    val SYSTEM_TEMPORARY_DIRECTORY: Path = PLATFORM_TEMPORARY_DIRECTORY
   }
 }

--- a/okio/src/commonMain/kotlin/okio/Path.kt
+++ b/okio/src/commonMain/kotlin/okio/Path.kt
@@ -18,6 +18,9 @@ package okio
 import okio.ByteString.Companion.EMPTY
 import okio.ByteString.Companion.encodeUtf8
 import okio.Path.Companion.toPath
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
 
 /**
  * A hierarchical address on a filesystem. A path is an identifier only; a [Filesystem] is required
@@ -129,6 +132,7 @@ class Path private constructor(
    * example, the path "C:notepad.exe" is relative to whatever the current working directory is on
    * the C: drive.
    */
+  @get:JvmName("volumeLetter")
   val volumeLetter: Char?
     get() {
       if (slash != BACKSLASH) return null
@@ -139,6 +143,7 @@ class Path private constructor(
       return c
     }
 
+  @get:JvmName("nameBytes")
   val nameBytes: ByteString
     get() {
       val lastSlash = bytes.lastIndexOf(slash)
@@ -149,6 +154,7 @@ class Path private constructor(
       }
     }
 
+  @get:JvmName("name")
   val name: String
     get() = nameBytes.utf8()
 
@@ -164,6 +170,7 @@ class Path private constructor(
    *  * A reference to the current working directory on a Windows volume (`C:`).
    *  * A series of relative paths (like `..` and `../..`).
    */
+  @get:JvmName("parent")
   val parent: Path?
     get() {
       if (bytes == DOT || bytes == slash || lastSegmentIsDotDot()) {
@@ -217,6 +224,7 @@ class Path private constructor(
    * If [child] is an [absolute path][isAbsolute] or [has a volume letter][hasVolumeLetter] then
    * this function is equivalent to `child.toPath()`.
    */
+  @JvmName("resolve")
   operator fun div(child: String): Path {
     return div(Buffer().writeUtf8(child).toPath(slash))
   }
@@ -227,6 +235,7 @@ class Path private constructor(
    * If [child] is an [absolute path][isAbsolute] or [has a volume letter][hasVolumeLetter] then
    * this function is equivalent to `child.toPath()`.
    */
+  @JvmName("resolve")
   operator fun div(child: Path): Path {
     if (child.isAbsolute || child.volumeLetter != null) return child
 
@@ -256,6 +265,7 @@ class Path private constructor(
 
     val directorySeparator = DIRECTORY_SEPARATOR
 
+    @JvmName("get") @JvmOverloads @JvmStatic
     fun String.toPath(directorySeparator: String? = null): Path =
       Buffer().writeUtf8(this).toPath(directorySeparator?.toSlash())
 

--- a/okio/src/commonTest/kotlin/okio/FakeFilesystemTest.kt
+++ b/okio/src/commonTest/kotlin/okio/FakeFilesystemTest.kt
@@ -47,7 +47,7 @@ abstract class FakeFilesystemTest internal constructor(
   temporaryDirectory: Path
 ) : AbstractFilesystemTest(
   clock = clock,
-  filesystem = FakeFilesystem(clock, windowsLimitations),
+  filesystem = FakeFilesystem(windowsLimitations, clock = clock),
   windowsLimitations = windowsLimitations,
   temporaryDirectory = temporaryDirectory
 ) {

--- a/okio/src/jsMain/kotlin/okio/Platform.kt
+++ b/okio/src/jsMain/kotlin/okio/Platform.kt
@@ -18,7 +18,8 @@ package okio
 import okio.Path.Companion.toPath
 
 @ExperimentalFilesystem
-internal actual val PLATFORM_FILESYSTEM: Filesystem = NodeJsSystemFilesystem
+internal actual val PLATFORM_FILESYSTEM: Filesystem
+  get() = NodeJsSystemFilesystem
 
 @ExperimentalFilesystem
 internal actual val PLATFORM_TEMPORARY_DIRECTORY: Path

--- a/okio/src/jvmMain/kotlin/okio/Platform.kt
+++ b/okio/src/jvmMain/kotlin/okio/Platform.kt
@@ -19,14 +19,15 @@ import okio.Path.Companion.toPath
 import java.io.File
 
 @ExperimentalFilesystem
-internal actual val PLATFORM_FILESYSTEM: Filesystem = run {
-  try {
-    Class.forName("java.nio.file.Files")
-    NioSystemFilesystem()
-  } catch (e: ClassNotFoundException) {
-    JvmSystemFilesystem()
+internal actual val PLATFORM_FILESYSTEM: Filesystem
+  get() {
+    try {
+      Class.forName("java.nio.file.Files")
+      return NioSystemFilesystem()
+    } catch (e: ClassNotFoundException) {
+      return JvmSystemFilesystem()
+    }
   }
-}
 
 @ExperimentalFilesystem
 internal actual val PLATFORM_TEMPORARY_DIRECTORY: Path

--- a/okio/src/jvmTest/java/okio/FilesystemJavaTest.java
+++ b/okio/src/jvmTest/java/okio/FilesystemJavaTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class FilesystemJavaTest {
+  @Test
+  public void pathApi() {
+    Path path = Path.get("/home/jesse/todo.txt");
+
+    assertThat(Path.get("/home/jesse").resolve("todo.txt")).isEqualTo(path);
+    assertThat(Path.get("/home/jesse/todo.txt", "/")).isEqualTo(path);
+    assertThat(path.isAbsolute()).isTrue();
+    assertThat(path.isRelative()).isFalse();
+    assertThat(path.isRoot()).isFalse();
+    assertThat(path.name()).isEqualTo("todo.txt");
+    assertThat(path.nameBytes()).isEqualTo(ByteString.encodeUtf8("todo.txt"));
+    assertThat(path.parent()).isEqualTo(Path.get("/home/jesse"));
+    assertThat(path.volumeLetter()).isNull();
+  }
+
+  @Test
+  public void filesystemApi() throws IOException {
+    assertThat(Filesystem.SYSTEM.metadata(Filesystem.SYSTEM_TEMPORARY_DIRECTORY)).isNotNull();
+  }
+
+  @Test
+  public void fakeFilesystemApi() {
+    FakeFilesystem fakeFilesystem = new FakeFilesystem();
+    assertThat(fakeFilesystem.clock).isNotNull();
+    assertThat(fakeFilesystem.allPaths()).isEmpty();
+    assertThat(fakeFilesystem.openPaths()).isEmpty();
+    fakeFilesystem.checkNoOpenFiles();
+  }
+
+  @Test
+  public void forwardingFilesystemApi() throws IOException {
+    FakeFilesystem fakeFilesystem = new FakeFilesystem();
+    final List<String> log = new ArrayList<>();
+    ForwardingFilesystem forwardingFilesystem = new ForwardingFilesystem(fakeFilesystem) {
+      @Override public Path onPathParameter(Path path, String functionName, String parameterName) {
+        log.add(functionName + "(" + parameterName + "=" + path + ")");
+        return path;
+      }
+    };
+    forwardingFilesystem.metadataOrNull(Path.get("/"));
+    assertThat(log).containsExactly("metadataOrNull(path=/)");
+  }
+}

--- a/okio/src/nativeMain/kotlin/okio/Platform.kt
+++ b/okio/src/nativeMain/kotlin/okio/Platform.kt
@@ -16,7 +16,8 @@
 package okio
 
 @ExperimentalFilesystem
-internal actual val PLATFORM_FILESYSTEM: Filesystem = PosixSystemFilesystem
+internal actual val PLATFORM_FILESYSTEM: Filesystem
+  get() = PosixSystemFilesystem
 
 internal actual val DIRECTORY_SEPARATOR
   get() = VARIANT_DIRECTORY_SEPARATOR


### PR DESCRIPTION
One gotcha with @ExperimentalFilesystem is that it doesn't impact Java callers.
We'll need to do that with documentation instead.