### PR TITLE
Fix 'NSData.toByteString'

### DIFF
--- a/okio/src/appleMain/kotlin/okio/ByteString.kt
+++ b/okio/src/appleMain/kotlin/okio/ByteString.kt
@@ -23,7 +23,7 @@ import platform.posix.memcpy
 fun NSData.toByteString(): ByteString {
   val data = this
   val size = data.length.toInt()
-  return if (size != 0 ) {
+  return if (size != 0) {
     ByteString(
       ByteArray(size).apply {
         usePinned { pinned ->

--- a/okio/src/appleMain/kotlin/okio/ByteString.kt
+++ b/okio/src/appleMain/kotlin/okio/ByteString.kt
@@ -23,13 +23,15 @@ import platform.posix.memcpy
 fun NSData.toByteString(): ByteString {
   val data = this
   val size = data.length.toInt()
-  return ByteString(
-    ByteArray(size).apply {
-      if (size != 0 ) {
+  return if (size != 0 ) {
+    ByteString(
+      ByteArray(size).apply {
         usePinned { pinned ->
           memcpy(pinned.addressOf(0), data.bytes, data.length)
         }
       }
-    }
-  )
+    )
+  } else {
+    ByteString.EMPTY
+  }
 }

--- a/okio/src/appleMain/kotlin/okio/ByteString.kt
+++ b/okio/src/appleMain/kotlin/okio/ByteString.kt
@@ -22,10 +22,13 @@ import platform.posix.memcpy
 
 fun NSData.toByteString(): ByteString {
   val data = this
+  val size = data.length.toInt()
   return ByteString(
-    ByteArray(data.length.toInt()).apply {
-      usePinned { pinned ->
-        memcpy(pinned.addressOf(0), data.bytes, data.length)
+    ByteArray(size).apply {
+      if (size != 0 ) {
+        usePinned { pinned ->
+          memcpy(pinned.addressOf(0), data.bytes, data.length)
+        }
       }
     }
   )

--- a/okio/src/appleTest/kotlin/okio/AppleByteStringTest.kt
+++ b/okio/src/appleTest/kotlin/okio/AppleByteStringTest.kt
@@ -28,4 +28,10 @@ class AppleByteStringTest {
     val byteString = data.toByteString()
     assertEquals("Hello", byteString.utf8())
   }
+
+  @Test fun emptyNsDataToByteString() {
+    val data = ("" as NSString).dataUsingEncoding(NSUTF8StringEncoding) as NSData
+    val byteString = data.toByteString()
+    assertEquals("", byteString.utf8())
+  }
 }

--- a/okio/src/appleTest/kotlin/okio/AppleByteStringTest.kt
+++ b/okio/src/appleTest/kotlin/okio/AppleByteStringTest.kt
@@ -32,6 +32,6 @@ class AppleByteStringTest {
   @Test fun emptyNsDataToByteString() {
     val data = ("" as NSString).dataUsingEncoding(NSUTF8StringEncoding) as NSData
     val byteString = data.toByteString()
-    assertEquals("", byteString.utf8())
+    assertEquals(ByteString.EMPTY, byteString)
   }
 }


### PR DESCRIPTION
If you try to use `NSData.toByteString` with empty NSData method crashes with `kotlin.ArrayIndexOutOfBoundsException`