### PR TITLE
New zipfilesystem module and FixedLengthSource class

### DIFF
--- a/okio-zipfilesystem/README.md
+++ b/okio-zipfilesystem/README.md
@@ -1,0 +1,4 @@
+Okio Zip File System (pre-release)
+----------------------------------
+
+This module contains a file system that reads the contents of zip files.

--- a/okio-zipfilesystem/build.gradle
+++ b/okio-zipfilesystem/build.gradle
@@ -1,0 +1,33 @@
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+
+kotlin {
+  jvm {
+    withJava()
+  }
+  sourceSets {
+    commonMain {
+      dependencies {
+        api deps.kotlin.stdLib.common
+        api deps.kotlin.time
+        api project(":okio")
+      }
+    }
+    jvmTest {
+      dependencies {
+        implementation deps.test.junit
+        implementation deps.test.assertj
+        implementation deps.kotlin.test.jdk
+      }
+    }
+  }
+}
+
+// modify these lines for MANIFEST.MF properties or for specific bnd instructions
+project.ext.bndManifest = '''
+    Export-Package: okio.zipfilesystem
+    Automatic-Module-Name: okio.zipfilesystem
+    Bundle-SymbolicName: com.squareup.okio.zipfilesystem
+    '''
+
+apply from: "$rootDir/okio/jvm/jvm.gradle"
+apply from: "$rootDir/gradle/gradle-mvn-mpp-push.gradle"

--- a/okio-zipfilesystem/gradle.properties
+++ b/okio-zipfilesystem/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=okio-zipfilesystem
+POM_NAME=Okio Zip File System

--- a/okio-zipfilesystem/src/jvmMain/kotlin/okio/zipfilesystem/FixedLengthSource.kt
+++ b/okio-zipfilesystem/src/jvmMain/kotlin/okio/zipfilesystem/FixedLengthSource.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.zipfilesystem
+
+import okio.Buffer
+import okio.ForwardingSource
+import okio.IOException
+import okio.Source
+
+/**
+ * A source that returns [size] bytes of [delegate].
+ *
+ * This throws an [IOException] if the delegate returns fewer than [size] bytes.
+ *
+ * If [truncate] is true, this truncates to [size] bytes. Otherwise this requires that [delegate]
+ * will return exactly [size] bytes, and will throw an [IOException] if it doesn't.
+ */
+internal class FixedLengthSource(
+  delegate: Source,
+  private val size: Long,
+  private val truncate: Boolean
+) : ForwardingSource(delegate) {
+  private var bytesReceived = 0L
+
+  override fun read(sink: Buffer, byteCount: Long): Long {
+    // Figure out how many bytes to attempt to read.
+    //
+    // If we're truncating, we never attempt to read more than what's remaining.
+    //
+    // Otherwise we expect the underlying source to be exactly the promised size. Read as much as
+    // possible and throw an exception if too many bytes are returned.
+    val toRead = when {
+      bytesReceived > size -> 0L // Already read more than the promised size.
+      truncate -> {
+        val remaining = size - bytesReceived
+        if (remaining == 0L) return -1L // Already read exactly the promised size.
+        minOf(byteCount, remaining)
+      }
+      else -> byteCount
+    }
+
+    val result = super.read(sink, toRead)
+
+    if (result != -1L) bytesReceived += result
+
+    // Throw an exception if we received too few bytes or too many.
+    if ((bytesReceived < size && result == -1L) || bytesReceived > size) {
+      if (result > 0L && bytesReceived > size) {
+        // If we received bytes beyond the limit, don't return them to the caller.
+        sink.truncateToSize(sink.size - (bytesReceived - size))
+      }
+      throw IOException("expected $size bytes but got $bytesReceived")
+    }
+
+    return result
+  }
+
+  private fun Buffer.truncateToSize(newSize: Long) {
+    val scratch = Buffer()
+    scratch.writeAll(this)
+    write(scratch, newSize)
+    scratch.clear()
+  }
+}

--- a/okio-zipfilesystem/src/jvmTest/kotlin/okio/zipfilesystem/FixedLengthSourceTest.kt
+++ b/okio-zipfilesystem/src/jvmTest/kotlin/okio/zipfilesystem/FixedLengthSourceTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.zipfilesystem
+
+import okio.Buffer
+import okio.IOException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import kotlin.test.fail
+
+internal class FixedLengthSourceTest {
+  @Test
+  fun happyPathWithTruncate() {
+    val delegate = Buffer().writeUtf8("abcdefghijklmnop")
+    val fixedLengthSource = FixedLengthSource(delegate, 16, truncate = true)
+    val buffer = Buffer()
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(10L)
+    assertThat(buffer.readUtf8()).isEqualTo("abcdefghij")
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(6L)
+    assertThat(buffer.readUtf8()).isEqualTo("klmnop")
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(-1L)
+    assertThat(buffer.readUtf8()).isEqualTo("")
+  }
+
+  @Test
+  fun happyPathNoTruncate() {
+    val delegate = Buffer().writeUtf8("abcdefghijklmnop")
+    val fixedLengthSource = FixedLengthSource(delegate, 16, truncate = false)
+    val buffer = Buffer()
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(10L)
+    assertThat(buffer.readUtf8()).isEqualTo("abcdefghij")
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(6L)
+    assertThat(buffer.readUtf8()).isEqualTo("klmnop")
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(-1L)
+    assertThat(buffer.readUtf8()).isEqualTo("")
+  }
+
+  @Test
+  fun delegateTooLongWithTruncate() {
+    val delegate = Buffer().writeUtf8("abcdefghijklmnopqr")
+    val fixedLengthSource = FixedLengthSource(delegate, 16, truncate = true)
+    val buffer = Buffer()
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(10L)
+    assertThat(buffer.readUtf8()).isEqualTo("abcdefghij")
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(6L)
+    assertThat(buffer.readUtf8()).isEqualTo("klmnop")
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(-1L)
+    assertThat(buffer.readUtf8()).isEqualTo("")
+  }
+
+  @Test
+  fun delegateTooLongWithTruncateFencepost() {
+    val delegate = Buffer().writeUtf8("abcdefghijklmnop")
+    val fixedLengthSource = FixedLengthSource(delegate, 10, truncate = true)
+    val buffer = Buffer()
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(10L)
+    assertThat(buffer.readUtf8()).isEqualTo("abcdefghij")
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(-1L)
+    assertThat(buffer.readUtf8()).isEmpty()
+  }
+
+  @Test
+  fun delegateTooLongNoTruncate() {
+    val delegate = Buffer().writeUtf8("abcdefghijklmnopqr")
+    val fixedLengthSource = FixedLengthSource(delegate, 16, truncate = false)
+    val buffer = Buffer()
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(10L)
+    assertThat(buffer.readUtf8()).isEqualTo("abcdefghij")
+    try {
+      fixedLengthSource.read(buffer, 10L)
+      fail()
+    } catch (e: IOException) {
+      assertThat(e).hasMessage("expected 16 bytes but got 18")
+      assertThat(buffer.readUtf8()).isEqualTo("klmnop") // Doesn't produce too many bytes!
+    }
+    try {
+      fixedLengthSource.read(buffer, 10L)
+      fail()
+    } catch (e: IOException) {
+      assertThat(e).hasMessage("expected 16 bytes but got 18")
+      assertThat(buffer.readUtf8()).isEmpty() // Doesn't produce any bytes!
+    }
+  }
+
+  @Test
+  fun delegateTooLongNoTruncateFencepost() {
+    val delegate = Buffer().writeUtf8("abcdefghijklmnop")
+    val fixedLengthSource = FixedLengthSource(delegate, 10, truncate = false)
+    val buffer = Buffer()
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(10L)
+    assertThat(buffer.readUtf8()).isEqualTo("abcdefghij")
+    try {
+      fixedLengthSource.read(buffer, 10L)
+      fail()
+    } catch (e: IOException) {
+      assertThat(e).hasMessage("expected 10 bytes but got 16")
+      assertThat(buffer.readUtf8()).isEmpty() // Doesn't produce too many bytes!
+    }
+    try {
+      fixedLengthSource.read(buffer, 10L)
+      fail()
+    } catch (e: IOException) {
+      assertThat(e).hasMessage("expected 10 bytes but got 16")
+      assertThat(buffer.readUtf8()).isEmpty() // Doesn't produce any bytes!
+    }
+  }
+
+  @Test
+  fun delegateTooShortWithTruncate() {
+    val delegate = Buffer().writeUtf8("abcdefghijklmn")
+    val fixedLengthSource = FixedLengthSource(delegate, 16, truncate = true)
+    val buffer = Buffer()
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(10L)
+    assertThat(buffer.readUtf8()).isEqualTo("abcdefghij")
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(4L)
+    assertThat(buffer.readUtf8()).isEqualTo("klmn")
+    try {
+      fixedLengthSource.read(buffer, 10L)
+      fail()
+    } catch (e: IOException) {
+      assertThat(e).hasMessage("expected 16 bytes but got 14")
+    }
+    try {
+      fixedLengthSource.read(buffer, 10L)
+      fail()
+    } catch (e: IOException) {
+      assertThat(e).hasMessage("expected 16 bytes but got 14")
+    }
+  }
+
+  @Test
+  fun delegateTooShortNoTruncate() {
+    val delegate = Buffer().writeUtf8("abcdefghijklmn")
+    val fixedLengthSource = FixedLengthSource(delegate, 16, truncate = false)
+    val buffer = Buffer()
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(10L)
+    assertThat(buffer.readUtf8()).isEqualTo("abcdefghij")
+    assertThat(fixedLengthSource.read(buffer, 10L)).isEqualTo(4L)
+    assertThat(buffer.readUtf8()).isEqualTo("klmn")
+    try {
+      fixedLengthSource.read(buffer, 10L)
+      fail()
+    } catch (e: IOException) {
+      assertThat(e).hasMessage("expected 16 bytes but got 14")
+    }
+    try {
+      fixedLengthSource.read(buffer, 10L)
+      fail()
+    } catch (e: IOException) {
+      assertThat(e).hasMessage("expected 16 bytes but got 14")
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = 'okio-parent'
 
 include ':okio'
 include ':okio-fakefilesystem'
+include ':okio-zipfilesystem'
 include ':okio:jvm:japicmp'
 include ':okio:jvm:jmh'
 include ':samples'


### PR DESCRIPTION
The FixedLengthSource will be necessary with the ZIP implementation. When
reading an uncompressed slice we need to put a bound on the end of the
source. When reading a compressed slice we expect it to exhaust exactly
as expected.