### PR TITLE
Create Java-language overloads where appropriate

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/FileSystem.kt
@@ -46,6 +46,8 @@ actual abstract class FileSystem {
   actual open fun listRecursively(dir: Path, followSymlinks: Boolean): Sequence<Path> =
     commonListRecursively(dir, followSymlinks)
 
+  fun listRecursively(dir: Path): Sequence<Path> = listRecursively(dir, followSymlinks = false)
+
   @Throws(IOException::class)
   actual abstract fun openReadOnly(file: Path): FileHandle
 
@@ -53,9 +55,14 @@ actual abstract class FileSystem {
   actual abstract fun openReadWrite(file: Path, mustCreate: Boolean, mustExist: Boolean): FileHandle
 
   @Throws(IOException::class)
+  fun openReadWrite(file: Path): FileHandle =
+    openReadWrite(file, mustCreate = false, mustExist = false)
+
+  @Throws(IOException::class)
   actual abstract fun source(file: Path): Source
 
   @Throws(IOException::class)
+  @JvmName("-read")
   actual inline fun <T> read(file: Path, readerAction: BufferedSource.() -> T): T {
     return source(file).buffer().use {
       it.readerAction()
@@ -66,6 +73,10 @@ actual abstract class FileSystem {
   actual abstract fun sink(file: Path, mustCreate: Boolean): Sink
 
   @Throws(IOException::class)
+  fun sink(file: Path): Sink = sink(file, mustCreate = false)
+
+  @Throws(IOException::class)
+  @JvmName("-write")
   actual inline fun <T> write(file: Path, mustCreate: Boolean, writerAction: BufferedSink.() -> T): T {
     return sink(file, mustCreate = mustCreate).buffer().use {
       it.writerAction()
@@ -74,6 +85,9 @@ actual abstract class FileSystem {
 
   @Throws(IOException::class)
   actual abstract fun appendingSink(file: Path, mustExist: Boolean): Sink
+
+  @Throws(IOException::class)
+  fun appendingSink(file: Path): Sink = appendingSink(file, mustExist = false)
 
   @Throws(IOException::class)
   actual abstract fun createDirectory(dir: Path)

--- a/okio/src/jvmTest/java/okio/FileSystemJavaTest.java
+++ b/okio/src/jvmTest/java/okio/FileSystemJavaTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import kotlin.sequences.Sequence;
 import okio.fakefilesystem.FakeFileSystem;
 import org.junit.Test;
 
@@ -66,9 +67,37 @@ public final class FileSystemJavaTest {
     assertThat((Object) okioPath.toNioPath()).isEqualTo(nioPath);
   }
 
-  @Test
+  // Just confirm these APIs exist; don't invoke them
+  @SuppressWarnings("unused")
   public void fileSystemApi() throws IOException {
-    assertThat(FileSystem.SYSTEM.metadata(FileSystem.SYSTEM_TEMPORARY_DIRECTORY)).isNotNull();
+    FileSystem fileSystem = FileSystem.SYSTEM;
+    Path pathA = Path.get("a.txt");
+    Path pathB = Path.get("b.txt");
+    Path canonicalized = fileSystem.canonicalize(pathA);
+    FileMetadata metadata = fileSystem.metadata(pathA);
+    FileMetadata metadataOrNull = fileSystem.metadataOrNull(pathA);
+    boolean exists = fileSystem.exists(pathA);
+    List<Path> list = fileSystem.list(pathA);
+    List<Path> listOrNull = fileSystem.listOrNull(pathA);
+    Sequence<Path> listRecursivelyBoolean = fileSystem.listRecursively(pathA, false);
+    Sequence<Path> listRecursively = fileSystem.listRecursively(pathA);
+    FileHandle openReadOnly = fileSystem.openReadOnly(pathA);
+    FileHandle openReadOnlyBooleanBoolean = fileSystem.openReadWrite(pathA, false, false);
+    FileHandle openReadWrite = fileSystem.openReadWrite(pathA);
+    Source source = fileSystem.source(pathA);
+    // Note that FileSystem.read() isn't available to Java callers.
+    Sink sinkFalse = fileSystem.sink(pathA, false);
+    Sink sink = fileSystem.sink(pathA);
+    // Note that FileSystem.write() isn't available to Java callers.
+    Sink appendingSinkBoolean = fileSystem.appendingSink(pathA, false);
+    Sink appendingSink = fileSystem.appendingSink(pathA);
+    fileSystem.createDirectory(pathA);
+    fileSystem.createDirectories(pathA);
+    fileSystem.atomicMove(pathA, pathB);
+    fileSystem.copy(pathA, pathB);
+    fileSystem.delete(pathA);
+    fileSystem.deleteRecursively(pathA);
+    fileSystem.createSymlink(pathA, pathB);
   }
 
   @Test

--- a/okio/src/jvmTest/java/okio/ZipFileSystemJavaTest.java
+++ b/okio/src/jvmTest/java/okio/ZipFileSystemJavaTest.java
@@ -38,13 +38,9 @@ public final class ZipFileSystemJavaTest {
         .build();
     FileSystem zipFileSystem = Okio.openZip(fileSystem, zipPath);
 
-    String content = zipFileSystem.read(Path.get("hello.txt"), source -> {
-      try {
-        return source.readUtf8();
-      } catch (IOException e) {
-        throw new AssertionError(e);
-      }
-    });
-    assertThat(content).isEqualTo("Hello World");
+    try (BufferedSource source = Okio.buffer(zipFileSystem.source(Path.get("hello.txt")))) {
+      String content = source.readUtf8();
+      assertThat(content).isEqualTo("Hello World");
+    }
   }
 }


### PR DESCRIPTION
I am not using @JvmOverloads because they aren't supported for abstract functions,
and because I don't want to offer two overloads for functions that have two defaulted
parameters.

Also hide the two functions that take a lambda: read() and write(). These are
awful to call from Java because the body of the lamda can't throw an IOException.
I'd prefer to omit these completely than offer broken APIs. Later if we want we
could create our own lamda type here, but ARM blocks are idiomatic.