### PR TITLE
Do not expect zips to start with a local file header

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 android.enableJetifier=true
 android.useAndroidX=true
 kotlin.js.compiler=both
+kotlin.mpp.stability.nowarn=true
 
 # Publishing SHA 256 and 512 hashses of maven-metadata is not supported by Sonatype and Nexus.
 # See https://github.com/gradle/gradle/issues/11308 and


### PR DESCRIPTION
Zips can contain arbitrary data anywhere prior to the central directory including before any local file entry. Empty zips are now detected based on the file count from the central directory.

Closes #1094 