### PR TITLE
Remove our custom ArrayIndexOutOfBoundsException

### DIFF
--- a/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
+++ b/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
@@ -17,7 +17,6 @@ package okio.fakefilesystem
 
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import okio.ArrayIndexOutOfBoundsException
 import okio.Buffer
 import okio.ByteString
 import okio.ExperimentalFileSystem

--- a/okio/src/commonMain/kotlin/okio/-CommonPlatform.kt
+++ b/okio/src/commonMain/kotlin/okio/-CommonPlatform.kt
@@ -20,9 +20,6 @@ internal expect fun ByteArray.toUtf8String(): String
 
 internal expect fun String.asUtf8ToByteArray(): ByteArray
 
-// TODO make internal https://youtrack.jetbrains.com/issue/KT-37316
-expect class ArrayIndexOutOfBoundsException(message: String?) : IndexOutOfBoundsException
-
 internal expect inline fun <R> synchronized(lock: Any, block: () -> R): R
 
 expect open class IOException(message: String?, cause: Throwable?) : Exception {

--- a/okio/src/commonMain/kotlin/okio/internal/-Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/-Buffer.kt
@@ -19,7 +19,6 @@
 
 package okio.internal
 
-import okio.ArrayIndexOutOfBoundsException
 import okio.Buffer
 import okio.Buffer.UnsafeCursor
 import okio.ByteString

--- a/okio/src/commonMain/kotlin/okio/internal/-Utf8.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/-Utf8.kt
@@ -16,7 +16,6 @@
 
 package okio.internal
 
-import okio.ArrayIndexOutOfBoundsException
 import okio.processUtf16Chars
 import okio.processUtf8Bytes
 

--- a/okio/src/jvmMain/kotlin/okio/-JvmPlatform.kt
+++ b/okio/src/jvmMain/kotlin/okio/-JvmPlatform.kt
@@ -20,9 +20,6 @@ internal actual fun ByteArray.toUtf8String(): String = String(this, Charsets.UTF
 
 internal actual fun String.asUtf8ToByteArray(): ByteArray = toByteArray(Charsets.UTF_8)
 
-// TODO remove if https://youtrack.jetbrains.com/issue/KT-20641 provides a better solution
-actual typealias ArrayIndexOutOfBoundsException = java.lang.ArrayIndexOutOfBoundsException
-
 internal actual inline fun <R> synchronized(lock: Any, block: () -> R): R {
   return kotlin.synchronized(lock, block)
 }

--- a/okio/src/nonJvmMain/kotlin/okio/-NonJvmPlatform.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/-NonJvmPlatform.kt
@@ -25,10 +25,6 @@ internal actual fun ByteArray.toUtf8String(): String = commonToUtf8String()
 
 internal actual fun String.asUtf8ToByteArray(): ByteArray = commonAsUtf8ToByteArray()
 
-actual open class ArrayIndexOutOfBoundsException actual constructor(
-  message: String?
-) : IndexOutOfBoundsException(message)
-
 internal actual inline fun <R> synchronized(lock: Any, block: () -> R): R = block()
 
 actual open class IOException actual constructor(


### PR DESCRIPTION
This is binary-compatible on the JVM where the type was
already aliased to the real thing.

On native this is not a backwards-compatible change.