### PR TITLE
Don't do CI builds for obsolete JDKs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,8 @@ jobs:
       matrix:
         java-version:
           - 8
-          - 9
-          - 10
           - 11
-          - 12
-          - 13
-          - 14
-          - 15
-          - 18
+          - 17
           - 19
 
     steps:


### PR DESCRIPTION
This is motivated by an accute problem with OpenJDK 10, which is consistently failing in CI for reasons wholy unrelated to Okio.

    > Configure project :android-test
    Unable to detect AGP versions for included builds. All projects in the build should use the same AGP version. Class name for the included build object: org.gradle.composite.internal.DefaultIncludedBuild$IncludedBuildImpl_Decorated.
    e: /home/runner/work/okio/okio/android-test/build.gradle.kts:18:1: Unresolved reference: android

It's likely Gradle or AGP or something doesn't work on Java 10, even though it does work on Java 8, Java 9, Java 11, and Java 12.

I'm not interested in debugging this problem; the right fix for it is 'Upgrade to a newer JDK'.

I've specifically dropped unmaintained JDKs according to this page: https://en.wikipedia.org/wiki/Java_version_history