### PR TITLE
Minor edits to the Buffer.copy/clone Kdoc

### DIFF
--- a/okio/src/commonMain/kotlin/okio/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/Buffer.kt
@@ -133,7 +133,10 @@ expect class Buffer() : BufferedSource, BufferedSink {
 
   override fun writeHexadecimalUnsignedLong(v: Long): Buffer
 
-  /** Returns a deep copy of this buffer.  */
+  /**
+   * Returns a deep copy of this buffer. The returned [Buffer] initially shares the underlying
+   * [ByteArray]s. See [UnsafeCursor] for more details.
+   */
   fun copy(): Buffer
 
   /** Returns an immutable copy of this buffer as a byte string.  */
@@ -240,7 +243,7 @@ expect class Buffer() : BufferedSource, BufferedSink {
    * // start = 0     end = 3
    * ```
    *
-   * There is an optimization in `Buffer.clone()` and other methods that allows two segments to
+   * There is an optimization in `Buffer.copy()` and other methods that allows two segments to
    * share the same underlying byte array. Clones can't write to the shared byte array; instead they
    * allocate a new (private) segment early.
    *
@@ -253,7 +256,7 @@ expect class Buffer() : BufferedSource, BufferedSink {
    * //              ^                                  ^
    * //           start = 2                         end = 5000
    *
-   * nana2 = nana.clone()
+   * nana2 = nana.copy()
    * nana2.writeUtf8("batman")
    *
    * // [ 'n', 'a', 'n', 'a', ..., 'n', 'a', 'n', 'a', '?', '?', '?', ...]

--- a/okio/src/jvmMain/kotlin/okio/Buffer.kt
+++ b/okio/src/jvmMain/kotlin/okio/Buffer.kt
@@ -577,7 +577,10 @@ actual class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
 
   actual fun copy(): Buffer = commonCopy()
 
-  /** Returns a deep copy of this buffer. */
+  /**
+   * Returns a deep copy of this buffer. This is the same as [copy] but allows [Buffer] to implement
+   * the [Cloneable] interface on the JVM.
+   */
   public override fun clone(): Buffer = copy()
 
   actual fun snapshot(): ByteString = commonSnapshot()


### PR DESCRIPTION
Been wondering for some time why there was both [copy](https://square.github.io/okio/3.x/okio/okio/okio/-buffer/index.html#-18127258%2FFunctions%2F-1473893935) and [clone](https://square.github.io/okio/3.x/okio/okio/okio/-buffer/index.html#1052611650%2FFunctions%2F1773621890).  Looks like `clone` is a JVM only thing and there's no other reason than implementing `Cloneable`? Hoping this can clear the confusion. Also added a note about `copy()` initially sharing the ByteArrays.