### PR TITLE
Open files in binary mode on Windows

### DIFF
--- a/okio/src/commonMain/kotlin/okio/Path.kt
+++ b/okio/src/commonMain/kotlin/okio/Path.kt
@@ -203,6 +203,13 @@ expect class Path internal constructor(bytes: ByteString) : Comparable<Path> {
   override fun toString(): String
 
   companion object {
+    /**
+     * Either `/` (on UNIX-like systems including Android, iOS, and Linux) or `\` (on Windows
+     * systems).
+     *
+     * This separator is used by `FileSystem.SYSTEM` and possibly other file systems on the host
+     * system. Some file system implementations may not use this separator.
+     */
     val DIRECTORY_SEPARATOR: String
 
     fun String.toPath(): Path

--- a/okio/src/jvmMain/kotlin/okio/Path.kt
+++ b/okio/src/jvmMain/kotlin/okio/Path.kt
@@ -82,10 +82,6 @@ actual class Path internal actual constructor(
   actual override fun toString() = commonToString()
 
   actual companion object {
-    /**
-     * Either `/` (on UNIX-like systems including Android, iOS, and Linux) or `\` (on Windows
-     * systems).
-     */
     @JvmField
     actual val DIRECTORY_SEPARATOR: String = File.separator
 

--- a/okio/src/mingwX64Main/kotlin/okio/-WindowsPosixVariant.kt
+++ b/okio/src/mingwX64Main/kotlin/okio/-WindowsPosixVariant.kt
@@ -33,6 +33,7 @@ import platform.posix.S_IFREG
 import platform.posix._fullpath
 import platform.posix._stat64
 import platform.posix.errno
+import platform.posix.fopen
 import platform.posix.fread
 import platform.posix.free
 import platform.posix.fwrite
@@ -145,6 +146,27 @@ internal actual fun variantFwrite(
   file: CPointer<FILE>
 ): UInt {
   return fwrite(source, 1, byteCount.toULong(), file).toUInt()
+}
+
+@ExperimentalFileSystem
+internal actual fun PosixFileSystem.variantSource(file: Path): Source {
+  val openFile: CPointer<FILE> = fopen(file.toString(), "rb")
+    ?: throw errnoToIOException(errno)
+  return FileSource(openFile)
+}
+
+@ExperimentalFileSystem
+internal actual fun PosixFileSystem.variantSink(file: Path): Sink {
+  val openFile: CPointer<FILE> = fopen(file.toString(), "wb")
+    ?: throw errnoToIOException(errno)
+  return FileSink(openFile)
+}
+
+@ExperimentalFileSystem
+internal actual fun PosixFileSystem.variantAppendingSink(file: Path): Sink {
+  val openFile: CPointer<FILE> = fopen(file.toString(), "ab")
+    ?: throw errnoToIOException(errno)
+  return FileSink(openFile)
 }
 
 @ExperimentalFileSystem

--- a/okio/src/nativeMain/kotlin/okio/-PosixVariant.kt
+++ b/okio/src/nativeMain/kotlin/okio/-PosixVariant.kt
@@ -34,6 +34,15 @@ internal expect fun PosixFileSystem.variantMetadataOrNull(path: Path): FileMetad
 internal expect fun PosixFileSystem.variantMove(source: Path, target: Path)
 
 @ExperimentalFileSystem
+internal expect fun PosixFileSystem.variantSource(file: Path): Source
+
+@ExperimentalFileSystem
+internal expect fun PosixFileSystem.variantSink(file: Path): Sink
+
+@ExperimentalFileSystem
+internal expect fun PosixFileSystem.variantAppendingSink(file: Path): Sink
+
+@ExperimentalFileSystem
 internal expect fun PosixFileSystem.variantOpenReadOnly(file: Path): FileHandle
 
 @ExperimentalFileSystem

--- a/okio/src/nativeMain/kotlin/okio/PosixFileSystem.kt
+++ b/okio/src/nativeMain/kotlin/okio/PosixFileSystem.kt
@@ -20,11 +20,9 @@ import kotlinx.cinterop.get
 import okio.Path.Companion.toPath
 import okio.internal.toPath
 import platform.posix.DIR
-import platform.posix.FILE
 import platform.posix.closedir
 import platform.posix.dirent
 import platform.posix.errno
-import platform.posix.fopen
 import platform.posix.opendir
 import platform.posix.readdir
 import platform.posix.set_posix_errno
@@ -73,23 +71,11 @@ internal object PosixFileSystem : FileSystem() {
 
   override fun openReadWrite(file: Path) = variantOpenReadWrite(file)
 
-  override fun source(file: Path): Source {
-    val openFile: CPointer<FILE> = fopen(file.toString(), "r")
-      ?: throw errnoToIOException(errno)
-    return FileSource(openFile)
-  }
+  override fun source(file: Path) = variantSource(file)
 
-  override fun sink(file: Path): Sink {
-    val openFile: CPointer<FILE> = fopen(file.toString(), "w")
-      ?: throw errnoToIOException(errno)
-    return FileSink(openFile)
-  }
+  override fun sink(file: Path) = variantSink(file)
 
-  override fun appendingSink(file: Path): Sink {
-    val openFile: CPointer<FILE> = fopen(file.toString(), "a")
-      ?: throw errnoToIOException(errno)
-    return FileSink(openFile)
-  }
+  override fun appendingSink(file: Path) = variantAppendingSink(file)
 
   override fun createDirectory(dir: Path) {
     val result = variantMkdir(dir)

--- a/okio/src/unixMain/kotlin/okio/-UnixPosixVariant.kt
+++ b/okio/src/unixMain/kotlin/okio/-UnixPosixVariant.kt
@@ -79,6 +79,27 @@ internal actual fun PosixFileSystem.variantMove(
 }
 
 @ExperimentalFileSystem
+internal actual fun PosixFileSystem.variantSource(file: Path): Source {
+  val openFile: CPointer<FILE> = fopen(file.toString(), "r")
+    ?: throw errnoToIOException(errno)
+  return FileSource(openFile)
+}
+
+@ExperimentalFileSystem
+internal actual fun PosixFileSystem.variantSink(file: Path): Sink {
+  val openFile: CPointer<FILE> = fopen(file.toString(), "w")
+    ?: throw errnoToIOException(errno)
+  return FileSink(openFile)
+}
+
+@ExperimentalFileSystem
+internal actual fun PosixFileSystem.variantAppendingSink(file: Path): Sink {
+  val openFile: CPointer<FILE> = fopen(file.toString(), "a")
+    ?: throw errnoToIOException(errno)
+  return FileSink(openFile)
+}
+
+@ExperimentalFileSystem
 internal actual fun PosixFileSystem.variantOpenReadOnly(file: Path): FileHandle {
   val openFile: CPointer<FILE> = fopen(file.toString(), "r")
     ?: throw errnoToIOException(errno)


### PR DESCRIPTION
Without this, files that contain 0x1a will be prematurely terminated.

https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-160