### PR TITLE
Make UnsafeCursor implement Closable interface in multiplatform (Fixes #1238)

### DIFF
--- a/okio/src/commonMain/kotlin/okio/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/Buffer.kt
@@ -337,7 +337,7 @@ expect class Buffer() : BufferedSource, BufferedSink {
    * You can reuse instances of this class if you like. Use the overloads of [Buffer.readUnsafe] and
    * [Buffer.readAndWriteUnsafe] that take a cursor and close it after use.
    */
-  class UnsafeCursor constructor() {
+  class UnsafeCursor constructor() : Closeable {
     @JvmField var buffer: Buffer?
 
     @JvmField var readWrite: Boolean
@@ -408,6 +408,6 @@ expect class Buffer() : BufferedSource, BufferedSink {
      */
     fun expandBuffer(minByteCount: Int): Long
 
-    fun close()
+    override fun close()
   }
 }

--- a/okio/src/commonTest/kotlin/okio/UnsafeCursorTest.kt
+++ b/okio/src/commonTest/kotlin/okio/UnsafeCursorTest.kt
@@ -17,6 +17,7 @@ package okio
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class UnsafeCursorTest {
   @Test fun acquireForRead() {
@@ -83,5 +84,9 @@ class UnsafeCursorTest {
     }
 
     assertEquals("z".repeat(100), buffer.readUtf8())
+  }
+
+  @Test fun testUnsafeCursorIsClosable() {
+    assertTrue(Closeable::class.isInstance(Buffer.UnsafeCursor()))
   }
 }

--- a/okio/src/nonJvmMain/kotlin/okio/Buffer.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/Buffer.kt
@@ -297,7 +297,7 @@ actual class Buffer : BufferedSource, BufferedSink {
   actual fun readAndWriteUnsafe(unsafeCursor: UnsafeCursor): UnsafeCursor =
     commonReadAndWriteUnsafe(unsafeCursor)
 
-  actual class UnsafeCursor {
+  actual class UnsafeCursor : Closeable {
     actual var buffer: Buffer? = null
     actual var readWrite: Boolean = false
 
@@ -315,7 +315,7 @@ actual class Buffer : BufferedSource, BufferedSink {
 
     actual fun expandBuffer(minByteCount: Int): Long = commonExpandBuffer(minByteCount)
 
-    actual fun close() {
+    actual override fun close() {
       commonClose()
     }
   }


### PR DESCRIPTION
While docs recommend to use `Closable.use` extension to manage UnsafeCursor as resource, `Closable.use` extension is not applicable to UnsafeCursor because UnsafeCursor does not implement Closable interface.

This PR contains:

1. Multiplatform test to ensure Unsafe Cursor implements Closeable interface
2. Commit that fixes #1238 and ensures the test above