### PR TITLE
Better tests for zip files

### DIFF
--- a/okio-zipfilesystem/build.gradle
+++ b/okio-zipfilesystem/build.gradle
@@ -17,6 +17,7 @@ kotlin {
         implementation deps.test.junit
         implementation deps.test.assertj
         implementation deps.kotlin.test.jdk
+        implementation deps.kotlin.time
       }
     }
   }

--- a/okio-zipfilesystem/src/jvmTest/kotlin/okio/zipfilesystem/ZipBuilder.kt
+++ b/okio-zipfilesystem/src/jvmTest/kotlin/okio/zipfilesystem/ZipBuilder.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.zipfilesystem
+
+import okio.ExperimentalFileSystem
+import okio.FileSystem
+import okio.Path
+import okio.buffer
+import okio.sink
+import org.junit.Assume.assumeTrue
+
+/**
+ * Execute the `zip` command line program to create reference zip files for testing.
+ *
+ * Unfortunately the `zip` command line is limited in its ability to create exactly the zip files
+ * we want for testing. In particular, the only way it will create zip64 archives is if the input
+ * file is received from a UNIX pipe. (In such cases the file length is unknown in advance, and so
+ * the tool uses zip64 for the possibility of a very large file.) Files received from a pipe are
+ * always named `-`.
+ */
+@ExperimentalFileSystem
+class ZipBuilder(
+  private val directory: Path
+) {
+  private val fileSystem = FileSystem.SYSTEM
+
+  val options = mutableListOf<String>()
+  val entries = mutableListOf<Entry>()
+  var archiveComment: String = ""
+
+  fun build(): Path {
+    assumeTrue("ZipBuilder doesn't work on Windows", Path.DIRECTORY_SEPARATOR == "/")
+
+    val archive = directory / "${randomToken()}.zip"
+    val anyZip64 = entries.any { it.zip64 }
+
+    require(!anyZip64 || entries.size == 1) {
+      "ZipBuilder permits at most one zip64 entry"
+    }
+    require(!anyZip64 || archiveComment.isEmpty()) {
+      "Cannot combine archiveComment with zip64"
+    }
+
+    val promptForComments = entries.any { it.comment.isNotEmpty() }
+    if (promptForComments) {
+      options += "--entry-comments"
+    }
+    if (archiveComment.isNotEmpty()) {
+      options += "--archive-comment"
+    }
+
+    val command = mutableListOf<String>()
+    command += "zip"
+    command += options
+    command += archive.toString()
+
+    for (entry in entries) {
+      if (!entry.zip64) {
+        val absolutePath = directory / entry.path
+        fileSystem.createDirectories(absolutePath.parent!!)
+
+        if (entry.directory) {
+          fileSystem.createDirectories(absolutePath)
+        } else {
+          fileSystem.write(absolutePath) {
+            writeUtf8(entry.content!!)
+          }
+        }
+
+        if (entry.modifiedAt != null) {
+          val exitCode = ProcessBuilder()
+            .command("touch", "-m", "-t", entry.modifiedAt, absolutePath.toString())
+            .apply { environment()["TZ"] = "UTC" }
+            .start()
+            .waitFor()
+          require(exitCode == 0)
+        }
+      }
+      command += entry.path
+    }
+
+    val process = ProcessBuilder()
+      .command(command)
+      .directory(directory.toFile())
+      .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+      .redirectError(ProcessBuilder.Redirect.INHERIT)
+      .start()
+
+    process.outputStream.sink().buffer().use { sink ->
+      if (anyZip64) {
+        sink.writeUtf8(entries.single().content!!)
+      }
+      if (promptForComments) {
+        for (entry in entries) {
+          sink.writeUtf8(entry.comment)
+          sink.writeUtf8("\n")
+          sink.flush()
+        }
+      }
+      sink.writeUtf8(archiveComment)
+    }
+
+    val result = process.waitFor()
+    require(result == 0) { "process failed: $command" }
+
+    return archive
+  }
+
+  class Entry(
+    val path: String,
+    val content: String? = null,
+    val directory: Boolean = false,
+    val comment: String = "",
+    val modifiedAt: String? = null,
+    val zip64: Boolean = false
+  ) {
+    init {
+      require(directory != (content != null)) { "must be a directory or have content" }
+      if (zip64) {
+        require(path == "-") { "zip64 file name must be '-'" }
+        require(comment == "") { "zip64 must not have comments" }
+        require(modifiedAt == null) { "zip64 must not have modifiedAt" }
+      }
+    }
+  }
+}

--- a/okio-zipfilesystem/src/jvmTest/kotlin/okio/zipfilesystem/ZipFileSystemTest.kt
+++ b/okio-zipfilesystem/src/jvmTest/kotlin/okio/zipfilesystem/ZipFileSystemTest.kt
@@ -1,18 +1,19 @@
 package okio.zipfilesystem
 
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone.Companion.currentSystemDefault
+import kotlinx.datetime.toInstant
 import okio.ByteString.Companion.toByteString
 import okio.ExperimentalFileSystem
 import okio.FileSystem
-import okio.Path
+import okio.IOException
 import okio.Path.Companion.toPath
-import okio.buffer
-import okio.sink
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
 import kotlin.random.Random
+import kotlin.test.assertFailsWith
 
 @ExperimentalFileSystem
 class ZipFileSystemTest {
@@ -25,13 +26,13 @@ class ZipFileSystemTest {
   }
 
   @Test
-  fun readFiles() {
-    val zipPath = base / "file.zip"
-    writeZipFile(
-      zipPath = zipPath,
-      "hello.txt" to "Hello World",
-      "directory/subdirectory/child.txt" to "Another file!",
-    )
+  fun zipWithFiles() {
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("hello.txt", "Hello World")
+        entries += ZipBuilder.Entry("directory/subdirectory/child.txt", "Another file!")
+      }
+      .build()
     val zipFileSystem = open(zipPath, fileSystem)
 
     assertThat(zipFileSystem.read("hello.txt".toPath()) { readUtf8() })
@@ -41,19 +42,326 @@ class ZipFileSystemTest {
       .isEqualTo("Another file!")
   }
 
-  private fun writeZipFile(zipPath: Path, vararg files: Pair<String, String>) {
-    fileSystem.write(zipPath) {
-      ZipOutputStream(this.outputStream()).use { zip ->
-        for ((entryName, entryContent) in files) {
-          zip.putNextEntry(ZipEntry(entryName))
-          zip.sink().buffer().apply {
-            writeUtf8(entryContent)
-            emit()
-          }
-        }
+  /**
+   * Note that the zip tool does not compress files that don't benefit from it. Examples above like
+   * 'Hello World' are stored, not deflated.
+   */
+  @Test
+  fun zipWithDeflate() {
+    val content = "Android\n".repeat(1000)
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("a.txt", content)
+        options += "--compression-method"
+        options += "deflate"
       }
+      .build()
+    assertThat(fileSystem.metadata(zipPath).size).isLessThan(content.length.toLong())
+    val zipFileSystem = open(zipPath, fileSystem)
+
+    assertThat(zipFileSystem.read("a.txt".toPath()) { readUtf8() })
+      .isEqualTo(content)
+  }
+
+  @Test
+  fun zipWithStore() {
+    val content = "Android\n".repeat(1000)
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("a.txt", content)
+        options += "--compression-method"
+        options += "store"
+      }
+      .build()
+    assertThat(fileSystem.metadata(zipPath).size).isGreaterThan(content.length.toLong())
+    val zipFileSystem = open(zipPath, fileSystem)
+
+    assertThat(zipFileSystem.read("a.txt".toPath()) { readUtf8() })
+      .isEqualTo(content)
+  }
+
+  /**
+   * Confirm we can read zip files that have file comments, even if these comments are not exposed
+   * in the public API.
+   */
+  @Test
+  fun zipWithFileComments() {
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("a.txt", "Android", comment = "A is for Android")
+        entries += ZipBuilder.Entry("b.txt", "Banana", comment = "B or not to Be")
+      }
+      .build()
+    val zipFileSystem = open(zipPath, fileSystem)
+
+    assertThat(zipFileSystem.read("a.txt".toPath()) { readUtf8() })
+      .isEqualTo("Android")
+
+    assertThat(zipFileSystem.read("b.txt".toPath()) { readUtf8() })
+      .isEqualTo("Banana")
+  }
+
+  @Test
+  fun zipWithFileModifiedDate() {
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("a.txt", "Android", modifiedAt = "200102030405.06")
+        entries += ZipBuilder.Entry("b.txt", "Banana", modifiedAt = "200908070605.04")
+      }
+      .build()
+    val zipFileSystem = open(zipPath, fileSystem)
+
+    zipFileSystem.metadata("a.txt".toPath())
+      .apply {
+        assertThat(isRegularFile).isTrue()
+        assertThat(isDirectory).isFalse()
+        assertThat(size).isEqualTo(7L)
+        assertThat(createdAtMillis).isNull()
+        assertThat(lastModifiedAtMillis).isEqualTo("2001-02-03T04:05:06Z".toEpochMillis())
+        assertThat(lastAccessedAtMillis).isNull()
+      }
+
+    zipFileSystem.metadata("b.txt".toPath())
+      .apply {
+        assertThat(isRegularFile).isTrue()
+        assertThat(isDirectory).isFalse()
+        assertThat(size).isEqualTo(6L)
+        assertThat(createdAtMillis).isNull()
+        assertThat(lastModifiedAtMillis).isEqualTo("2009-08-07T06:05:04Z".toEpochMillis())
+        assertThat(lastAccessedAtMillis).isNull()
+      }
+  }
+
+  /**
+   * Confirm handling the limitations of DOS dates as they're stored in zip files. The dates printed
+   * by the 'unzip' command don't have these limitations! When we implement support for NTFS and
+   * UNIX extensions neither should we.
+   */
+  @Test
+  fun zipWithFileOutOfBoundsModifiedDate() {
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("a.txt", "Android", modifiedAt = "197912310000.00")
+        entries += ZipBuilder.Entry("b.txt", "Banana", modifiedAt = "210801020000.00")
+      }
+      .build()
+    val zipFileSystem = open(zipPath, fileSystem)
+
+    // Lower than the lower bound (1980-01-01) returns the lower bound.
+    zipFileSystem.metadata("a.txt".toPath())
+      .apply {
+        assertThat(isRegularFile).isTrue()
+        assertThat(isDirectory).isFalse()
+        assertThat(size).isEqualTo(7L)
+        assertThat(createdAtMillis).isNull()
+        assertThat(lastModifiedAtMillis).isEqualTo("1980-01-01T00:00:00".toLocalEpochMillis())
+        assertThat(lastAccessedAtMillis).isNull()
+      }
+
+    // Greater than the upper bound (2108-01-01) wraps around.
+    zipFileSystem.metadata("b.txt".toPath())
+      .apply {
+        assertThat(isRegularFile).isTrue()
+        assertThat(isDirectory).isFalse()
+        assertThat(size).isEqualTo(6L)
+        assertThat(createdAtMillis).isNull()
+        assertThat(lastModifiedAtMillis).isEqualTo("1980-01-02T00:00:00Z".toEpochMillis())
+        assertThat(lastAccessedAtMillis).isNull()
+      }
+  }
+
+  /**
+   * Directories are optional in the zip file. But if we want metadata on them they must be stored.
+   * Note that this test adds the directories last; otherwise adding child files to them will cause
+   * their modified at times to change.
+   */
+  @Test
+  fun zipWithDirectoryModifiedDate() {
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("a/a.txt", "Android")
+        entries += ZipBuilder.Entry("a", directory = true, modifiedAt = "200102030405.06")
+        entries += ZipBuilder.Entry("b/b.txt", "Android")
+        entries += ZipBuilder.Entry("b", directory = true, modifiedAt = "200908070605.04")
+      }
+      .build()
+    val zipFileSystem = open(zipPath, fileSystem)
+
+    zipFileSystem.metadata("a".toPath())
+      .apply {
+        assertThat(isRegularFile).isFalse()
+        assertThat(isDirectory).isTrue()
+        assertThat(size).isNull()
+        assertThat(createdAtMillis).isNull()
+        assertThat(lastModifiedAtMillis).isEqualTo("2001-02-03T04:05:06Z".toEpochMillis())
+        assertThat(lastAccessedAtMillis).isNull()
+      }
+    assertThat(zipFileSystem.list("a".toPath())).containsExactly("/a/a.txt".toPath())
+
+    zipFileSystem.metadata("b".toPath())
+      .apply {
+        assertThat(isRegularFile).isFalse()
+        assertThat(isDirectory).isTrue()
+        assertThat(size).isNull()
+        assertThat(createdAtMillis).isNull()
+        assertThat(lastModifiedAtMillis).isEqualTo("2009-08-07T06:05:04Z".toEpochMillis())
+        assertThat(lastAccessedAtMillis).isNull()
+      }
+    assertThat(zipFileSystem.list("b".toPath())).containsExactly("/b/b.txt".toPath())
+  }
+
+  /** Build a very small zip file with just a single empty directory. */
+  @Test
+  fun zipWithEmptyDirectory() {
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("a", directory = true, modifiedAt = "200102030405.06")
+      }
+      .build()
+    val zipFileSystem = open(zipPath, fileSystem)
+
+    zipFileSystem.metadata("a".toPath())
+      .apply {
+        assertThat(isRegularFile).isFalse()
+        assertThat(isDirectory).isTrue()
+        assertThat(size).isNull()
+        assertThat(createdAtMillis).isNull()
+        assertThat(lastModifiedAtMillis).isEqualTo("2001-02-03T04:05:06Z".toEpochMillis())
+        assertThat(lastAccessedAtMillis).isNull()
+      }
+    assertThat(zipFileSystem.list("a".toPath())).isEmpty()
+  }
+
+  /**
+   * The `--no-dir-entries` option causes the zip file to omit the directories from the encoded
+   * file. Our implementation synthesizes these missing directories automatically.
+   */
+  @Test
+  fun zipWithSyntheticDirectory() {
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("a/a.txt", "Android")
+        entries += ZipBuilder.Entry("a", directory = true, modifiedAt = "200102030405.06")
+        entries += ZipBuilder.Entry("b/b.txt", "Android")
+        entries += ZipBuilder.Entry("b", directory = true, modifiedAt = "200908070605.04")
+        options += "--no-dir-entries"
+      }
+      .build()
+    val zipFileSystem = open(zipPath, fileSystem)
+
+    zipFileSystem.metadata("a".toPath())
+      .apply {
+        assertThat(isRegularFile).isFalse()
+        assertThat(isDirectory).isTrue()
+        assertThat(size).isNull()
+        assertThat(createdAtMillis).isNull()
+        assertThat(lastModifiedAtMillis).isNull()
+        assertThat(lastAccessedAtMillis).isNull()
+      }
+    assertThat(zipFileSystem.list("a".toPath())).containsExactly("/a/a.txt".toPath())
+
+    zipFileSystem.metadata("b".toPath())
+      .apply {
+        assertThat(isRegularFile).isFalse()
+        assertThat(isDirectory).isTrue()
+        assertThat(size).isNull()
+        assertThat(createdAtMillis).isNull()
+        assertThat(lastModifiedAtMillis).isNull()
+        assertThat(lastAccessedAtMillis).isNull()
+      }
+    assertThat(zipFileSystem.list("b".toPath())).containsExactly("/b/b.txt".toPath())
+  }
+
+  /**
+   * Force a file to be encoded with zip64 metadata. We use a pipe to force the zip command to
+   * create a zip64 archive; otherwise we'd need to add a very large file to get this format.
+   */
+  @Test
+  fun zip64() {
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("-", "Android", zip64 = true)
+      }
+      .build()
+    val zipFileSystem = open(zipPath, fileSystem)
+
+    assertThat(zipFileSystem.read("-".toPath()) { readUtf8() })
+      .isEqualTo("Android")
+  }
+
+  /**
+   * Confirm we can read zip files with a full-archive comment, even if this comment is not surfaced
+   * in our API.
+   */
+  @Test
+  fun zipWithArchiveComment() {
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("a.txt", "Android")
+        archiveComment = "this comment applies to the entire archive"
+      }
+      .build()
+    val zipFileSystem = open(zipPath, fileSystem)
+
+    assertThat(zipFileSystem.read("a.txt".toPath()) { readUtf8() })
+      .isEqualTo("Android")
+  }
+
+  @Test
+  fun cannotReadZipWithSpanning() {
+    // Spanned archives must be at least 64 KiB.
+    val largeFile = randomToken(length = 128 * 1024)
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("large_file.txt", largeFile)
+        options += "--split-size"
+        options += "64k"
+      }
+      .build()
+    assertFailsWith<IOException> {
+      open(zipPath, fileSystem)
+    }
+  }
+
+  @Test
+  fun cannotReadZipWithEncryption() {
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("a.txt", "Android")
+        options += "--password"
+        options += "secret"
+      }
+      .build()
+    assertFailsWith<IOException> {
+      open(zipPath, fileSystem)
+    }
+  }
+
+  @Test
+  fun zipTooShort() {
+    val zipPath = ZipBuilder(base)
+      .apply {
+        entries += ZipBuilder.Entry("a.txt", "Android")
+      }
+      .build()
+
+    val prefix = fileSystem.read(zipPath) { readByteString(20) }
+    fileSystem.write(zipPath) { write(prefix) }
+
+    assertFailsWith<IOException> {
+      open(zipPath, fileSystem)
     }
   }
 }
 
-fun randomToken() = Random.nextBytes(16).toByteString(0, 16).hex()
+/** Decodes this ISO8601 time string. */
+fun String.toEpochMillis() = Instant.parse(this).toEpochMilliseconds()
+
+/** Decodes this ISO8601 local time string using the machine's time zone. */
+fun String.toLocalEpochMillis(): Long {
+  val localDateTime = LocalDateTime.parse(this)
+  val localInstant = localDateTime.toInstant(currentSystemDefault())
+  return localInstant.toEpochMilliseconds()
+}
+
+fun randomToken(length: Int = 16) = Random.nextBytes(length).toByteString().hex()


### PR DESCRIPTION
I've decided that I can't use Java's built-in zip APIs to create complete-enough
zip files. These APIs target a subset of the zip spec and can't create data rich
enough for a good test suite.

In follow-up it might be useful to commit these zip files rather than creating
them on-demand. That approach should also make it possible to test Windows-originated
zip files on UNIX and vice-versa.