### PR TITLE
ByteString.copyInto()

### DIFF
--- a/okio/src/commonMain/kotlin/okio/ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/ByteString.kt
@@ -133,6 +133,14 @@ internal constructor(data: ByteArray) : Comparable<ByteString> {
    */
   fun rangeEquals(offset: Int, other: ByteArray, otherOffset: Int, byteCount: Int): Boolean
 
+  /**
+   * Copies bytes of this in `[offset..offset+byteCount]` to other in
+   * `[targetOffset..targetOffset+byteCount]`.
+   *
+   * @throws IndexOutOfBoundsException if either range is out of bounds.
+   */
+  fun copyInto(offset: Int = 0, target: ByteArray, targetOffset: Int = 0, byteCount: Int)
+
   fun startsWith(prefix: ByteString): Boolean
 
   fun startsWith(prefix: ByteArray): Boolean

--- a/okio/src/commonMain/kotlin/okio/internal/-ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/-ByteString.kt
@@ -174,6 +174,16 @@ internal inline fun ByteString.commonRangeEquals(
 }
 
 @Suppress("NOTHING_TO_INLINE")
+internal inline fun ByteString.commonCopyInto(
+  offset: Int,
+  target: ByteArray,
+  targetOffset: Int,
+  byteCount: Int
+) {
+  data.copyInto(target, targetOffset, offset, offset + byteCount)
+}
+
+@Suppress("NOTHING_TO_INLINE")
 internal inline fun ByteString.commonStartsWith(prefix: ByteString) =
   rangeEquals(0, prefix, 0, prefix.size)
 

--- a/okio/src/commonMain/kotlin/okio/internal/-SegmentedByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/-SegmentedByteString.kt
@@ -201,6 +201,22 @@ internal inline fun SegmentedByteString.commonRangeEquals(
   return true
 }
 
+internal inline fun SegmentedByteString.commonCopyInto(
+  offset: Int,
+  target: ByteArray,
+  targetOffset: Int,
+  byteCount: Int
+) {
+  checkOffsetAndCount(size.toLong(), offset.toLong(), byteCount.toLong())
+  checkOffsetAndCount(target.size.toLong(), targetOffset.toLong(), byteCount.toLong())
+  // Go segment-by-segment through this, copying ranges of arrays.
+  var targetOffset = targetOffset
+  forEachSegment(offset, offset + byteCount) { data, offset, byteCount ->
+    data.copyInto(target, targetOffset, offset, offset + byteCount)
+    targetOffset += byteCount
+  }
+}
+
 internal inline fun SegmentedByteString.commonEquals(other: Any?): Boolean {
   return when {
     other === this -> true

--- a/okio/src/commonTest/kotlin/okio/ByteStringTest.kt
+++ b/okio/src/commonTest/kotlin/okio/ByteStringTest.kt
@@ -496,4 +496,73 @@ abstract class AbstractByteStringTest internal constructor(
     assertEquals("0e4dd66217fc8d2e298b78c8cd9392870dcd065d0ff675d0edff5bcd227837e9", sha256().hex())
     assertEquals("483676b93c4417198b465083d196ec6a9fab8d004515874b8ff47e041f5f56303cc08179625030b8b5b721c09149a18f0f59e64e7ae099518cea78d3d83167e1", sha512().hex())
   }
+
+  @Test fun copyInto() {
+    val byteString = factory.encodeUtf8("abcdefgh")
+    val byteArray = "WwwwXxxxYyyyZzzz".encodeToByteArray()
+    byteString.copyInto(target = byteArray, byteCount = 5)
+    assertEquals("abcdexxxYyyyZzzz", byteArray.decodeToString())
+  }
+
+  @Test fun copyIntoFullRange() {
+    val byteString = factory.encodeUtf8("abcdefghijklmnop")
+    val byteArray = "WwwwXxxxYyyyZzzz".encodeToByteArray()
+    byteString.copyInto(target = byteArray, byteCount = 16)
+    assertEquals("abcdefghijklmnop", byteArray.decodeToString())
+  }
+
+  @Test fun copyIntoWithTargetOffset() {
+    val byteString = factory.encodeUtf8("abcdefgh")
+    val byteArray = "WwwwXxxxYyyyZzzz".encodeToByteArray()
+    byteString.copyInto(target = byteArray, targetOffset = 11, byteCount = 5)
+    assertEquals("WwwwXxxxYyyabcde", byteArray.decodeToString())
+  }
+
+  @Test fun copyIntoWithSourceOffset() {
+    val byteString = factory.encodeUtf8("abcdefgh")
+    val byteArray = "WwwwXxxxYyyyZzzz".encodeToByteArray()
+    byteString.copyInto(offset = 3, target = byteArray, byteCount = 5)
+    assertEquals("defghxxxYyyyZzzz", byteArray.decodeToString())
+  }
+
+  @Test fun copyIntoWithAllParameters() {
+    val byteString = factory.encodeUtf8("abcdefgh")
+    val byteArray = "WwwwXxxxYyyyZzzz".encodeToByteArray()
+    byteString.copyInto(offset = 3, target = byteArray, targetOffset = 11, byteCount = 5)
+    assertEquals("WwwwXxxxYyydefgh", byteArray.decodeToString())
+  }
+
+  @Test fun copyIntoBoundsChecks() {
+    val byteString = factory.encodeUtf8("abcdefgh")
+    val byteArray = "WwwwXxxxYyyyZzzz".encodeToByteArray()
+    assertFailsWith<IndexOutOfBoundsException> {
+      byteString.copyInto(offset = -1, target = byteArray, targetOffset = 1, byteCount = 1)
+    }
+    assertFailsWith<IndexOutOfBoundsException> {
+      byteString.copyInto(offset = 9, target = byteArray, targetOffset = 0, byteCount = 0)
+    }
+    assertFailsWith<IndexOutOfBoundsException> {
+      byteString.copyInto(offset = 1, target = byteArray, targetOffset = -1, byteCount = 1)
+    }
+    assertFailsWith<IndexOutOfBoundsException> {
+      byteString.copyInto(offset = 1, target = byteArray, targetOffset = 17, byteCount = 1)
+    }
+    assertFailsWith<IndexOutOfBoundsException> {
+      byteString.copyInto(offset = 7, target = byteArray, targetOffset = 1, byteCount = 2)
+    }
+    assertFailsWith<IndexOutOfBoundsException> {
+      byteString.copyInto(offset = 1, target = byteArray, targetOffset = 15, byteCount = 2)
+    }
+  }
+
+  @Test fun copyEmptyAtBounds() {
+    val byteString = factory.encodeUtf8("abcdefgh")
+    val byteArray = "WwwwXxxxYyyyZzzz".encodeToByteArray()
+    byteString.copyInto(offset = 0, target = byteArray, targetOffset = 0, byteCount = 0)
+    assertEquals("WwwwXxxxYyyyZzzz", byteArray.decodeToString())
+    byteString.copyInto(offset = 0, target = byteArray, targetOffset = 16, byteCount = 0)
+    assertEquals("WwwwXxxxYyyyZzzz", byteArray.decodeToString())
+    byteString.copyInto(offset = 8, target = byteArray, targetOffset = 0, byteCount = 0)
+    assertEquals("WwwwXxxxYyyyZzzz", byteArray.decodeToString())
+  }
 }

--- a/okio/src/jvmMain/kotlin/okio/ByteString.kt
+++ b/okio/src/jvmMain/kotlin/okio/ByteString.kt
@@ -18,6 +18,7 @@ package okio
 import okio.internal.commonBase64
 import okio.internal.commonBase64Url
 import okio.internal.commonCompareTo
+import okio.internal.commonCopyInto
 import okio.internal.commonDecodeBase64
 import okio.internal.commonDecodeHex
 import okio.internal.commonEncodeUtf8
@@ -155,6 +156,13 @@ internal actual constructor(
     otherOffset: Int,
     byteCount: Int
   ): Boolean = commonRangeEquals(offset, other, otherOffset, byteCount)
+
+  actual open fun copyInto(
+    offset: Int,
+    target: ByteArray,
+    targetOffset: Int,
+    byteCount: Int
+  ) = commonCopyInto(offset, target, targetOffset, byteCount)
 
   actual fun startsWith(prefix: ByteString) = commonStartsWith(prefix)
 

--- a/okio/src/jvmMain/kotlin/okio/SegmentedByteString.kt
+++ b/okio/src/jvmMain/kotlin/okio/SegmentedByteString.kt
@@ -15,6 +15,7 @@
  */
 package okio
 
+import okio.internal.commonCopyInto
 import okio.internal.commonEquals
 import okio.internal.commonGetSize
 import okio.internal.commonHashCode
@@ -107,6 +108,13 @@ internal actual class SegmentedByteString internal actual constructor(
     otherOffset: Int,
     byteCount: Int
   ): Boolean = commonRangeEquals(offset, other, otherOffset, byteCount)
+
+  override fun copyInto(
+    offset: Int,
+    target: ByteArray,
+    targetOffset: Int,
+    byteCount: Int
+  ) = commonCopyInto(offset, target, targetOffset, byteCount)
 
   override fun indexOf(other: ByteArray, fromIndex: Int) = toByteString().indexOf(other, fromIndex)
 

--- a/okio/src/nonJvmMain/kotlin/okio/ByteString.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/ByteString.kt
@@ -25,6 +25,7 @@ import okio.internal.Sha512
 import okio.internal.commonBase64
 import okio.internal.commonBase64Url
 import okio.internal.commonCompareTo
+import okio.internal.commonCopyInto
 import okio.internal.commonDecodeBase64
 import okio.internal.commonDecodeHex
 import okio.internal.commonEncodeUtf8
@@ -134,6 +135,13 @@ internal actual constructor(
     otherOffset: Int,
     byteCount: Int
   ): Boolean = commonRangeEquals(offset, other, otherOffset, byteCount)
+
+  actual open fun copyInto(
+    offset: Int,
+    target: ByteArray,
+    targetOffset: Int,
+    byteCount: Int
+  ) = commonCopyInto(offset, target, targetOffset, byteCount)
 
   actual fun startsWith(prefix: ByteString) = commonStartsWith(prefix)
 

--- a/okio/src/nonJvmMain/kotlin/okio/SegmentedByteString.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/SegmentedByteString.kt
@@ -16,6 +16,7 @@
 package okio
 
 import okio.internal.HashFunction
+import okio.internal.commonCopyInto
 import okio.internal.commonEquals
 import okio.internal.commonGetSize
 import okio.internal.commonHashCode
@@ -66,6 +67,13 @@ internal actual class SegmentedByteString internal actual constructor(
     otherOffset: Int,
     byteCount: Int
   ): Boolean = commonRangeEquals(offset, other, otherOffset, byteCount)
+
+  override fun copyInto(
+    offset: Int,
+    target: ByteArray,
+    targetOffset: Int,
+    byteCount: Int
+  ) = commonCopyInto(offset, target, targetOffset, byteCount)
 
   override fun indexOf(other: ByteArray, fromIndex: Int) = toByteString().indexOf(other, fromIndex)
 


### PR DESCRIPTION
I have a use-case for this in Wire and doing an intermediate copy is not
appropriate.