### PR TITLE
Make pom.xml depend on the JVM artifact

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,8 @@ import aQute.bnd.gradle.BundleTaskConvention
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
+import groovy.util.Node
+import groovy.util.NodeList
 import java.nio.charset.StandardCharsets
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
@@ -87,6 +89,7 @@ allprojects {
   }
 
   plugins.withId("com.vanniktech.maven.publish.base") {
+    val publishingExtension = extensions.getByType(PublishingExtension::class.java)
     configure<MavenPublishBaseExtension> {
       publishToMavenCentral(SonatypeHost.S01)
       signAllPublications()
@@ -110,6 +113,31 @@ allprojects {
           developer {
             id.set("square")
             name.set("Square, Inc.")
+          }
+        }
+      }
+
+      // Configure the kotlinMultiplatform artifact to depend on the JVM artifact in pom.xml only.
+      // This hack allows Maven users to continue using our original Okio artifact names (like
+      // com.squareup.okio:okio:3.x.y) even though we changed that artifact from JVM-only to Kotlin
+      // Multiplatform. Note that module.json doesn't need this hack.
+      val mavenPublications = publishingExtension.publications.withType<MavenPublication>()
+      mavenPublications.configureEach {
+        if (name != "jvm") return@configureEach
+        val jvmPublication = this
+        val kmpPublication = mavenPublications.getByName("kotlinMultiplatform")
+        kmpPublication.pom.withXml {
+          val root = asNode()
+          val dependencies = (root["dependencies"] as NodeList).firstOrNull() as Node?
+            ?: root.appendNode("dependencies")
+          for (child in dependencies.children().toList()) {
+            dependencies.remove(child as Node)
+          }
+          dependencies.appendNode("dependency").apply {
+            appendNode("groupId", jvmPublication.groupId)
+            appendNode("artifactId", jvmPublication.artifactId)
+            appendNode("version", jvmPublication.version)
+            appendNode("scope", "compile")
           }
         }
       }


### PR DESCRIPTION
This should prevent Maven users from needing to change
their dependencies from okio to okio-jvm. More importantly,
it should also prevent them from inadvertently getting two
different Okio JVM artifacts on their classpaths at once.