### PR TITLE
Remove workaround and publish sha256/sha512 checksums

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,6 @@ android.useAndroidX=true
 kotlin.js.compiler=both
 kotlin.mpp.stability.nowarn=true
 
-# Publishing SHA 256 and 512 hashses of maven-metadata is not supported by Sonatype and Nexus.
-# See https://github.com/gradle/gradle/issues/11308 and
-# https://issues.sonatype.org/browse/NEXUS-21802
-systemProp.org.gradle.internal.publish.checksums.insecure=true
-
 # Enable compatibility with non-hierarchical projects.
 # See https://kotlinlang.org/docs/multiplatform-hierarchy.html#for-library-authors
 kotlin.mpp.enableCompatibilityMetadataVariant=true


### PR DESCRIPTION
Pretty sure this is not needed anymore as it was fixed by Sonatype. I've been running my projects without this and it's working fine these days.