### PR TITLE
Run tests on JDK 18 + 19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
           - 13
           - 14
           - 15
+          - 18
+          - 19
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Ahead of some testing with Loom on 19. https://github.com/square/okio/pull/1176

Add regular builds in for 18 + 19.