### PR TITLE
Upgrade to Kotlin 1.5.31

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,7 +5,7 @@ val kmpJsEnabled = System.getProperty("kjs", "true").toBoolean()
 val kmpNativeEnabled = System.getProperty("knative", "true").toBoolean()
 
 object versions {
-  const val kotlin = "1.5.30"
+  const val kotlin = "1.5.31"
   const val jmh = "1.33"
   const val ktlint = "0.42.1"
 }


### PR DESCRIPTION
This is great for downstream projects as kotlin.test is broken on
1.5.21 (multiplatform packaging issue) and the compiler is broken
on 1.5.30 (defaultfield verify error). With 1.5.31 everything should
work all on the same version.