### PR TITLE
Fix using okio from background thread on Kotlin/Native targets

### DIFF
--- a/okio/build.gradle.kts
+++ b/okio/build.gradle.kts
@@ -1,4 +1,7 @@
 import aQute.bnd.gradle.BundleTaskConvention
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
 import ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferExtension
 
 plugins {
@@ -207,6 +210,20 @@ kotlin {
       }
       val linuxX64Test by getting {
         dependsOn(nativeTest)
+      }
+    }
+  }
+
+  targets.withType<KotlinNativeTargetWithTests<*>> {
+    binaries {
+      // Configure a separate test where code runs in background
+      test("background", setOf(NativeBuildType.DEBUG)) {
+        freeCompilerArgs += "-trw"
+      }
+    }
+    testRuns {
+      val background by creating {
+        setExecutionSourceFrom(binaries.getByName("backgroundDebugTest") as TestExecutable)
       }
     }
   }

--- a/okio/src/commonMain/kotlin/okio/-Base64.kt
+++ b/okio/src/commonMain/kotlin/okio/-Base64.kt
@@ -18,11 +18,14 @@
 package okio
 
 import okio.ByteString.Companion.encodeUtf8
+import kotlin.native.concurrent.SharedImmutable
 
 /** @author Alexander Y. Kleymenov */
 
+@SharedImmutable
 internal val BASE64 =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".encodeUtf8().data
+@SharedImmutable
 internal val BASE64_URL_SAFE =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".encodeUtf8().data
 

--- a/okio/src/commonMain/kotlin/okio/internal/-Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/-Buffer.kt
@@ -36,7 +36,9 @@ import okio.asUtf8ToByteArray
 import okio.checkOffsetAndCount
 import okio.minOf
 import okio.toHexString
+import kotlin.native.concurrent.SharedImmutable
 
+@SharedImmutable
 internal val HEX_DIGIT_BYTES = "0123456789abcdef".asUtf8ToByteArray()
 
 // Threshold determined empirically via ReadByteStringBenchmark

--- a/okio/src/commonMain/kotlin/okio/internal/-ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/-ByteString.kt
@@ -30,6 +30,7 @@ import okio.isIsoControl
 import okio.processUtf8CodePoints
 import okio.shr
 import okio.toUtf8String
+import kotlin.native.concurrent.SharedImmutable
 
 // TODO Kotlin's expect classes can't have default implementations, so platform implementations
 // have to call these functions. Remove all this nonsense when expect class allow actual code.
@@ -51,6 +52,7 @@ internal inline fun ByteString.commonBase64(): String = data.encodeBase64()
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun ByteString.commonBase64Url() = data.encodeBase64(map = BASE64_URL_SAFE)
 
+@SharedImmutable
 internal val HEX_DIGIT_CHARS =
   charArrayOf('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
 

--- a/okio/src/commonMain/kotlin/okio/internal/-Path.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/-Path.kt
@@ -20,11 +20,17 @@ import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import okio.ExperimentalFileSystem
 import okio.Path
+import kotlin.native.concurrent.SharedImmutable
 
+@SharedImmutable
 private val SLASH = "/".encodeUtf8()
+@SharedImmutable
 private val BACKSLASH = "\\".encodeUtf8()
+@SharedImmutable
 private val ANY_SLASH = "/\\".encodeUtf8()
+@SharedImmutable
 private val DOT = ".".encodeUtf8()
+@SharedImmutable
 private val DOT_DOT = "..".encodeUtf8()
 
 @ExperimentalFileSystem


### PR DESCRIPTION
- Marks all top level properties with `@SharedImmutabble` annotation in order to avoid error `kotlin.native.IncorrectDereferenceException: Trying to access top level value not marked as @ThreadLocal or @SharedImmutable from non-main thread
` when calling okio from background thread.
- Configure additional test tasks for native targets to run code in the background ([the same approach](https://github.com/Kotlin/kotlinx.coroutines/blob/1efc9f16a352632e6b632b4daab075ac882e661a/kotlinx-coroutines-core/build.gradle#L87-L102) was taken by kotlin.coroutines project).