### PR TITLE
Remove the slash property from Path

### DIFF
--- a/okio/src/commonMain/kotlin/okio/Path.kt
+++ b/okio/src/commonMain/kotlin/okio/Path.kt
@@ -135,8 +135,7 @@ import okio.Path.Companion.toPath
  * </table>
  */
 @ExperimentalFileSystem
-expect class Path internal constructor(slash: ByteString, bytes: ByteString) : Comparable<Path> {
-  internal val slash: ByteString
+expect class Path internal constructor(bytes: ByteString) : Comparable<Path> {
   internal val bytes: ByteString
 
   val isAbsolute: Boolean
@@ -207,7 +206,5 @@ expect class Path internal constructor(slash: ByteString, bytes: ByteString) : C
     val DIRECTORY_SEPARATOR: String
 
     fun String.toPath(): Path
-
-    fun String.toPath(directorySeparator: String?): Path
   }
 }

--- a/okio/src/commonTest/kotlin/okio/PathTest.kt
+++ b/okio/src/commonTest/kotlin/okio/PathTest.kt
@@ -19,6 +19,7 @@ import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -26,7 +27,7 @@ import kotlin.test.assertTrue
 class PathTest {
   @Test
   fun unixRoot() {
-    val path = "/".toPath("/")
+    val path = "/".toPath()
     assertEquals("/", path.toString())
     assertNull(path.parent)
     assertNull(path.volumeLetter)
@@ -37,9 +38,9 @@ class PathTest {
 
   @Test
   fun unixAbsolutePath() {
-    val path = "/home/jesse/todo.txt".toPath("/")
+    val path = "/home/jesse/todo.txt".toPath()
     assertEquals("/home/jesse/todo.txt", path.toString())
-    assertEquals("/home/jesse".toPath("/"), path.parent)
+    assertEquals("/home/jesse".toPath(), path.parent)
     assertNull(path.volumeLetter)
     assertEquals("todo.txt", path.name)
     assertTrue(path.isAbsolute)
@@ -48,9 +49,9 @@ class PathTest {
 
   @Test
   fun unixRelativePath() {
-    val path = "project/todo.txt".toPath("/")
+    val path = "project/todo.txt".toPath()
     assertEquals("project/todo.txt", path.toString())
-    assertEquals("project".toPath("/"), path.parent)
+    assertEquals("project".toPath(), path.parent)
     assertNull(path.volumeLetter)
     assertEquals("todo.txt", path.name)
     assertFalse(path.isAbsolute)
@@ -59,9 +60,9 @@ class PathTest {
 
   @Test
   fun unixRelativePathWithDots() {
-    val path = "../../project/todo.txt".toPath("/")
+    val path = "../../project/todo.txt".toPath()
     assertEquals("../../project/todo.txt", path.toString())
-    assertEquals("../../project".toPath("/"), path.parent)
+    assertEquals("../../project".toPath(), path.parent)
     assertNull(path.volumeLetter)
     assertEquals("todo.txt", path.name)
     assertFalse(path.isAbsolute)
@@ -70,7 +71,7 @@ class PathTest {
 
   @Test
   fun unixRelativeSeriesOfDotDots() {
-    val path = "../../..".toPath("/")
+    val path = "../../..".toPath()
     assertEquals("../../..", path.toString())
     assertNull(path.parent)
     assertNull(path.volumeLetter)
@@ -81,7 +82,7 @@ class PathTest {
 
   @Test
   fun unixAbsoluteSeriesOfDotDots() {
-    val path = "/../../..".toPath("/")
+    val path = "/../../..".toPath()
     assertEquals("/", path.toString())
     assertNull(path.parent)
     assertNull(path.volumeLetter)
@@ -92,7 +93,7 @@ class PathTest {
 
   @Test
   fun unixAbsoluteSingleDot() {
-    val path = "/.".toPath("/")
+    val path = "/.".toPath()
     assertEquals("/", path.toString())
     assertNull(path.parent)
     assertNull(path.volumeLetter)
@@ -103,7 +104,7 @@ class PathTest {
 
   @Test
   fun unixRelativeDoubleDots() {
-    val path = "..".toPath("/")
+    val path = "..".toPath()
     assertEquals("..", path.toString())
     assertNull(path.parent)
     assertNull(path.volumeLetter)
@@ -114,7 +115,7 @@ class PathTest {
 
   @Test
   fun unixRelativeSingleDot() {
-    val path = ".".toPath("/")
+    val path = ".".toPath()
     assertEquals(".", path.toString())
     assertNull(path.parent)
     assertNull(path.volumeLetter)
@@ -125,7 +126,7 @@ class PathTest {
 
   @Test
   fun windowsVolumeLetter() {
-    val path = "C:\\".toPath("\\")
+    val path = "C:\\".toPath()
     assertEquals("C:\\", path.toString())
     assertNull(path.parent)
     assertEquals('C', path.volumeLetter)
@@ -136,9 +137,9 @@ class PathTest {
 
   @Test
   fun windowsAbsolutePathWithVolumeLetter() {
-    val path = "C:\\Windows\\notepad.exe".toPath("\\")
+    val path = "C:\\Windows\\notepad.exe".toPath()
     assertEquals("C:\\Windows\\notepad.exe", path.toString())
-    assertEquals("C:\\Windows".toPath("\\"), path.parent)
+    assertEquals("C:\\Windows".toPath(), path.parent)
     assertEquals('C', path.volumeLetter)
     assertEquals("notepad.exe", path.name)
     assertTrue(path.isAbsolute)
@@ -147,7 +148,7 @@ class PathTest {
 
   @Test
   fun windowsAbsolutePath() {
-    val path = "\\".toPath("\\")
+    val path = "\\".toPath()
     assertEquals("\\", path.toString())
     assertEquals(null, path.parent)
     assertNull(path.volumeLetter)
@@ -158,9 +159,9 @@ class PathTest {
 
   @Test
   fun windowsAbsolutePathWithoutVolumeLetter() {
-    val path = "\\Windows\\notepad.exe".toPath("\\")
+    val path = "\\Windows\\notepad.exe".toPath()
     assertEquals("\\Windows\\notepad.exe", path.toString())
-    assertEquals("\\Windows".toPath("\\"), path.parent)
+    assertEquals("\\Windows".toPath(), path.parent)
     assertNull(path.volumeLetter)
     assertEquals("notepad.exe", path.name)
     assertTrue(path.isAbsolute)
@@ -169,9 +170,9 @@ class PathTest {
 
   @Test
   fun windowsRelativePathWithVolumeLetter() {
-    val path = "C:Windows\\notepad.exe".toPath("\\")
+    val path = "C:Windows\\notepad.exe".toPath()
     assertEquals("C:Windows\\notepad.exe", path.toString())
-    assertEquals("C:Windows".toPath("\\"), path.parent)
+    assertEquals("C:Windows".toPath(), path.parent)
     assertEquals('C', path.volumeLetter)
     assertEquals("notepad.exe", path.name)
     assertFalse(path.isAbsolute)
@@ -180,7 +181,7 @@ class PathTest {
 
   @Test
   fun windowsVolumeLetterRelative() {
-    val path = "C:".toPath("\\")
+    val path = "C:".toPath()
     assertEquals("C:", path.toString())
     assertNull(path.parent)
     assertEquals('C', path.volumeLetter)
@@ -191,9 +192,9 @@ class PathTest {
 
   @Test
   fun windowsRelativePath() {
-    val path = "Windows\\notepad.exe".toPath("\\")
+    val path = "Windows\\notepad.exe".toPath()
     assertEquals("Windows\\notepad.exe", path.toString())
-    assertEquals("Windows".toPath("\\"), path.parent)
+    assertEquals("Windows".toPath(), path.parent)
     assertNull(path.volumeLetter)
     assertEquals("notepad.exe", path.name)
     assertFalse(path.isAbsolute)
@@ -202,7 +203,7 @@ class PathTest {
 
   @Test
   fun windowsUncServer() {
-    val path = "\\\\server".toPath("\\")
+    val path = "\\\\server".toPath()
     assertEquals("\\\\server", path.toString())
     assertNull(path.parent)
     assertNull(path.volumeLetter)
@@ -213,9 +214,9 @@ class PathTest {
 
   @Test
   fun windowsUncAbsolutePath() {
-    val path = "\\\\server\\project\\notes.txt".toPath("\\")
+    val path = "\\\\server\\project\\notes.txt".toPath()
     assertEquals("\\\\server\\project\\notes.txt", path.toString())
-    assertEquals("\\\\server\\project".toPath("\\"), path.parent)
+    assertEquals("\\\\server\\project".toPath(), path.parent)
     assertNull(path.volumeLetter)
     assertEquals("notes.txt", path.name)
     assertTrue(path.isAbsolute)
@@ -233,28 +234,33 @@ class PathTest {
 
   @Test
   fun relativePathTraversalWithDivOperator() {
-    val cwd = ".".toPath("/")
-    assertEquals("home".toPath("/"), cwd / "home")
-    assertEquals("home/jesse".toPath("/"), cwd / "home" / "jesse")
-    assertEquals("home".toPath("/"), cwd / "home" / "jesse" / "..")
-    assertEquals("home/jake".toPath("/"), cwd / "home" / "jesse" / ".." / "jake")
+    val slash = Path.DIRECTORY_SEPARATOR
+    val cwd = ".".toPath()
+    assertEquals("home".toPath(), cwd / "home")
+    assertEquals("home${slash}jesse".toPath(), cwd / "home" / "jesse")
+    assertEquals("home".toPath(), cwd / "home" / "jesse" / "..")
+    assertEquals("home${slash}jake".toPath(), cwd / "home" / "jesse" / ".." / "jake")
   }
 
   @Test
   fun relativePathTraversalWithDots() {
-    val cwd = ".".toPath("/")
-    assertEquals("..".toPath("/"), cwd / "..")
-    assertEquals("../..".toPath("/"), cwd / ".." / "..")
-    assertEquals("../../etc".toPath("/"), cwd / ".." / ".." / "etc")
-    assertEquals("../../etc/passwd".toPath("/"), cwd / ".." / ".." / "etc" / "passwd")
+    val slash = Path.DIRECTORY_SEPARATOR
+    val cwd = ".".toPath()
+    assertEquals("..".toPath(), cwd / "..")
+    assertEquals("..$slash..".toPath(), cwd / ".." / "..")
+    assertEquals("..$slash..${slash}etc".toPath(), cwd / ".." / ".." / "etc")
+    assertEquals(
+      "..$slash..${slash}etc${slash}passwd".toPath(),
+      cwd / ".." / ".." / "etc" / "passwd"
+    )
   }
 
   @Test
   fun pathTraversalBaseIgnoredIfChildIsAnAbsolutePath() {
-    assertEquals("/home".toPath(), "".toPath("/") / "/home")
-    assertEquals("/home".toPath(), "relative".toPath("/") / "/home")
-    assertEquals("/home".toPath(), "/base".toPath("/") / "/home")
-    assertEquals("/home".toPath(), "/".toPath("/") / "/home")
+    assertEquals("/home".toPath(), "".toPath() / "/home")
+    assertEquals("/home".toPath(), "relative".toPath() / "/home")
+    assertEquals("/home".toPath(), "/base".toPath() / "/home")
+    assertEquals("/home".toPath(), "/".toPath() / "/home")
   }
 
   @Test
@@ -361,5 +367,17 @@ class PathTest {
   fun windowsPathTraversalUp() {
     assertEquals("C:\\z".toPath(), "C:\\x\\y\\..\\..\\..\\z".toPath())
     assertEquals("C:..\\z".toPath(), "C:x\\y\\..\\..\\..\\z".toPath())
+  }
+
+  @Test
+  fun samePathDifferentSlashesAreNotEqual() {
+    assertNotEquals("/a".toPath(), "\\b".toPath())
+    assertNotEquals("a/b".toPath(), "a\\b".toPath())
+  }
+
+  @Test
+  fun samePathNoSlashesAreEqual() {
+    assertEquals("a".toPath().parent!!, "a".toPath().parent!!)
+    assertEquals("a/b".toPath().parent!!, "a\\b".toPath().parent!!)
   }
 }

--- a/okio/src/jvmMain/kotlin/okio/Path.kt
+++ b/okio/src/jvmMain/kotlin/okio/Path.kt
@@ -35,7 +35,6 @@ import java.nio.file.Path as NioPath
 
 @ExperimentalFileSystem
 actual class Path internal actual constructor(
-  internal actual val slash: ByteString,
   internal actual val bytes: ByteString
 ) : Comparable<Path> {
   actual val isAbsolute: Boolean
@@ -92,9 +91,6 @@ actual class Path internal actual constructor(
 
     @JvmName("get") @JvmStatic
     actual fun String.toPath(): Path = commonToPath()
-
-    @JvmName("get") @JvmStatic
-    actual fun String.toPath(directorySeparator: String?): Path = commonToPath(directorySeparator)
 
     @JvmName("get") @JvmStatic
     fun File.toOkioPath(): Path = toString().toPath()

--- a/okio/src/jvmTest/java/okio/FileSystemJavaTest.java
+++ b/okio/src/jvmTest/java/okio/FileSystemJavaTest.java
@@ -31,7 +31,7 @@ public final class FileSystemJavaTest {
     Path path = Path.get("/home/jesse/todo.txt");
 
     assertThat(Path.get("/home/jesse").resolve("todo.txt")).isEqualTo(path);
-    assertThat(Path.get("/home/jesse/todo.txt", "/")).isEqualTo(path);
+    assertThat(Path.get("/home/jesse/todo.txt")).isEqualTo(path);
     assertThat(path.isAbsolute()).isTrue();
     assertThat(path.isRelative()).isFalse();
     assertThat(path.isRoot()).isFalse();

--- a/okio/src/nonJvmMain/kotlin/okio/Path.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/Path.kt
@@ -31,7 +31,6 @@ import okio.internal.commonVolumeLetter
 
 @ExperimentalFileSystem
 actual class Path internal actual constructor(
-  internal actual val slash: ByteString,
   internal actual val bytes: ByteString
 ) : Comparable<Path> {
   actual val isAbsolute: Boolean
@@ -71,7 +70,5 @@ actual class Path internal actual constructor(
     actual val DIRECTORY_SEPARATOR: String = PLATFORM_DIRECTORY_SEPARATOR
 
     actual fun String.toPath(): Path = commonToPath()
-
-    actual fun String.toPath(directorySeparator: String?): Path = commonToPath(directorySeparator)
   }
 }


### PR DESCRIPTION
This was an attempt to make Paths have a property that would
differentiate whether they follow Windows vs. UNIX rules. But
the consequence as that two relative paths, 'foo', and 'foo'
could be different because of the hidden state of the unused
slash.

Instead just look inside the path for the slash. In the case
where we're resolving two paths without either having any
slash characters internally, just use the platform slash.