### PR TITLE
Make `String.commonToPath(Boolean)` internal

### DIFF
--- a/okio/src/commonMain/kotlin/okio/internal/-Path.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/-Path.kt
@@ -294,7 +294,7 @@ internal inline fun Path.commonToString(): String {
   return bytes.utf8()
 }
 
-fun String.commonToPath(normalize: Boolean): Path {
+internal fun String.commonToPath(normalize: Boolean): Path {
   return Buffer().writeUtf8(this).toPath(normalize)
 }
 


### PR DESCRIPTION
Presumably the API should just be exposing `String.toPath(Boolean)` which delegates to `String.commonToPath(Boolean)`.