### PR TITLE
Make ResourceFileSystem initialize lazily

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/FileSystem.kt
@@ -115,6 +115,9 @@ actual abstract class FileSystem {
      * resources of a specific class loader.
      */
     @JvmField
-    val RESOURCES: FileSystem = ResourceFileSystem(ResourceFileSystem::class.java.classLoader)
+    val RESOURCES: FileSystem = ResourceFileSystem(
+      classLoader = ResourceFileSystem::class.java.classLoader,
+      indexEagerly = false,
+    )
   }
 }

--- a/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
@@ -232,7 +232,7 @@ fun Source.hashingSource(digest: MessageDigest): HashingSource = HashingSource(t
 fun FileSystem.openZip(zipPath: Path): FileSystem = okio.internal.openZip(zipPath, this)
 
 @ExperimentalFileSystem
-fun ClassLoader.asResourceFileSystem(): FileSystem = ResourceFileSystem(this)
+fun ClassLoader.asResourceFileSystem(): FileSystem = ResourceFileSystem(this, indexEagerly = true)
 
 /**
  * Returns true if this error is due to a firmware bug fixed after Android 4.2.2.


### PR DESCRIPTION
My recent PRs to load all roots makes behavior better, but it causes the
file system to be initialized too eagerly. This makes every FileSystem user
pay for initialization of the ResourceFileSystem even if they don't use it.