### PR TITLE
Fix PipeTest to be less flaky

### DIFF
--- a/okio/src/jvmTest/java/okio/PipeTest.java
+++ b/okio/src/jvmTest/java/okio/PipeTest.java
@@ -371,6 +371,6 @@ public final class PipeTest {
    * -50..+450 milliseconds.
    */
   private void assertElapsed(double duration, double start) {
-    assertEquals(duration, now() - start - 200d, 250.0);
+    assertEquals(duration, now() - start + 200d, 250.0);
   }
 }


### PR DESCRIPTION
The code was commented to permit -50..+450, but was implemented to permit -450..+50. This fixes the code to match the comment.