### PR TITLE
Implement support for creating and traversing symlinks

### DIFF
--- a/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
+++ b/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
@@ -32,6 +32,7 @@ import okio.Sink
 import okio.Source
 import okio.fakefilesystem.FakeFileSystem.Element.Directory
 import okio.fakefilesystem.FakeFileSystem.Element.File
+import okio.fakefilesystem.FakeFileSystem.Element.Symlink
 import okio.fakefilesystem.FakeFileSystem.Operation.READ
 import okio.fakefilesystem.FakeFileSystem.Operation.WRITE
 import kotlin.jvm.JvmField
@@ -47,8 +48,7 @@ import kotlin.jvm.JvmName
  * Strict By Default
  * -----------------
  *
- * By default this file system is strict. These actions are not allowed and throw an [IOException]
- * if attempted:
+ * These actions are not allowed and throw an [IOException] if attempted:
  *
  *  * Moving a file that is currently open for reading or writing.
  *  * Deleting a file that is currently open for reading or writing.
@@ -66,8 +66,8 @@ class FakeFileSystem(
   val clock: Clock = Clock.System
 ) : FileSystem() {
 
-  /** Keys are canonical paths. Each value is either a [Directory] or a [ByteString]. */
-  private val elements = mutableMapOf<Path, Element>()
+  /** File system roots. Each element is a Directory and is created on-demand. */
+  private val roots = mutableMapOf<Path, Directory>()
 
   /** Files that are currently open and need to be closed to avoid resource leaks. */
   private val openFiles = mutableListOf<OpenFile>()
@@ -115,6 +115,13 @@ class FakeFileSystem(
   var allowReadsWhileWriting = false
 
   /**
+   * True to allow symlinks to be created. UNIX file systems typically allow symlinks; Windows file
+   * systems do not. Setting this to false after creating a symlink does not prevent that symlink
+   * from being returned or used.
+   */
+  var allowSymlinks = false
+
+  /**
    * Canonical paths for every file and directory in this file system. This omits file system roots
    * like `C:\` and `/`.
    */
@@ -122,9 +129,8 @@ class FakeFileSystem(
   val allPaths: Set<Path>
     get() {
       val result = mutableListOf<Path>()
-      for (path in elements.keys) {
-        if (path.isRoot) continue
-        result += path
+      for (path in roots.keys) {
+        result += listRecursively(path)
       }
       result.sort()
       return result.toSet()
@@ -197,12 +203,13 @@ class FakeFileSystem(
     allowClobberingEmptyDirectories = false
     allowWritesWhileWriting = true
     allowReadsWhileWriting = true
+    allowSymlinks = true
   }
 
   override fun canonicalize(path: Path): Path {
     val canonicalPath = workingDirectory / path
 
-    if (canonicalPath !in elements) {
+    if (lookupPath(canonicalPath)?.element == null) {
       throw FileNotFoundException("no such file: $path")
     }
 
@@ -211,30 +218,25 @@ class FakeFileSystem(
 
   override fun metadataOrNull(path: Path): FileMetadata? {
     val canonicalPath = workingDirectory / path
-    var element = elements[canonicalPath]
-
-    // If the path is a root, create it on demand.
-    if (element == null && canonicalPath.isRoot) {
-      element = Directory(createdAt = clock.now())
-      elements[canonicalPath] = element
-    }
-
-    return element?.metadata
+    val lookupResult = lookupPath(
+      canonicalPath = canonicalPath,
+      createRootOnDemand = canonicalPath.isRoot,
+      resolveLastSymlink = false
+    )
+    return lookupResult?.element?.metadata
   }
 
   override fun list(dir: Path): List<Path> {
     val canonicalPath = workingDirectory / dir
-    val element = requireDirectory(canonicalPath)
+    val lookupResult = lookupPath(canonicalPath)
+    if (lookupResult?.element == null) {
+      throw FileNotFoundException("no such directory: $dir")
+    }
+    val element = lookupResult.element as? Directory
+      ?: throw IOException("not a directory: $dir")
 
     element.access(now = clock.now())
-    val paths = elements.keys.filterTo(mutableListOf()) { it.parent == canonicalPath }
-    if (dir.isRelative) {
-      for (i in paths.indices) {
-        paths[i] = dir / paths[i].name
-      }
-    }
-    paths.sort()
-    return paths
+    return element.children.keys.map { dir / it }.sorted()
   }
 
   override fun source(file: Path): Source {
@@ -269,14 +271,14 @@ class FakeFileSystem(
     readWrite: Boolean
   ): FileHandle {
     val canonicalPath = workingDirectory / file
-    val existing = elements[canonicalPath]
+    val lookupResult = lookupPath(canonicalPath, createRootOnDemand = readWrite)
     val now = clock.now()
     val element: File
     val operation: Operation
 
     if (readWrite) {
       // Note that this case is used for both write and read/write.
-      if (existing is Directory) {
+      if (lookupResult?.element is Directory) {
         throw IOException("destination is a directory: $file")
       }
       if (!allowWritesWhileWriting) {
@@ -290,18 +292,21 @@ class FakeFileSystem(
         }
       }
 
-      val parent = requireDirectory(canonicalPath.parent)
+      val parent = lookupResult?.parent
+        ?: throw FileNotFoundException("parent directory does not exist")
       parent.access(now, true)
 
+      val existing = lookupResult.element
       element = File(createdAt = existing?.createdAt ?: now)
-      elements[canonicalPath] = element
+      parent.children[lookupResult.segment!!] = element
       operation = WRITE
 
       if (existing is File) {
         element.data = existing.data
       }
     } else {
-      if (existing == null) throw FileNotFoundException("no such file: $file")
+      val existing = lookupResult?.element
+        ?: throw FileNotFoundException("no such file: $file")
       element = existing as? File ?: throw IOException("not a file: $file")
       operation = READ
 
@@ -327,26 +332,36 @@ class FakeFileSystem(
   override fun createDirectory(dir: Path) {
     val canonicalPath = workingDirectory / dir
 
-    if (elements[canonicalPath] != null) {
+    val lookupResult = lookupPath(canonicalPath, createRootOnDemand = true)
+
+    if (canonicalPath.isRoot) {
+      // Looking it up was sufficient. Don't crash when creating roots that already exist.
+      return
+    }
+
+    if (lookupResult?.element != null) {
       throw IOException("already exists: $dir")
     }
-    requireDirectory(canonicalPath.parent)
 
-    elements[canonicalPath] = Directory(createdAt = clock.now())
+    val parentDirectory = lookupResult.requireParent()
+    parentDirectory.children[canonicalPath.nameBytes] = Directory(createdAt = clock.now())
   }
 
-  override fun atomicMove(source: Path, target: Path) {
+  override fun atomicMove(
+    source: Path,
+    target: Path
+  ) {
     val canonicalSource = workingDirectory / source
     val canonicalTarget = workingDirectory / target
 
-    val targetElement = elements[canonicalTarget]
-    val sourceElement = elements[canonicalSource]
+    val targetLookupResult = lookupPath(canonicalTarget, createRootOnDemand = true)
+    val sourceLookupResult = lookupPath(canonicalSource, resolveLastSymlink = false)
 
     // Universal constraints.
-    if (targetElement is Directory) {
+    if (targetLookupResult?.element is Directory) {
       throw IOException("target is a directory: $target")
     }
-    requireDirectory(canonicalTarget.parent)
+    val targetParent = targetLookupResult.requireParent()
     if (!allowMovingOpenFiles) {
       findOpenFile(canonicalSource)?.let {
         throw IOException("source is open $source", it.backtrace)
@@ -356,20 +371,27 @@ class FakeFileSystem(
       }
     }
     if (!allowClobberingEmptyDirectories) {
-      if (sourceElement is Directory && targetElement is File) {
+      if (sourceLookupResult?.element is Directory && targetLookupResult?.element is File) {
         throw IOException("source is a directory and target is a file")
       }
     }
 
-    val removed = elements.remove(canonicalSource)
+    val sourceParent = sourceLookupResult.requireParent()
+    val removed = sourceParent.children.remove(canonicalSource.nameBytes)
       ?: throw FileNotFoundException("source doesn't exist: $source")
-    elements[canonicalTarget] = removed
+    targetParent.children[canonicalTarget.nameBytes] = removed
   }
 
   override fun delete(path: Path) {
     val canonicalPath = workingDirectory / path
 
-    if (elements.keys.any { it.parent == canonicalPath }) {
+    val lookupResult = lookupPath(canonicalPath, createRootOnDemand = true)
+
+    if (lookupResult?.element == null) {
+      throw FileNotFoundException("no such file: $path")
+    }
+
+    if (lookupResult.element is Directory && lookupResult.element.children.isNotEmpty()) {
       throw IOException("non-empty directory")
     }
 
@@ -379,34 +401,129 @@ class FakeFileSystem(
       }
     }
 
-    if (elements.remove(canonicalPath) == null) {
-      throw FileNotFoundException("no such file: $path")
+    val directory = lookupResult.requireParent()
+    directory.children.remove(canonicalPath.nameBytes)
+  }
+
+  override fun createSymlink(
+    source: Path,
+    target: Path
+  ) {
+    val canonicalSource = workingDirectory / source
+
+    val existingLookupResult = lookupPath(canonicalSource, createRootOnDemand = true)
+    if (existingLookupResult?.element != null) {
+      throw IOException("already exists: $source")
     }
+    val parent = existingLookupResult.requireParent()
+
+    if (!allowSymlinks) {
+      throw IOException("symlinks are not supported")
+    }
+
+    parent.children[canonicalSource.nameBytes] = Symlink(createdAt = clock.now(), target)
   }
 
   /**
-   * Gets the directory at [path], creating it if [path] is a file system root.
+   * Walks the file system looking for [canonicalPath], following symlinks encountered along the
+   * way. This function is designed to be used both when looking up existing files and when creating
+   * new files into an existing directory.
    *
-   * @throws IOException if the named directory is not a root and does not exist, or if it does
-   *     exist but is not a directory.
+   * It returns either:
+   *
+   *  * a path lookup result with an element if that file or directory or symlink exists. This is
+   *    useful when reading or writing an existing fie.
+   *
+   *  * a path lookup result that only got as far as the canonical path's parent, if the parent
+   *    exists but the child file does not. This is useful when creating a new file.
+   *
+   *  * null, if not even the parent directory exists. A file cannot yet be created with this path
+   *    because there is no parent to attach it to.
+   *
+   * This will create the root of the returned path if it does not exist.
+   *
+   * @param recurseCount used internally to detect cycles
+   * @param resolveLastSymlink true if the result's element must not itself be a symlink. Use this
+   *     for looking up metadata, or operations that apply to the path like delete and move. We
+   *     always follow symlinks for enclosing directories.
+   * @param createRootOnDemand true to create a root directory like `C:\` or `/` if it doesn't
+   *     exist. Pass true for mutating operations.
    */
-  private fun requireDirectory(path: Path?): Directory {
-    if (path == null) throw IOException("directory does not exist")
-
-    // If the path is a directory, return it!
-    val element = elements[path]
-    if (element is Directory) return element
-
-    // If the path is a root, create a directory for it on demand.
-    if (path.isRoot) {
-      val root = Directory(createdAt = clock.now())
-      elements[path] = root
-      return root
+  private fun lookupPath(
+    canonicalPath: Path,
+    recurseCount: Int = 0,
+    resolveLastSymlink: Boolean = true,
+    createRootOnDemand: Boolean = false,
+  ): PathLookupResult? {
+    // 40 is chosen for consistency with the Linux kernel (which previously used 8).
+    if (recurseCount > 40) {
+      throw IOException("symlink cycle?")
     }
 
-    if (element == null) throw FileNotFoundException("no such directory: $path")
+    val rootPath = canonicalPath.root!!
+    var root = roots[rootPath]
 
-    throw IOException("not a directory: $path")
+    // If the path is a root, create it on demand.
+    if (root == null) {
+      if (!createRootOnDemand) return null
+      root = Directory(createdAt = clock.now())
+      roots[rootPath] = root
+    }
+
+    var parent: Directory? = null
+    var lastSegment: ByteString? = null
+    var current: Element = root
+    var currentPath: Path = rootPath
+
+    var segmentsTraversed = 0
+    val segments = canonicalPath.segmentsBytes
+    for (segment in segments) {
+      lastSegment = segment
+
+      // Push the newest segment.
+      if (current !is Directory) {
+        throw IOException("not a directory: $currentPath")
+      }
+      parent = current
+      current = current.children[segment] ?: break
+      currentPath /= segment
+      segmentsTraversed++
+
+      // If it's a symlink, recurse to follow it.
+      val isLastSegment = segmentsTraversed == segments.size
+      val followSymlinks = !isLastSegment || resolveLastSymlink
+      if (current is Symlink && followSymlinks) {
+        current.access(now = clock.now())
+        currentPath = currentPath.parent!! / current.target
+        val symlinkLookupResult = lookupPath(
+          canonicalPath = currentPath,
+          recurseCount = recurseCount + 1,
+          createRootOnDemand = createRootOnDemand
+        ) ?: break
+        parent = symlinkLookupResult.parent
+        lastSegment = symlinkLookupResult.segment
+        current = symlinkLookupResult.element ?: break
+      }
+    }
+
+    return when (segmentsTraversed) {
+      segments.size -> PathLookupResult(parent, lastSegment, current) // The file.
+      segments.size - 1 -> PathLookupResult(parent, lastSegment, null) // The enclosing directory.
+      else -> null // We found nothing.
+    }
+  }
+
+  private class PathLookupResult(
+    /** Only null if the looked up path is a root. */
+    val parent: Directory?,
+    /** Only null if the looked up path is a root. */
+    val segment: ByteString?,
+    /** Non-null if this is a root. Also not null if this file exists. */
+    val element: Element?
+  )
+
+  private fun PathLookupResult?.requireParent(): Directory {
+    return this?.parent ?: throw IOException("parent directory does not exist")
   }
 
   private sealed class Element(
@@ -429,6 +546,9 @@ class FakeFileSystem(
     }
 
     class Directory(createdAt: Instant) : Element(createdAt) {
+      /** Keys are path segments. */
+      val children = mutableMapOf<ByteString, Element>()
+
       override val metadata: FileMetadata
         get() = FileMetadata(
           isDirectory = true,
@@ -438,7 +558,24 @@ class FakeFileSystem(
         )
     }
 
-    fun access(now: Instant, modified: Boolean = false) {
+    class Symlink(
+      createdAt: Instant,
+      /** This may be an absolute or relative path. */
+      val target: Path
+    ) : Element(createdAt) {
+      override val metadata: FileMetadata
+        get() = FileMetadata(
+          symlinkTarget = target,
+          createdAt = createdAt,
+          lastModifiedAt = lastModifiedAt,
+          lastAccessedAt = lastAccessedAt
+        )
+    }
+
+    fun access(
+      now: Instant,
+      modified: Boolean = false
+    ) {
       lastAccessedAt = now
       if (modified) {
         lastModifiedAt = now
@@ -448,13 +585,20 @@ class FakeFileSystem(
     abstract val metadata: FileMetadata
   }
 
-  private fun findOpenFile(canonicalPath: Path, operation: Operation? = null): OpenFile? {
+  private fun findOpenFile(
+    canonicalPath: Path,
+    operation: Operation? = null
+  ): OpenFile? {
     return openFiles.firstOrNull {
       it.canonicalPath == canonicalPath && (operation == null || operation == it.operation)
     }
   }
 
-  private fun checkOffsetAndCount(size: Long, offset: Long, byteCount: Long) {
+  private fun checkOffsetAndCount(
+    size: Long,
+    offset: Long,
+    byteCount: Long
+  ) {
     if (offset or byteCount < 0 || offset > size || size - offset < byteCount) {
       throw ArrayIndexOutOfBoundsException("size=$size offset=$offset byteCount=$byteCount")
     }

--- a/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/time.kt
+++ b/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/time.kt
@@ -19,6 +19,7 @@ package okio.fakefilesystem
 import kotlinx.datetime.Instant
 import okio.ExperimentalFileSystem
 import okio.FileMetadata
+import okio.Path
 import kotlin.jvm.JvmName
 
 @JvmName("newFileMetadata")
@@ -26,6 +27,7 @@ import kotlin.jvm.JvmName
 internal fun FileMetadata(
   isRegularFile: Boolean = false,
   isDirectory: Boolean = false,
+  symlinkTarget: Path? = null,
   size: Long? = null,
   createdAt: Instant? = null,
   lastModifiedAt: Instant? = null,
@@ -34,6 +36,7 @@ internal fun FileMetadata(
   return FileMetadata(
     isRegularFile = isRegularFile,
     isDirectory = isDirectory,
+    symlinkTarget = symlinkTarget,
     size = size,
     createdAtMillis = createdAt?.toEpochMilliseconds(),
     lastModifiedAtMillis = lastModifiedAt?.toEpochMilliseconds(),

--- a/okio-nodefilesystem/src/main/kotlin/okio/NodeJsFileSystem.kt
+++ b/okio-nodefilesystem/src/main/kotlin/okio/NodeJsFileSystem.kt
@@ -50,6 +50,7 @@ object NodeJsFileSystem : FileSystem() {
     return FileMetadata(
       isRegularFile = stat.mode.toInt() and S_IFMT == S_IFREG,
       isDirectory = stat.mode.toInt() and S_IFMT == S_IFDIR,
+      symlinkTarget = null,
       size = stat.size.toLong(),
       createdAtMillis = stat.ctimeMs.toLong(),
       lastModifiedAtMillis = stat.mtimeMs.toLong(),
@@ -168,6 +169,10 @@ object NodeJsFileSystem : FileSystem() {
     } catch (e: Throwable) {
       throw e.toIOException()
     }
+  }
+
+  override fun createSymlink(source: Path, target: Path) {
+    throw IOException("unsupported")
   }
 
   private fun Throwable.toIOException(): IOException {

--- a/okio/src/commonMain/kotlin/okio/FileMetadata.kt
+++ b/okio/src/commonMain/kotlin/okio/FileMetadata.kt
@@ -52,24 +52,30 @@ package okio
 @ExperimentalFileSystem
 class FileMetadata(
   /** True if this file is a container of bytes. If this is true, then [size] is non-null. */
-  val isRegularFile: Boolean,
+  val isRegularFile: Boolean = false,
 
   /** True if the path refers to a directory that contains 0 or more child paths. */
-  val isDirectory: Boolean,
+  val isDirectory: Boolean = false,
+
+  /**
+   * The absolute or relative path that this file is a symlink to, or null if this is not a symlink.
+   * If this is a relative path, it is relative to the source file's parent directory.
+   */
+  val symlinkTarget: Path? = null,
 
   /**
    * Returns the number of bytes readable from this file. The amount of storage resources consumed
    * by this file may be larger (due to block size overhead, redundant copies for RAID, etc.), or
    * smaller (due to file system compression, shared inodes, etc).
    */
-  val size: Long?,
+  val size: Long? = null,
 
   /**
    * Returns the system time of the host computer when this file was created, if the host file
    * system supports this feature. This is typically available on Windows NTFS file systems and not
    * available on UNIX or Windows FAT file systems.
    */
-  val createdAtMillis: Long?,
+  val createdAtMillis: Long? = null,
 
   /**
    * Returns the system time of the host computer when this file was most recently written.
@@ -78,7 +84,7 @@ class FileMetadata(
    * particular, this value is expressed with millisecond precision but may be accessed at
    * second- or day-accuracy only.
    */
-  val lastModifiedAtMillis: Long?,
+  val lastModifiedAtMillis: Long? = null,
 
   /**
    * Returns the system time of the host computer when this file was most recently read or written.
@@ -87,7 +93,7 @@ class FileMetadata(
    * particular, this value is expressed with millisecond precision but may be accessed at
    * second- or day-accuracy only.
    */
-  val lastAccessedAtMillis: Long?
+  val lastAccessedAtMillis: Long? = null,
 ) {
   override fun equals(other: Any?) = other is FileMetadata && toString() == other.toString()
 

--- a/okio/src/commonMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/commonMain/kotlin/okio/FileSystem.kt
@@ -40,8 +40,8 @@ package okio
  * It is not suitable for high-latency or unreliable remote file systems. It lacks support for
  * retries, timeouts, cancellation, and bulk operations.
  *
- * It cannot create special file types like hard links, symlinks, pipes, or mounts. Reading
- * or writing these files works as if they were regular files.
+ * It cannot create special file types like hard links, pipes, or mounts. Reading or writing these
+ * files works as if they were regular files.
  *
  * It cannot read or write file access control features like the UNIX `chmod` and Windows access
  * control lists. It does honor these controls and will fail with an [IOException] if privileges
@@ -322,6 +322,17 @@ expect abstract class FileSystem() {
    */
   @Throws(IOException::class)
   open fun deleteRecursively(fileOrDirectory: Path)
+
+  /**
+   * Creates a symbolic link at [source] that resolves to [target]. If [target] is a relative path,
+   * it is relative to `source.parent`.
+   *
+   * @throws IOException if [source] cannot be created. This may be because it already exists
+   *     or because its storage doesn't support symlinks. This list of potential problems is not
+   *     exhaustive.
+   */
+  @Throws(IOException::class)
+  abstract fun createSymlink(source: Path, target: Path)
 
   companion object {
     /**

--- a/okio/src/commonMain/kotlin/okio/ForwardingFileSystem.kt
+++ b/okio/src/commonMain/kotlin/okio/ForwardingFileSystem.kt
@@ -220,5 +220,12 @@ abstract class ForwardingFileSystem(
     delegate.delete(path)
   }
 
+  @Throws(IOException::class)
+  override fun createSymlink(source: Path, target: Path) {
+    val source = onPathParameter(source, "createSymlink", "source")
+    val target = onPathParameter(target, "createSymlink", "target")
+    delegate.createSymlink(source, target)
+  }
+
   override fun toString() = "${this::class.simpleName}($delegate)"
 }

--- a/okio/src/commonMain/kotlin/okio/Path.kt
+++ b/okio/src/commonMain/kotlin/okio/Path.kt
@@ -206,6 +206,14 @@ expect class Path internal constructor(bytes: ByteString) : Comparable<Path> {
    * If [child] is an [absolute path][isAbsolute] or [has a volume letter][hasVolumeLetter] then
    * this function is equivalent to `child.toPath()`.
    */
+  operator fun div(child: ByteString): Path
+
+  /**
+   * Returns a path that resolves [child] relative to this path.
+   *
+   * If [child] is an [absolute path][isAbsolute] or [has a volume letter][hasVolumeLetter] then
+   * this function is equivalent to `child.toPath()`.
+   */
   operator fun div(child: Path): Path
 
   /**

--- a/okio/src/commonMain/kotlin/okio/internal/-Path.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/-Path.kt
@@ -213,6 +213,12 @@ internal inline fun Path.commonResolve(child: String): Path {
 
 @ExperimentalFileSystem
 @Suppress("NOTHING_TO_INLINE")
+internal inline fun Path.commonResolve(child: ByteString): Path {
+  return div(Buffer().write(child).toPath())
+}
+
+@ExperimentalFileSystem
+@Suppress("NOTHING_TO_INLINE")
 internal inline fun Path.commonResolve(child: Path): Path {
   if (child.isAbsolute || child.volumeLetter != null) return child
 

--- a/okio/src/commonTest/kotlin/okio/FakeFileSystemTest.kt
+++ b/okio/src/commonTest/kotlin/okio/FakeFileSystemTest.kt
@@ -363,4 +363,26 @@ abstract class FakeFileSystemTest internal constructor(
       }
     }
   }
+
+  @Test
+  fun symlinkCanBeUsedAfterSettingAllowSymlinksToFalse() {
+    if (!supportsSymlink()) return
+
+    val target = base / "symlink-target"
+    val source = base / "symlink-source"
+    fileSystem.createSymlink(source, target)
+    fakeFileSystem.allowSymlinks = false
+    target.writeUtf8("I am the target file")
+    assertEquals("I am the target file", source.readUtf8())
+  }
+
+  @Test
+  fun symlinkCannotBeCreatedAfterSettingAllowSymlinksToFalse() {
+    fakeFileSystem.allowSymlinks = false
+    val target = base / "symlink-target"
+    val source = base / "symlink-source"
+    assertFailsWith<IOException> {
+      fileSystem.createSymlink(source, target)
+    }
+  }
 }

--- a/okio/src/jsMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/jsMain/kotlin/okio/FileSystem.kt
@@ -72,6 +72,8 @@ actual abstract class FileSystem {
   actual open fun deleteRecursively(fileOrDirectory: Path): Unit =
     commonDeleteRecursively(fileOrDirectory)
 
+  actual abstract fun createSymlink(source: Path, target: Path)
+
   actual companion object {
     actual val SYSTEM_TEMPORARY_DIRECTORY: Path = tmpdir.toPath()
   }

--- a/okio/src/jvmMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/FileSystem.kt
@@ -91,6 +91,9 @@ actual abstract class FileSystem {
   actual open fun deleteRecursively(fileOrDirectory: Path): Unit =
     commonDeleteRecursively(fileOrDirectory)
 
+  @Throws(IOException::class)
+  actual abstract fun createSymlink(source: Path, target: Path)
+
   actual companion object {
     /**
      * The current process's host file system. Use this instance directly, or dependency inject a

--- a/okio/src/jvmMain/kotlin/okio/JvmSystemFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmSystemFileSystem.kt
@@ -51,6 +51,7 @@ internal open class JvmSystemFileSystem : FileSystem() {
     return FileMetadata(
       isRegularFile = isRegularFile,
       isDirectory = isDirectory,
+      symlinkTarget = null,
       size = size,
       createdAtMillis = null,
       lastModifiedAtMillis = lastModifiedAtMillis,
@@ -106,6 +107,10 @@ internal open class JvmSystemFileSystem : FileSystem() {
       if (!file.exists()) throw FileNotFoundException("no such file: $path")
       else throw IOException("failed to delete $path")
     }
+  }
+
+  override fun createSymlink(source: Path, target: Path) {
+    throw IOException("unsupported")
   }
 
   override fun toString() = "JvmSystemFileSystem"

--- a/okio/src/jvmMain/kotlin/okio/Path.kt
+++ b/okio/src/jvmMain/kotlin/okio/Path.kt
@@ -79,6 +79,9 @@ actual class Path internal actual constructor(
   actual operator fun div(child: String): Path = commonResolve(child)
 
   @JvmName("resolve")
+  actual operator fun div(child: ByteString): Path = commonResolve(child)
+
+  @JvmName("resolve")
   actual operator fun div(child: Path): Path = commonResolve(child)
 
   actual fun relativeTo(other: Path): Path = commonRelativeTo(other)

--- a/okio/src/jvmMain/kotlin/okio/ZipFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/ZipFileSystem.kt
@@ -80,6 +80,7 @@ class ZipFileSystem internal constructor(
     val basicMetadata = FileMetadata(
       isRegularFile = !entry.isDirectory,
       isDirectory = entry.isDirectory,
+      symlinkTarget = null,
       size = if (entry.isDirectory) null else entry.size,
       createdAtMillis = null,
       lastModifiedAtMillis = entry.lastModifiedAtMillis,
@@ -145,4 +146,7 @@ class ZipFileSystem internal constructor(
     throw IOException("zip file systems are read-only")
 
   override fun delete(path: Path): Unit = throw IOException("zip file systems are read-only")
+
+  override fun createSymlink(source: Path, target: Path): Unit =
+    throw IOException("zip file systems are read-only")
 }

--- a/okio/src/jvmMain/kotlin/okio/internal/ResourceFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/internal/ResourceFileSystem.kt
@@ -125,6 +125,9 @@ internal class ResourceFileSystem internal constructor(
 
   override fun delete(path: Path): Unit = throw IOException("$this is read-only")
 
+  override fun createSymlink(source: Path, target: Path): Unit =
+    throw IOException("$this is read-only")
+
   private fun Path.toRelativePath(): String = canonicalize(this).toString().substring(1)
 
   private companion object {

--- a/okio/src/jvmMain/kotlin/okio/internal/zip.kt
+++ b/okio/src/jvmMain/kotlin/okio/internal/zip.kt
@@ -435,6 +435,7 @@ private fun BufferedSource.readOrSkipLocalHeader(basicMetadata: FileMetadata?): 
   return FileMetadata(
     isRegularFile = basicMetadata.isRegularFile,
     isDirectory = basicMetadata.isDirectory,
+    symlinkTarget = null,
     size = basicMetadata.size,
     createdAtMillis = createdAtMillis,
     lastModifiedAtMillis = lastModifiedAtMillis,

--- a/okio/src/linuxX64Main/kotlin/okio/-LinuxX64PosixVariant.kt
+++ b/okio/src/linuxX64Main/kotlin/okio/-LinuxX64PosixVariant.kt
@@ -36,6 +36,7 @@ internal actual fun PosixFileSystem.variantMetadataOrNull(path: Path): FileMetad
     return@memScoped FileMetadata(
       isRegularFile = stat.st_mode.toInt() and S_IFMT == S_IFREG,
       isDirectory = stat.st_mode.toInt() and S_IFMT == S_IFDIR,
+      symlinkTarget = null,
       size = stat.st_size,
       createdAtMillis = stat.st_ctim.epochMillis,
       lastModifiedAtMillis = stat.st_mtim.epochMillis,

--- a/okio/src/mingwX64Main/kotlin/okio/-WindowsPosixVariant.kt
+++ b/okio/src/mingwX64Main/kotlin/okio/-WindowsPosixVariant.kt
@@ -117,6 +117,7 @@ internal actual fun PosixFileSystem.variantMetadataOrNull(path: Path): FileMetad
     return@memScoped FileMetadata(
       isRegularFile = stat.st_mode.toInt() and S_IFMT == S_IFREG,
       isDirectory = stat.st_mode.toInt() and S_IFMT == S_IFDIR,
+      symlinkTarget = null,
       size = stat.st_size,
       createdAtMillis = stat.st_ctime * 1000L,
       lastModifiedAtMillis = stat.st_mtime * 1000L,

--- a/okio/src/nativeMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/nativeMain/kotlin/okio/FileSystem.kt
@@ -89,6 +89,9 @@ actual abstract class FileSystem {
   actual open fun deleteRecursively(fileOrDirectory: Path): Unit =
     commonDeleteRecursively(fileOrDirectory)
 
+  @Throws(IOException::class)
+  actual abstract fun createSymlink(source: Path, target: Path)
+
   actual companion object {
     /**
      * The current process's host file system. Use this instance directly, or dependency inject a

--- a/okio/src/nativeMain/kotlin/okio/PosixFileSystem.kt
+++ b/okio/src/nativeMain/kotlin/okio/PosixFileSystem.kt
@@ -95,5 +95,9 @@ internal object PosixFileSystem : FileSystem() {
     variantDelete(path)
   }
 
+  override fun createSymlink(source: Path, target: Path) {
+    throw IOException("unsupported")
+  }
+
   override fun toString() = "PosixSystemFileSystem"
 }

--- a/okio/src/nonJvmMain/kotlin/okio/Path.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/Path.kt
@@ -69,6 +69,8 @@ actual class Path internal actual constructor(
 
   actual operator fun div(child: String): Path = commonResolve(child)
 
+  actual operator fun div(child: ByteString): Path = commonResolve(child)
+
   actual operator fun div(child: Path): Path = commonResolve(child)
 
   actual fun relativeTo(other: Path): Path = commonRelativeTo(other)


### PR DESCRIPTION
This required significant rework to the internals of FakeFileSystem
which must now implement symlink-aware path resolution.