### PR TITLE
Split open() into openReadOnly() and openReadWrite().

### DIFF
--- a/okio-nodefilesystem/src/jsMain/kotlin/okio/NodeJsFileSystem.kt
+++ b/okio-nodefilesystem/src/jsMain/kotlin/okio/NodeJsFileSystem.kt
@@ -86,11 +86,11 @@ object NodeJsFileSystem : FileSystem() {
     }
   }
 
-  override fun open(
-    file: Path,
-    read: Boolean,
-    write: Boolean
-  ): FileHandle {
+  override fun openReadOnly(file: Path): FileHandle {
+    throw UnsupportedOperationException("not implemented yet!")
+  }
+
+  override fun openReadWrite(file: Path): FileHandle {
     throw UnsupportedOperationException("not implemented yet!")
   }
 

--- a/okio/src/commonMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/commonMain/kotlin/okio/FileSystem.kt
@@ -138,18 +138,25 @@ expect abstract class FileSystem() {
   abstract fun list(dir: Path): List<Path>
 
   /**
-   * Returns a handle to operate on [file].
+   * Returns a handle to read [file]. This will fail if the file doesn't already exist.
    *
    * @throws IOException if [file] does not exist, is not a file, or cannot be accessed. A file
    *     cannot be accessed if the current process doesn't have sufficient permissions for [file],
    *     if there's a loop of symbolic links, or if any name is too long.
    */
   @Throws(IOException::class)
-  abstract fun open(
-    file: Path,
-    read: Boolean = false,
-    write: Boolean = false
-  ): FileHandle
+  abstract fun openReadOnly(file: Path): FileHandle
+
+  /**
+   * Returns a handle to read and write [file]. This will create the file if it doesn't already
+   * exist.
+   *
+   * @throws IOException if [file] is not a file, or cannot be accessed. A file cannot be accessed
+   *     if the current process doesn't have sufficient reading and writing permissions for [file],
+   *     if there's a loop of symbolic links, or if any name is too long.
+   */
+  @Throws(IOException::class)
+  abstract fun openReadWrite(file: Path): FileHandle
 
   /**
    * Returns a source that reads the bytes of [file] from beginning to end.

--- a/okio/src/commonMain/kotlin/okio/ForwardingFileSystem.kt
+++ b/okio/src/commonMain/kotlin/okio/ForwardingFileSystem.kt
@@ -166,13 +166,15 @@ abstract class ForwardingFileSystem(
   }
 
   @Throws(IOException::class)
-  override fun open(
-    file: Path,
-    read: Boolean,
-    write: Boolean
-  ): FileHandle {
-    val file = onPathParameter(file, "open", "file")
-    return delegate.open(file, read, write)
+  override fun openReadOnly(file: Path): FileHandle {
+    val file = onPathParameter(file, "openReadOnly", "file")
+    return delegate.openReadOnly(file)
+  }
+
+  @Throws(IOException::class)
+  override fun openReadWrite(file: Path): FileHandle {
+    val file = onPathParameter(file, "openReadWrite", "file")
+    return delegate.openReadWrite(file)
   }
 
   @Throws(IOException::class)

--- a/okio/src/jsMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/jsMain/kotlin/okio/FileSystem.kt
@@ -34,11 +34,9 @@ actual abstract class FileSystem {
 
   actual abstract fun list(dir: Path): List<Path>
 
-  actual abstract fun open(
-    file: Path,
-    read: Boolean,
-    write: Boolean
-  ): FileHandle
+  actual abstract fun openReadOnly(file: Path): FileHandle
+
+  actual abstract fun openReadWrite(file: Path): FileHandle
 
   actual abstract fun source(file: Path): Source
 

--- a/okio/src/jvmMain/kotlin/okio/JvmFileHandle.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmFileHandle.kt
@@ -19,10 +19,11 @@ import java.io.RandomAccessFile
 
 @ExperimentalFileSystem
 internal class JvmFileHandle(
+  readWrite: Boolean,
   private val randomAccessFile: RandomAccessFile
-) : FileHandle() {
+) : FileHandle(readWrite) {
   @Synchronized
-  override fun resize(size: Long) {
+  override fun protectedResize(size: Long) {
     val currentSize = size()
     val delta = size - currentSize
     if (delta > 0) {

--- a/okio/src/jvmMain/kotlin/okio/JvmSystemFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmSystemFileSystem.kt
@@ -70,17 +70,12 @@ internal open class JvmSystemFileSystem : FileSystem() {
     return result
   }
 
-  override fun open(
-    file: Path,
-    read: Boolean,
-    write: Boolean
-  ): FileHandle {
-    val mode = when {
-      write -> "rw"
-      read -> "r"
-      else -> throw IllegalArgumentException("unexpected open options read=$read write=$write")
-    }
-    return JvmFileHandle(RandomAccessFile(file.toFile(), mode))
+  override fun openReadOnly(file: Path): FileHandle {
+    return JvmFileHandle(readWrite = false, randomAccessFile = RandomAccessFile(file.toFile(), "r"))
+  }
+
+  override fun openReadWrite(file: Path): FileHandle {
+    return JvmFileHandle(readWrite = true, randomAccessFile = RandomAccessFile(file.toFile(), "rw"))
   }
 
   override fun source(file: Path): Source {

--- a/okio/src/jvmMain/kotlin/okio/ResourceFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/ResourceFileSystem.kt
@@ -47,18 +47,14 @@ class ResourceFileSystem internal constructor(
     return fileSystem.list(fileSystemPath).filterNot { it.name.endsWith(".class") }
   }
 
-  override fun open(
-    file: Path,
-    read: Boolean,
-    write: Boolean
-  ): FileHandle {
+  override fun openReadOnly(file: Path): FileHandle {
     val (fileSystem, fileSystemPath) = toSystemPath(file)
       ?: throw FileNotFoundException("file not found: $file")
-    return fileSystem.open(
-      file = fileSystemPath,
-      read = read,
-      write = write
-    )
+    return fileSystem.openReadOnly(file = fileSystemPath)
+  }
+
+  override fun openReadWrite(file: Path): FileHandle {
+    throw IOException("resources are not writable")
   }
 
   override fun metadataOrNull(path: Path): FileMetadata? {

--- a/okio/src/jvmMain/kotlin/okio/internal/zip.kt
+++ b/okio/src/jvmMain/kotlin/okio/internal/zip.kt
@@ -59,7 +59,7 @@ private const val HEADER_ID_EXTENDED_TIMESTAMP = 0x5455
 @Throws(IOException::class)
 @ExperimentalFileSystem
 internal fun openZip(zipPath: Path, fileSystem: FileSystem): ZipFileSystem {
-  fileSystem.open(zipPath, read = true).use { fileHandle ->
+  fileSystem.openReadOnly(zipPath).use { fileHandle ->
 
     fileHandle.source().buffer().use { source ->
       val firstFileSignature = source.readIntLe()

--- a/okio/src/jvmTest/kotlin/okio/FileHandleTestingFileSystem.kt
+++ b/okio/src/jvmTest/kotlin/okio/FileHandleTestingFileSystem.kt
@@ -37,20 +37,20 @@ class FileHandleFileSystemTest : AbstractFileSystemTest(
    */
   class FileHandleTestingFileSystem(delegate: FileSystem) : ForwardingFileSystem(delegate) {
     override fun source(file: Path): Source {
-      val fileHandle = open(file, read = true)
+      val fileHandle = openReadOnly(file)
       return fileHandle.source()
         .also { fileHandle.close() }
     }
 
     override fun sink(file: Path): Sink {
-      val fileHandle = open(file, write = true)
+      val fileHandle = openReadWrite(file)
       fileHandle.resize(0L) // If the file already has data, get rid of it.
       return fileHandle.sink()
         .also { fileHandle.close() }
     }
 
     override fun appendingSink(file: Path): Sink {
-      val fileHandle = open(file, write = true)
+      val fileHandle = openReadWrite(file)
       return fileHandle.appendingSink()
         .also { fileHandle.close() }
     }

--- a/okio/src/nativeMain/kotlin/okio/PosixFileSystem.kt
+++ b/okio/src/nativeMain/kotlin/okio/PosixFileSystem.kt
@@ -71,11 +71,11 @@ internal object PosixFileSystem : FileSystem() {
     }
   }
 
-  override fun open(
-    file: Path,
-    read: Boolean,
-    write: Boolean
-  ): FileHandle {
+  override fun openReadOnly(file: Path): FileHandle {
+    throw UnsupportedOperationException("not implemented yet!")
+  }
+
+  override fun openReadWrite(file: Path): FileHandle {
     throw UnsupportedOperationException("not implemented yet!")
   }
 

--- a/okio/src/nonJsMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/nonJsMain/kotlin/okio/FileSystem.kt
@@ -40,11 +40,10 @@ actual abstract class FileSystem {
   actual abstract fun list(dir: Path): List<Path>
 
   @Throws(IOException::class)
-  actual abstract fun open(
-    file: Path,
-    read: Boolean,
-    write: Boolean
-  ): FileHandle
+  actual abstract fun openReadOnly(file: Path): FileHandle
+
+  @Throws(IOException::class)
+  actual abstract fun openReadWrite(file: Path): FileHandle
 
   @Throws(IOException::class)
   actual abstract fun source(file: Path): Source


### PR DESCRIPTION
This is easier to use from Java (no boolean parameters). It also opens the
door to having a ReadWriteFileHandle subtype.