### PR TITLE
Fix FakeFileSystem.list() to return relative paths

### DIFF
--- a/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
+++ b/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
@@ -228,6 +228,11 @@ class FakeFileSystem(
 
     element.access(now = clock.now())
     val paths = elements.keys.filterTo(mutableListOf()) { it.parent == canonicalPath }
+    if (dir.isRelative) {
+      for (i in paths.indices) {
+        paths[i] = dir / paths[i].name
+      }
+    }
     paths.sort()
     return paths
   }

--- a/okio/src/commonMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/commonMain/kotlin/okio/FileSystem.kt
@@ -133,7 +133,8 @@ abstract class FileSystem {
 
   /**
    * Returns the children of the directory identified by [dir]. The returned list is sorted using
-   * natural ordering.
+   * natural ordering. If [dir] is a relative path, the returned elements will also be relative
+   * paths. If it is an absolute path, the returned elements will also be absolute paths.
    *
    * @throws IOException if [dir] does not exist, is not a directory, or cannot be read. A directory
    *     cannot be read if the current process doesn't have access to [dir], or if there's a loop of

--- a/okio/src/commonTest/kotlin/okio/AbstractFileSystemTest.kt
+++ b/okio/src/commonTest/kotlin/okio/AbstractFileSystemTest.kt
@@ -78,6 +78,22 @@ abstract class AbstractFileSystemTest(
   }
 
   @Test
+  fun listOnRelativePathReturnsRelativePaths() {
+    // Make sure there's always at least one file so our assertion is useful.
+    if (fileSystem is FakeFileSystem) {
+      val workingDirectory = "/directory".toPath()
+      fileSystem.createDirectory(workingDirectory)
+      fileSystem.workingDirectory = workingDirectory
+      fileSystem.write("a.txt".toPath()) {
+        writeUtf8("hello, world!")
+      }
+    }
+
+    val entries = fileSystem.list(".".toPath())
+    assertTrue(entries.toString()) { entries.isNotEmpty() && entries.all { it.isRelative } }
+  }
+
+  @Test
   fun listResultsAreSorted() {
     val fileA = base / "a"
     val fileB = base / "b"


### PR DESCRIPTION
We were previously returning absolute paths always, even when the
input directory was a relative path.