### PR TITLE
API change: make intersectWith() return a value

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/Timeout.kt
+++ b/okio/src/jvmMain/kotlin/okio/Timeout.kt
@@ -182,7 +182,7 @@ actual open class Timeout {
    * Applies the minimum intersection between this timeout and `other`, run `block`, then finally
    * rollback this timeout's values.
    */
-  inline fun intersectWith(other: Timeout, block: () -> Unit) {
+  inline fun <T> intersectWith(other: Timeout, block: () -> T): T {
     val originalTimeout = this.timeoutNanos()
     this.timeout(minTimeout(other.timeoutNanos(), this.timeoutNanos()), TimeUnit.NANOSECONDS)
 
@@ -192,7 +192,7 @@ actual open class Timeout {
         this.deadlineNanoTime(Math.min(this.deadlineNanoTime(), other.deadlineNanoTime()))
       }
       try {
-        block()
+        return block()
       } finally {
         this.timeout(originalTimeout, TimeUnit.NANOSECONDS)
         if (other.hasDeadline()) {
@@ -204,7 +204,7 @@ actual open class Timeout {
         this.deadlineNanoTime(other.deadlineNanoTime())
       }
       try {
-        block()
+        return block()
       } finally {
         this.timeout(originalTimeout, TimeUnit.NANOSECONDS)
         if (other.hasDeadline()) {

--- a/okio/src/jvmTest/kotlin/okio/TimeoutTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/TimeoutTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.rules.Timeout as JUnitTimeout
+
+class TimeoutTest {
+  @JvmField @Rule val timeout = JUnitTimeout(5, TimeUnit.SECONDS)
+
+  private val executorService = Executors.newScheduledThreadPool(1)
+
+  @After @Throws(Exception::class)
+  fun tearDown() {
+    executorService.shutdown()
+  }
+
+  @Test fun intersectWithReturnsAValue() {
+    val timeoutA = Timeout()
+    val timeoutB = Timeout()
+
+    val s = timeoutA.intersectWith(timeoutB) { "hello" }
+    assertEquals("hello", s)
+  }
+
+  @Test fun intersectWithPrefersSmallerTimeout() {
+    val timeoutA = Timeout()
+    timeoutA.timeout(smallerTimeoutNanos, TimeUnit.NANOSECONDS)
+
+    val timeoutB = Timeout()
+    timeoutB.timeout(biggerTimeoutNanos, TimeUnit.NANOSECONDS)
+
+    timeoutA.intersectWith(timeoutB) {
+      assertEquals(smallerTimeoutNanos, timeoutA.timeoutNanos())
+      assertEquals(biggerTimeoutNanos, timeoutB.timeoutNanos())
+    }
+    timeoutB.intersectWith(timeoutA) {
+      assertEquals(smallerTimeoutNanos, timeoutA.timeoutNanos())
+      assertEquals(smallerTimeoutNanos, timeoutB.timeoutNanos())
+    }
+    assertEquals(smallerTimeoutNanos, timeoutA.timeoutNanos())
+    assertEquals(biggerTimeoutNanos, timeoutB.timeoutNanos())
+  }
+
+  @Test fun intersectWithPrefersNonZeroTimeout() {
+    val timeoutA = Timeout()
+
+    val timeoutB = Timeout()
+    timeoutB.timeout(biggerTimeoutNanos, TimeUnit.NANOSECONDS)
+
+    timeoutA.intersectWith(timeoutB) {
+      assertEquals(biggerTimeoutNanos, timeoutA.timeoutNanos())
+      assertEquals(biggerTimeoutNanos, timeoutB.timeoutNanos())
+    }
+    timeoutB.intersectWith(timeoutA) {
+      assertEquals(0L, timeoutA.timeoutNanos())
+      assertEquals(biggerTimeoutNanos, timeoutB.timeoutNanos())
+    }
+    assertEquals(0L, timeoutA.timeoutNanos())
+    assertEquals(biggerTimeoutNanos, timeoutB.timeoutNanos())
+  }
+
+  @Test fun intersectWithPrefersSmallerDeadline() {
+    val timeoutA = Timeout()
+    timeoutA.deadlineNanoTime(smallerDeadlineNanos)
+
+    val timeoutB = Timeout()
+    timeoutB.deadlineNanoTime(biggerDeadlineNanos)
+
+    timeoutA.intersectWith(timeoutB) {
+      assertEquals(smallerDeadlineNanos, timeoutA.deadlineNanoTime())
+      assertEquals(biggerDeadlineNanos, timeoutB.deadlineNanoTime())
+    }
+    timeoutB.intersectWith(timeoutA) {
+      assertEquals(smallerDeadlineNanos, timeoutA.deadlineNanoTime())
+      assertEquals(smallerDeadlineNanos, timeoutB.deadlineNanoTime())
+    }
+    assertEquals(smallerDeadlineNanos, timeoutA.deadlineNanoTime())
+    assertEquals(biggerDeadlineNanos, timeoutB.deadlineNanoTime())
+  }
+
+  @Test fun intersectWithPrefersNonZeroDeadline() {
+    val timeoutA = Timeout()
+
+    val timeoutB = Timeout()
+    timeoutB.deadlineNanoTime(biggerDeadlineNanos)
+
+    timeoutA.intersectWith(timeoutB) {
+      assertEquals(biggerDeadlineNanos, timeoutA.deadlineNanoTime())
+      assertEquals(biggerDeadlineNanos, timeoutB.deadlineNanoTime())
+    }
+    timeoutB.intersectWith(timeoutA) {
+      assertFalse(timeoutA.hasDeadline())
+      assertEquals(biggerDeadlineNanos, timeoutB.deadlineNanoTime())
+    }
+    assertFalse(timeoutA.hasDeadline())
+    assertEquals(biggerDeadlineNanos, timeoutB.deadlineNanoTime())
+  }
+
+  companion object {
+    val smallerTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(500L)
+    val biggerTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(1500L)
+
+    val smallerDeadlineNanos = TimeUnit.MILLISECONDS.toNanos(500L)
+    val biggerDeadlineNanos = TimeUnit.MILLISECONDS.toNanos(1500L)
+  }
+}


### PR DESCRIPTION
This is a binary-incompatible change. It should be safe in-practice for the 3.0
upgrade because it's a very rarely-used function, and because the function is
always inlined.

Closes: https://github.com/square/okio/issues/709