### PR TITLE
Seal the `BufferedSource`/`BufferedSink` hierarchy

### DIFF
--- a/okio/src/commonMain/kotlin/okio/BufferedSink.kt
+++ b/okio/src/commonMain/kotlin/okio/BufferedSink.kt
@@ -19,7 +19,7 @@ package okio
  * A sink that keeps a buffer internally so that callers can do small writes without a performance
  * penalty.
  */
-expect interface BufferedSink : Sink {
+expect sealed interface BufferedSink : Sink {
   /** This sink's internal buffer. */
   val buffer: Buffer
 

--- a/okio/src/commonMain/kotlin/okio/BufferedSource.kt
+++ b/okio/src/commonMain/kotlin/okio/BufferedSource.kt
@@ -20,7 +20,7 @@ package okio
  * penalty. It also allows clients to read ahead, buffering as much as necessary before consuming
  * input.
  */
-expect interface BufferedSource : Source {
+expect sealed interface BufferedSource : Source {
   /** This source's internal buffer. */
   val buffer: Buffer
 

--- a/okio/src/jvmMain/kotlin/okio/BufferedSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/BufferedSink.kt
@@ -20,7 +20,7 @@ import java.io.OutputStream
 import java.nio.channels.WritableByteChannel
 import java.nio.charset.Charset
 
-actual interface BufferedSink : Sink, WritableByteChannel {
+actual sealed interface BufferedSink : Sink, WritableByteChannel {
   /** Returns this sink's internal buffer. */
   @Deprecated(
     message = "moved to val: use getBuffer() instead",

--- a/okio/src/jvmMain/kotlin/okio/BufferedSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/BufferedSource.kt
@@ -20,7 +20,7 @@ import java.io.InputStream
 import java.nio.channels.ReadableByteChannel
 import java.nio.charset.Charset
 
-actual interface BufferedSource : Source, ReadableByteChannel {
+actual sealed interface BufferedSource : Source, ReadableByteChannel {
   /** Returns this source's internal buffer. */
   @Deprecated(
     message = "moved to val: use getBuffer() instead",

--- a/okio/src/nonJvmMain/kotlin/okio/BufferedSink.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/BufferedSink.kt
@@ -15,7 +15,7 @@
  */
 package okio
 
-actual interface BufferedSink : Sink {
+actual sealed interface BufferedSink : Sink {
   actual val buffer: Buffer
 
   actual fun write(byteString: ByteString): BufferedSink

--- a/okio/src/nonJvmMain/kotlin/okio/BufferedSource.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/BufferedSource.kt
@@ -15,7 +15,7 @@
  */
 package okio
 
-actual interface BufferedSource : Source {
+actual sealed interface BufferedSource : Source {
   actual val buffer: Buffer
 
   actual fun exhausted(): Boolean


### PR DESCRIPTION
These interfaces are not meant for third-party implementation. The `Buffer` type and the type returned by `.buffer()` are the only valid implementations.