### PR TITLE
Check thread isInterrupted before deleting on JvmSystemFileSystem

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/JvmSystemFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmSystemFileSystem.kt
@@ -124,7 +124,7 @@ internal open class JvmSystemFileSystem : FileSystem() {
   }
 
   override fun delete(path: Path, mustExist: Boolean) {
-    if (Thread.currentThread().isInterrupted) {
+    if (Thread.interrupted()) {
       // If the current thread has been interrupted.
       throw InterruptedIOException("interrupted")
     }

--- a/okio/src/jvmMain/kotlin/okio/JvmSystemFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmSystemFileSystem.kt
@@ -16,6 +16,7 @@
 package okio
 
 import okio.Path.Companion.toOkioPath
+import java.io.InterruptedIOException
 import java.io.RandomAccessFile
 
 /**
@@ -123,6 +124,10 @@ internal open class JvmSystemFileSystem : FileSystem() {
   }
 
   override fun delete(path: Path, mustExist: Boolean) {
+    if (Thread.currentThread().isInterrupted) {
+      // If the current thread has been interrupted.
+      throw InterruptedIOException("interrupted")
+    }
     val file = path.toFile()
     val deleted = file.delete()
     if (!deleted) {

--- a/okio/src/jvmTest/kotlin/okio/JvmSystemFileSystemTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/JvmSystemFileSystemTest.kt
@@ -16,6 +16,11 @@
 package okio
 
 import kotlinx.datetime.Clock
+import org.junit.Test
+import java.io.InterruptedIOException
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.fail
 
 /**
  * This test will run using [NioSystemFileSystem] by default. If [java.nio.file.Files] is not found
@@ -35,4 +40,16 @@ class JvmSystemFileSystemTest : AbstractFileSystemTest(
   windowsLimitations = Path.DIRECTORY_SEPARATOR == "\\",
   allowClobberingEmptyDirectories = Path.DIRECTORY_SEPARATOR == "\\",
   temporaryDirectory = FileSystem.SYSTEM_TEMPORARY_DIRECTORY
-)
+) {
+
+  @Test fun checkInterruptedBeforeDeleting() {
+    Thread.currentThread().interrupt()
+    try {
+      fileSystem.delete(base)
+      fail()
+    } catch (expected: InterruptedIOException) {
+      assertEquals("interrupted", expected.message)
+      assertFalse(Thread.interrupted())
+    }
+  }
+}


### PR DESCRIPTION
If we use `JvmSystemFileSystem.deleteRecursively()` to delete a folder that contains sub-files, then interrupt the thread, we want the delete action will be interrupted earlier.