### PR TITLE
Throw on canonincalization of paths which do not exists

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/ZipFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/ZipFileSystem.kt
@@ -69,8 +69,11 @@ internal class ZipFileSystem internal constructor(
   private val comment: String?
 ) : FileSystem() {
   override fun canonicalize(path: Path): Path {
-    // TODO(jwilson): throw FileNotFoundException if the canonical file doesn't exist.
-    return canonicalizeInternal(path)
+    val canonical = canonicalizeInternal(path)
+    if (canonical !in entries) {
+      throw FileNotFoundException("$path")
+    }
+    return canonical
   }
 
   /** Don't throw [FileNotFoundException] if the path doesn't identify a file. */


### PR DESCRIPTION
Per `canonicalize` documentation.