### PR TITLE
Fix volume letter parsing in Windows Paths that contain forward slashes.

### DIFF
--- a/okio/src/commonMain/kotlin/okio/internal/Path.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/Path.kt
@@ -32,7 +32,7 @@ private val DOT_DOT = "..".encodeUtf8()
 internal inline fun Path.commonIsAbsolute(): Boolean {
   return bytes.startsWith(SLASH) ||
     bytes.startsWith(BACKSLASH) ||
-    (volumeLetter != null && bytes.size > 2 && bytes[2] == '\\'.toByte())
+    (volumeLetter != null && bytes.size > 2 && (bytes[2] == '\\'.toByte() || bytes[2] == '/'.toByte()))
 }
 
 @ExperimentalFileSystem
@@ -44,7 +44,6 @@ internal inline fun Path.commonIsRelative(): Boolean {
 @ExperimentalFileSystem
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun Path.commonVolumeLetter(): Char? {
-  if (bytes.indexOf(SLASH) != -1) return null
   if (bytes.size < 2) return null
   if (bytes[1] != ':'.toByte()) return null
   val c = bytes[0].toChar()

--- a/okio/src/commonTest/kotlin/okio/PathTest.kt
+++ b/okio/src/commonTest/kotlin/okio/PathTest.kt
@@ -147,6 +147,39 @@ class PathTest {
   }
 
   @Test
+  fun windowsAbsolutePathWithVolumeLetterForwardSlashes() {
+    val path = "C:/Windows/notepad.exe".toPath()
+    assertEquals("C:/Windows/notepad.exe", path.toString())
+    assertEquals("C:/Windows".toPath(), path.parent)
+    assertEquals('C', path.volumeLetter)
+    assertEquals("notepad.exe", path.name)
+    assertTrue(path.isAbsolute)
+    assertFalse(path.isRoot)
+  }
+
+  @Test
+  fun windowsAbsolutePathWithVolumeLetterMixedSlashesBackslashFirst() {
+    val path = "C:\\Windows/notepad.exe".toPath()
+    assertEquals("C:\\Windows\\notepad.exe", path.toString())
+    assertEquals("C:\\Windows".toPath(), path.parent)
+    assertEquals('C', path.volumeLetter)
+    assertEquals("notepad.exe", path.name)
+    assertTrue(path.isAbsolute)
+    assertFalse(path.isRoot)
+  }
+
+  @Test
+  fun windowsAbsolutePathWithVolumeLetterMixedSlashesSlashFirst() {
+    val path = "C:/Windows\\notepad.exe".toPath()
+    assertEquals("C:/Windows/notepad.exe", path.toString())
+    assertEquals("C:/Windows".toPath(), path.parent)
+    assertEquals('C', path.volumeLetter)
+    assertEquals("notepad.exe", path.name)
+    assertTrue(path.isAbsolute)
+    assertFalse(path.isRoot)
+  }
+
+  @Test
   fun windowsAbsolutePath() {
     val path = "\\".toPath()
     assertEquals("\\", path.toString())


### PR DESCRIPTION
#882 introduced a regression in Windows Path parsing. Windows allows forward slashes in path names, replacing them with backslashes as part of normalization (Here it's mentioned in [the Win32 docs for the `lpFileName` parameter][1], and [here it's mentioned for .NET][2]). `C:/foo` and `C:/foo\bar` are both valid Windows paths.

This PR removes the requirement for a backslash to be present for volume letters to be parsed.

Note that this doesn't fix the case of UNC paths that use forward slashes. A test like the following still fails:

```kotlin
@Test  fun windowsUncAbsolutePathForwardSlashes() {
  val path = "//server/project/notes.txt".toPath()
  assertEquals("//server/project/notes.txt", path.toString())
  assertEquals("//server/project".toPath(), path.parent)
  assertNull(path.volumeLetter)
  assertEquals("notes.txt", path.name)
  assertTrue(path.isAbsolute)
  assertFalse(path.isRoot)
}
```

Since `//foo` is valid as both a UNC path and a POSIX path, I don't believe paths like that can be parsed unambiguously without the notion of a system file separator or similar.

[1]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#parameters
[2]: https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats#canonicalize-separators