### PR TITLE
Fix nodefilesystem dependency coordinate

### DIFF
--- a/docs/multiplatform.md
+++ b/docs/multiplatform.md
@@ -58,7 +58,7 @@ kotlin {
         }
         val jsMain by getting {
             dependencies {
-                implementation("com.squareup.okio:okio-nodefilesystem-js:$okioVersion")
+                implementation("com.squareup.okio:okio-nodefilesystem:$okioVersion")
             }
         }
         val commonTest by getting {


### PR DESCRIPTION
Looking at the published artifacts, it appears to have been renamed for the alpha-10 release.

https://search.maven.org/artifact/com.squareup.okio/okio-nodefilesystem 
https://search.maven.org/artifact/com.squareup.okio/okio-nodefilesystem-js