### PR TITLE
Increase the performance of Gradle builds.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -177,4 +177,17 @@ subprojects {
       showStandardStreams = false
     }
   }
+
+  tasks.withType<AbstractArchiveTask>().configureEach {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+  }
+
+  normalization {
+    runtimeClasspath {
+      metaInf {
+        ignoreAttribute("Bnd-LastModified")
+      }
+    }
+  }
 }


### PR DESCRIPTION
Changes from this PR all work to increase the performance of Gradle builds for the project. Below is a summary of what these changes are and why they are recommended…

1.) Ignore the attribute ‘Bnd-LastModified’ from metadata files. 
Some snapshot jars (example okio-jvm-#.#.#-SNAPSHOT.jar) that are built within the project contain manifest files with the attribute ‘Bnd-LastModified’. This property is set to always set to the timestamp of the build, meaning that those manifest files will always be different for each build regardless of if anything else changes in the project. The end result is multiple Gradle tasks that have to be executed despite them being cacheable.

This was resolved by telling Gradle to ignore changes to the attribute ‘Bnd-LastModified’ for any manifest files that exist inside jars that are on the runtime classpath. This was accomplished by adding the following code snippet to the main build.gradle.kt file…

```kts
normalization {
    runtimeClasspath {
      metaInf {
        ignoreAttribute("Bnd-LastModified")
      }
    }
  }
```

2.) Ignoring file timestamps within archive files.
This project builds .klib files which Gradle is considering as different despite having identical content. The reason for this is that the timestamps of the files within these archives are different. This causes many tasks that could be cacheable to have to execute despite there being no real differences present. 

This was resolved by telling Gradle not to preserve timestamps within tasks that create archive files. Specifically, the following snippet was added to the main build.gradle.kt file…

```kts
  tasks.withType<AbstractArchiveTask>().configureEach {
    isPreserveFileTimestamps = false
    isReproducibleFileOrder = true
  }
```

EDIT
I wanted to include some additional info on how I found these inefficiencies and solutions. I used Gradle Enerprise to compare build scans for the project. After running the initial build, any task that is listed as cacheable but was executed anyways was a task I knew was worth investigating further. 

Go to [https://scans.gradle.com/s/i3mpo3cg4carm](url) to see more a build scan containing more info on the currently optimized build.