### PR TITLE
Redesign FakeFileSystem's Windows limitations

### DIFF
--- a/okio/src/commonTest/kotlin/okio/ForwardingFileSystemTest.kt
+++ b/okio/src/commonTest/kotlin/okio/ForwardingFileSystemTest.kt
@@ -28,7 +28,7 @@ import kotlin.time.ExperimentalTime
 @ExperimentalFileSystem
 class ForwardingFileSystemTest : AbstractFileSystemTest(
   clock = Clock.System,
-  fileSystem = object : ForwardingFileSystem(FakeFileSystem()) {},
+  fileSystem = object : ForwardingFileSystem(FakeFileSystem().apply { emulateUnix() }) {},
   windowsLimitations = false,
   temporaryDirectory = "/".toPath()
 ) {


### PR DESCRIPTION
Instead of having a single windows-vs-UNIX option, introduce individual
options that describe specific behavior, and functions to select UNIX
and Windows' options as a combo.

This permits a follow-up to forbid reading while writing, and also to
forbid multiple concurrent writers.