### PR TITLE
FileHandle, for reading and writing, streaming and random access

### DIFF
--- a/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
+++ b/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
@@ -21,6 +21,7 @@ import okio.Buffer
 import okio.ByteString
 import okio.Cursor
 import okio.ExperimentalFileSystem
+import okio.FileHandle
 import okio.FileMetadata
 import okio.FileNotFoundException
 import okio.FileSystem
@@ -235,6 +236,10 @@ class FakeFileSystem(
     }
     paths.sort()
     return paths
+  }
+
+  override fun open(file: Path): FileHandle {
+    throw UnsupportedOperationException("not implemented yet!")
   }
 
   override fun source(file: Path): Source {

--- a/okio-nodefilesystem/src/jsMain/kotlin/okio/NodeJsFileSystem.kt
+++ b/okio-nodefilesystem/src/jsMain/kotlin/okio/NodeJsFileSystem.kt
@@ -86,6 +86,10 @@ object NodeJsFileSystem : FileSystem() {
     }
   }
 
+  override fun open(file: Path): FileHandle {
+    throw UnsupportedOperationException("not implemented yet!")
+  }
+
   override fun source(file: Path): Source {
     try {
       val fd = openSync(file.toString(), flags = "r")

--- a/okio-zipfilesystem/src/jvmMain/kotlin/okio/zipfilesystem/ZipFileSystem.kt
+++ b/okio-zipfilesystem/src/jvmMain/kotlin/okio/zipfilesystem/ZipFileSystem.kt
@@ -17,6 +17,7 @@
 package okio.zipfilesystem
 
 import okio.ExperimentalFileSystem
+import okio.FileHandle
 import okio.FileMetadata
 import okio.FileSystem
 import okio.InflaterSource
@@ -98,6 +99,10 @@ class ZipFileSystem internal constructor(
     val cursor = source.cursor()!!
     cursor.seek(entry.offset)
     return source.readLocalHeader(basicMetadata)
+  }
+
+  override fun open(file: Path): FileHandle {
+    throw UnsupportedOperationException("not implemented yet!")
   }
 
   override fun list(dir: Path): List<Path> {

--- a/okio/src/commonMain/kotlin/okio/FileHandle.kt
+++ b/okio/src/commonMain/kotlin/okio/FileHandle.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+/**
+ * An open file for reading and writing; using either streaming and random access.
+ *
+ * Use [read] and [write] to perform one-off random-access reads and writes. Use [source], [sink],
+ * and [appendingSink] for streaming reads and writes.
+ *
+ * File handles must be closed when they are no longer needed. It is an error to read, write, or
+ * create streams after a file handle is closed. The operating system resources held by a file
+ * handle will be released once the file handle **and** all of its streams are closed.
+ *
+ * Although this class offers both reading and writing APIs, file handle instances may be
+ * read-only or write-only. For example, a handle to a file on a read-only file system will throw an
+ * exception if a write is attempted.
+ *
+ * File handles may be used by multiple threads concurrently. But the individual sources and sinks
+ * produced by a file handle are not safe for concurrent use.
+ */
+@ExperimentalFileSystem
+abstract class FileHandle : Closeable {
+  /**
+   * True once the file handle is closed. Resources should be released with [closeInternal] once
+   * this is true and [openStreamCount] is 0.
+   */
+  private var closed = false
+
+  /**
+   * Reference count of the number of open sources and sinks on this file handle. Resources should
+   * be released with [closeInternal] once this is 0 and [closed] is true.
+   */
+  private var openStreamCount = 0
+
+  /**
+   * Removes at least 1, and up to [byteCount] bytes from this and appends them to [sink]. Returns
+   * the number of bytes read, or -1 if this file is exhausted.
+   */
+  @Throws(IOException::class)
+  abstract fun read(offset: Long, sink: Buffer, byteCount: Long): Long
+
+  /**
+   * Returns the total number of bytes in the file. This will change if the file size changes.
+   */
+  @Throws(IOException::class)
+  abstract fun size(): Long
+
+  /** Removes [byteCount] bytes from [source] and writes them to this at [offset]. */
+  @Throws(IOException::class)
+  abstract fun write(offset: Long, source: Buffer, byteCount: Long)
+
+  /** Pushes all buffered bytes to their final destination. */
+  @Throws(IOException::class)
+  abstract fun flush()
+
+  /**
+   * Returns a source that reads from this starting at [offset]. The returned source must be closed
+   * when it is no longer needed.
+   */
+  @Throws(IOException::class)
+  fun source(offset: Long = 0L): Source {
+    synchronized(this) {
+      check(!closed) { "closed" }
+      openStreamCount++
+    }
+    return FileHandleSource(this, offset)
+  }
+
+  /**
+   * Returns the position of [source] in the file. The argument [source] must be either a source
+   * produced by this file handle, or a [BufferedSource] that directly wraps such a source. If the
+   * parameter is a [BufferedSource], it adjusts for buffered bytes.
+   */
+  @Throws(IOException::class)
+  fun position(source: Source): Long {
+    var source = source
+    var bufferSize = 0L
+
+    if (source is RealBufferedSource) {
+      bufferSize = source.buffer.size
+      source = source.source
+    }
+
+    require(source is FileHandleSource && source.fileHandle === this) {
+      "source was not created by this FileHandle"
+    }
+
+    return source.position - bufferSize
+  }
+
+  /**
+   * Returns a sink that writes to this starting at [offset]. The returned sink must be closed when
+   * it is no longer needed.
+   */
+  @Throws(IOException::class)
+  fun sink(offset: Long = 0L): Sink {
+    synchronized(this) {
+      check(!closed) { "closed" }
+      openStreamCount++
+    }
+    return FileHandleSink(this, offset)
+  }
+
+  /**
+   * Returns a sink that writes to this starting at the end. The returned sink must be closed when
+   * it is no longer needed.
+   */
+  @Throws(IOException::class)
+  fun appendingSink(): Sink {
+    return sink(size())
+  }
+
+  /**
+   * Returns the position of [sink] in the file. The argument [sink] must be either a sink produced
+   * by this file handle, or a [BufferedSink] that directly wraps such a sink. If the parameter is a
+   * [BufferedSink], it adjusts for buffered bytes.
+   */
+  @Throws(IOException::class)
+  fun position(sink: Sink): Long {
+    var sink = sink
+    var bufferSize = 0L
+
+    if (sink is RealBufferedSink) {
+      bufferSize = sink.buffer.size
+      sink = sink.sink
+    }
+
+    require(sink is FileHandleSink && sink.fileHandle === this) {
+      "sink was not created by this FileHandle"
+    }
+
+    return sink.position + bufferSize
+  }
+
+  @Throws(IOException::class)
+  override fun close() {
+    synchronized(this) {
+      if (closed) return@close
+      closed = true
+      if (openStreamCount != 0) return@close
+    }
+    closeInternal()
+  }
+
+  /**
+   * Subclasses should implement this to release resources held by this file handle. It is invoked
+   * once both the file handle is closed, and also all sources and sinks produced by it are also
+   * closed.
+   */
+  @Throws(IOException::class)
+  protected abstract fun closeInternal()
+
+  private class FileHandleSink(
+    val fileHandle: FileHandle,
+    var position: Long
+  ) : Sink {
+    var closed = false
+
+    override fun write(source: Buffer, byteCount: Long) {
+      fileHandle.write(position, source, byteCount)
+      position += byteCount
+    }
+
+    override fun flush() {
+      fileHandle.flush()
+    }
+
+    override fun timeout() = Timeout.NONE
+
+    override fun close() {
+      synchronized(fileHandle) {
+        if (closed) return@close
+        closed = true
+        fileHandle.openStreamCount--
+        if (fileHandle.openStreamCount != 0 || !fileHandle.closed) return@close
+      }
+      fileHandle.closeInternal()
+    }
+  }
+
+  private class FileHandleSource(
+    val fileHandle: FileHandle,
+    var position: Long
+  ) : Source {
+    var closed = false
+
+    override fun read(sink: Buffer, byteCount: Long): Long {
+      val result = fileHandle.read(position, sink, byteCount)
+      if (result != -1L) position += result
+      return result
+    }
+
+    override fun timeout() = Timeout.NONE
+
+    override fun close() {
+      synchronized(fileHandle) {
+        if (closed) return@close
+        closed = true
+        fileHandle.openStreamCount--
+        if (fileHandle.openStreamCount != 0 || !fileHandle.closed) return@close
+      }
+      fileHandle.closeInternal()
+    }
+  }
+}

--- a/okio/src/commonMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/commonMain/kotlin/okio/FileSystem.kt
@@ -138,6 +138,16 @@ expect abstract class FileSystem() {
   abstract fun list(dir: Path): List<Path>
 
   /**
+   * Returns a handle to operate on [file].
+   *
+   * @throws IOException if [file] does not exist, is not a file, or cannot be accessed. A file
+   *     cannot be accessed if the current process doesn't have sufficient permissions for [file],
+   *     if there's a loop of symbolic links, or if any name is too long.
+   */
+  @Throws(IOException::class)
+  abstract fun open(file: Path): FileHandle
+
+  /**
    * Returns a source that reads the bytes of [file] from beginning to end.
    *
    * @throws IOException if [file] does not exist, is not a file, or cannot be read. A file cannot

--- a/okio/src/commonMain/kotlin/okio/ForwardingFileSystem.kt
+++ b/okio/src/commonMain/kotlin/okio/ForwardingFileSystem.kt
@@ -166,6 +166,12 @@ abstract class ForwardingFileSystem(
   }
 
   @Throws(IOException::class)
+  override fun open(file: Path): FileHandle {
+    val file = onPathParameter(file, "open", "file")
+    return delegate.open(file)
+  }
+
+  @Throws(IOException::class)
   override fun source(file: Path): Source {
     val file = onPathParameter(file, "source", "file")
     return delegate.source(file)

--- a/okio/src/jsMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/jsMain/kotlin/okio/FileSystem.kt
@@ -34,6 +34,8 @@ actual abstract class FileSystem {
 
   actual abstract fun list(dir: Path): List<Path>
 
+  actual abstract fun open(file: Path): FileHandle
+
   actual abstract fun source(file: Path): Source
 
   actual inline fun <T> read(file: Path, readerAction: BufferedSource.() -> T): T {

--- a/okio/src/jvmMain/kotlin/okio/JvmSystemFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmSystemFileSystem.kt
@@ -69,6 +69,10 @@ internal open class JvmSystemFileSystem : FileSystem() {
     return result
   }
 
+  override fun open(file: Path): FileHandle {
+    throw UnsupportedOperationException("not implemented yet!")
+  }
+
   override fun source(file: Path): Source {
     return file.toFile().source()
   }

--- a/okio/src/nativeMain/kotlin/okio/PosixFileSystem.kt
+++ b/okio/src/nativeMain/kotlin/okio/PosixFileSystem.kt
@@ -71,6 +71,10 @@ internal object PosixFileSystem : FileSystem() {
     }
   }
 
+  override fun open(file: Path): FileHandle {
+    throw UnsupportedOperationException("not implemented yet!")
+  }
+
   override fun source(file: Path): Source {
     val openFile: CPointer<FILE> = fopen(file.toString(), "r")
       ?: throw errnoToIOException(errno)

--- a/okio/src/nonJsMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/nonJsMain/kotlin/okio/FileSystem.kt
@@ -40,6 +40,9 @@ actual abstract class FileSystem {
   actual abstract fun list(dir: Path): List<Path>
 
   @Throws(IOException::class)
+  actual abstract fun open(file: Path): FileHandle
+
+  @Throws(IOException::class)
   actual abstract fun source(file: Path): Source
 
   @Throws(IOException::class)


### PR DESCRIPTION
I'm hoping to get something close to the underlying file descriptor or file
handle abstraction in POSIX.

I am unsatisfied with the design of okio.Cursor and how it will work with
random-access reading and writing. I'm hoping to make this the successor to
that class, and to completely delete that class from our public API.

I am planning a follow up PR on FileSystem, FileSystem.open(Path) that
returns a FileHandle. I will also make FileSystem.source() and
FileSystem.sink() all delegate to FileSystem.open().