### PR TITLE
Filter .class files from the ResourceFileSystem

### DIFF
--- a/okio/src/jvmTest/java/okio/ResourceFileSystemTest.kt
+++ b/okio/src/jvmTest/java/okio/ResourceFileSystemTest.kt
@@ -122,6 +122,12 @@ class ResourceFileSystemTest {
   }
 
   @Test
+  fun testClassFilesOmittedFromJar() {
+    assertThat(fileSystem.list("/org/junit/rules".toPath())).isEmpty()
+    assertThat(fileSystem.metadataOrNull("/org/junit/Test.class".toPath())).isNull()
+  }
+
+  @Test
   fun testDirectoryFromJar() {
     val path = "org/junit/".toPath()
 


### PR DESCRIPTION
The resource file system could drag a lot of data into memory.
Omitting .class files from the index should save space.

This prevents .class files from being opened directly. I think
that's okay.