### PR TITLE
Kotlin 1.5.20

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,7 +5,7 @@ val kmpJsEnabled = System.getProperty("kjs", "true").toBoolean()
 val kmpNativeEnabled = System.getProperty("knative", "true").toBoolean()
 
 object versions {
-  val kotlin = "1.4.20"
+  val kotlin = "1.5.20"
   val jmhPlugin = "0.5.0"
   val animalSnifferPlugin = "1.5.0"
   val dokka = "1.4.20"
@@ -46,7 +46,7 @@ object deps {
       val js = "org.jetbrains.kotlin:kotlin-test-js"
     }
 
-    val time = "org.jetbrains.kotlinx:kotlinx-datetime:0.1.1"
+    val time = "org.jetbrains.kotlinx:kotlinx-datetime:0.2.1"
   }
 
   object jmh {

--- a/okio/src/commonTest/kotlin/okio/AbstractFileSystemTest.kt
+++ b/okio/src/commonTest/kotlin/okio/AbstractFileSystemTest.kt
@@ -58,8 +58,8 @@ abstract class AbstractFileSystemTest(
     val cwdString = cwd.toString()
     assertTrue(cwdString) {
       cwdString.endsWith("okio${Path.DIRECTORY_SEPARATOR}okio") ||
-        cwdString.endsWith("${Path.DIRECTORY_SEPARATOR}okio-parent-okio-jsLegacy-test") ||
-        cwdString.endsWith("${Path.DIRECTORY_SEPARATOR}okio-parent-okio-jsIr-test") ||
+        cwdString.endsWith("${Path.DIRECTORY_SEPARATOR}okio-parent-okio-js-legacy-test") ||
+        cwdString.endsWith("${Path.DIRECTORY_SEPARATOR}okio-parent-okio-js-ir-test") ||
         cwdString.contains("/CoreSimulator/Devices/") || // iOS simulator.
         cwdString == "/" // Android emulator.
     }


### PR DESCRIPTION
Changelog:
- Updated versions.kotlin to 1.5.20
    - Changelog for 1.5.20: https://kotlinlang.org/docs/whatsnew1520.html
    - Changelog for 1.5.0: https://kotlinlang.org/docs/whatsnew15.html
    - Changelog for 1.4.30: https://kotlinlang.org/docs/whatsnew1430.html
- Updated kotlinx-datetime from 0.1.1 to 0.2.1 since Kotlin 1.5.0 depends on datetime > 0.2.0
    - Due to the changes to the experimental Duration inline value class
    - Changelog: https://github.com/Kotlin/kotlinx-datetime/blob/master/CHANGELOG.md#021
- Changed expected values in tests due to hardcoded values of some updates around Kotlin JS/IR and Legacy JS APIs

Closes: #947