### PR TITLE
Fix two Linux bugs

### DIFF
--- a/okio/src/linuxX64Main/kotlin/okio/-LinuxX64PosixVariant.kt
+++ b/okio/src/linuxX64Main/kotlin/okio/-LinuxX64PosixVariant.kt
@@ -23,20 +23,21 @@ import platform.posix.S_IFDIR
 import platform.posix.S_IFMT
 import platform.posix.S_IFREG
 import platform.posix.errno
+import platform.posix.lstat
 import platform.posix.stat
 
 @ExperimentalFileSystem
 internal actual fun PosixFileSystem.variantMetadataOrNull(path: Path): FileMetadata? {
   return memScoped {
     val stat = alloc<stat>()
-    if (platform.posix.lstat(path.toString(), stat.ptr) != 0) {
+    if (lstat(path.toString(), stat.ptr) != 0) {
       if (errno == ENOENT) return null
       throw errnoToIOException(errno)
     }
     return@memScoped FileMetadata(
       isRegularFile = stat.st_mode.toInt() and S_IFMT == S_IFREG,
       isDirectory = stat.st_mode.toInt() and S_IFMT == S_IFDIR,
-      symlinkTarget = null,
+      symlinkTarget = symlinkTarget(stat, path),
       size = stat.st_size,
       createdAtMillis = stat.st_ctim.epochMillis,
       lastModifiedAtMillis = stat.st_mtim.epochMillis,

--- a/okio/src/mingwX64Main/kotlin/okio/-WindowsPosixVariant.kt
+++ b/okio/src/mingwX64Main/kotlin/okio/-WindowsPosixVariant.kt
@@ -188,7 +188,11 @@ internal actual fun PosixFileSystem.variantOpenReadOnly(file: Path): FileHandle 
 }
 
 @ExperimentalFileSystem
-internal actual fun PosixFileSystem.variantOpenReadWrite(file: Path): FileHandle {
+internal actual fun PosixFileSystem.variantOpenReadWrite(
+  file: Path,
+  mustCreate: Boolean,
+  mustExist: Boolean,
+): FileHandle {
   val openFile = CreateFileA(
     lpFileName = file.toString(),
     dwDesiredAccess = GENERIC_READ or GENERIC_WRITE.toUInt(),

--- a/okio/src/nativeMain/kotlin/okio/-PosixVariant.kt
+++ b/okio/src/nativeMain/kotlin/okio/-PosixVariant.kt
@@ -46,7 +46,11 @@ internal expect fun PosixFileSystem.variantAppendingSink(file: Path): Sink
 internal expect fun PosixFileSystem.variantOpenReadOnly(file: Path): FileHandle
 
 @ExperimentalFileSystem
-internal expect fun PosixFileSystem.variantOpenReadWrite(file: Path): FileHandle
+internal expect fun PosixFileSystem.variantOpenReadWrite(
+  file: Path,
+  mustCreate: Boolean,
+  mustExist: Boolean
+): FileHandle
 
 @ExperimentalFileSystem
 internal expect fun PosixFileSystem.variantCreateSymlink(source: Path, target: Path)

--- a/okio/src/nativeMain/kotlin/okio/PosixFileSystem.kt
+++ b/okio/src/nativeMain/kotlin/okio/PosixFileSystem.kt
@@ -70,7 +70,7 @@ internal object PosixFileSystem : FileSystem() {
   override fun openReadOnly(file: Path) = variantOpenReadOnly(file)
 
   override fun openReadWrite(file: Path, mustCreate: Boolean, mustExist: Boolean): FileHandle {
-    return variantOpenReadWrite(file)
+    return variantOpenReadWrite(file, mustCreate, mustExist)
   }
 
   override fun source(file: Path) = variantSource(file)

--- a/okio/src/unixMain/kotlin/okio/-UnixPosixVariant.kt
+++ b/okio/src/unixMain/kotlin/okio/-UnixPosixVariant.kt
@@ -15,20 +15,34 @@
  */
 package okio
 
+import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.CValuesRef
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.toKString
 import okio.Path.Companion.toPath
 import okio.internal.toPath
+import platform.posix.DEFFILEMODE
 import platform.posix.FILE
+import platform.posix.O_CREAT
+import platform.posix.O_EXCL
+import platform.posix.O_RDWR
+import platform.posix.PATH_MAX
+import platform.posix.S_IFLNK
+import platform.posix.S_IFMT
 import platform.posix.errno
+import platform.posix.fdopen
 import platform.posix.fopen
 import platform.posix.free
 import platform.posix.getenv
 import platform.posix.mkdir
+import platform.posix.open
+import platform.posix.readlink
 import platform.posix.realpath
 import platform.posix.remove
 import platform.posix.rename
+import platform.posix.stat
 import platform.posix.symlink
 import platform.posix.timespec
 
@@ -108,9 +122,28 @@ internal actual fun PosixFileSystem.variantOpenReadOnly(file: Path): FileHandle 
 }
 
 @ExperimentalFileSystem
-internal actual fun PosixFileSystem.variantOpenReadWrite(file: Path): FileHandle {
-  val openFile: CPointer<FILE> = fopen(file.toString(), "a+")
-    ?: throw errnoToIOException(errno)
+internal actual fun PosixFileSystem.variantOpenReadWrite(
+  file: Path,
+  mustCreate: Boolean,
+  mustExist: Boolean
+): FileHandle {
+  // Note that we're using open() followed by fdopen() rather than fopen() because this way we
+  // can pass exactly the flags we want. Note that there's no string mode that opens for reading
+  // and writing that creates if necessary. ("a+" has features but can't do random access).
+  val flags = when {
+    mustCreate && mustExist ->
+      throw IllegalArgumentException("Cannot require mustCreate and mustExist at the same time.")
+    mustCreate -> O_RDWR or O_CREAT or O_EXCL
+    mustExist -> O_RDWR
+    else -> O_RDWR or O_CREAT
+  }
+
+  val fid = open(file.toString(), flags, DEFFILEMODE)
+  if (fid == -1) throw errnoToIOException(errno)
+
+  // Use 'r+' to get reading and writing on the FILE, which is all we need.
+  val openFile = fdopen(fid, "r+") ?: throw errnoToIOException(errno)
+
   return UnixFileHandle(true, openFile)
 }
 
@@ -146,3 +179,18 @@ internal expect fun variantPwrite(
 
 internal val timespec.epochMillis: Long
   get() = tv_sec * 1000L + tv_sec / 1_000_000L
+
+@ExperimentalFileSystem
+internal fun symlinkTarget(stat: stat, path: Path): Path? {
+  if (stat.st_mode.toInt() and S_IFMT != S_IFLNK) return null
+
+  // `path` is a symlink, let's resolve its target.
+  memScoped {
+    val buffer = allocArray<ByteVar>(PATH_MAX)
+    val byteCount = readlink(path.toString(), buffer, PATH_MAX)
+    if (byteCount.toInt() == -1) {
+      throw errnoToIOException(errno)
+    }
+    return buffer.toKString().toPath()
+  }
+}


### PR DESCRIPTION
We were always appending to the end on FileHandle. This fix writes in
the appropriate place by changing open flags.

We weren't returning the symlink target.

Also fix file opens to be as atomic as possible on all UNIX systems.