### PR TITLE
mkdocs: add light/dark mode toggle

### DIFF
--- a/docs/css/app.css
+++ b/docs/css/app.css
@@ -27,7 +27,7 @@ body, input {
     font-family: cash-market,"Helvetica Neue",helvetica,sans-serif;
     line-height: normal;
     font-weight: bold;
-    color: #353535;
+    color: var(--md-default-fg-color);
 }
 
 button.dl {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,10 +57,11 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.magiclink
   - pymdownx.smartsymbols
-  - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true 
   - pymdownx.tilde
   - tables
+  - pymdownx.superfences
 
 nav:
   - 'Overview': index.md
@@ -77,4 +78,3 @@ nav:
   - 'Multiplatform': multiplatform.md
   - 'Contributing': contributing.md
   - 'Code of Conduct': code_of_conduct.md
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,11 +57,11 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.magiclink
   - pymdownx.smartsymbols
+  - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true 
   - pymdownx.tilde
   - tables
-  - pymdownx.superfences
 
 nav:
   - 'Overview': index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,8 +14,22 @@ theme:
   favicon: images/icon-square.png
   logo: images/icon-square.png
   palette:
-    primary: 'deep purple'
-    accent: 'white'
+    # Palette toggle for light mode
+    - scheme: default
+      media: "(prefers-color-scheme: light)"
+      primary: 'deep purple'
+      accent: 'white'
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - scheme: slate
+      media: "(prefers-color-scheme: dark)"
+      primary: 'deep purple'
+      accent: 'white'
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   icon:
     repo: fontawesome/brands/github
 


### PR DESCRIPTION
Adds a light/dark mode toggle to the docs

Live demo: https://asemy.github.io/okio/

Documentation here: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette-toggle

Example config here: https://github.com/squidfunk/mkdocs-material/blob/2569d4f0884b9fe3be934215ce0cfddf8efc94b8/mkdocs.yml#L60-L72



This PR is based on https://github.com/cashapp/sqldelight/pull/3637