### PR TITLE
Add `okio-jvm` to `okio-bom`

### DIFF
--- a/okio-bom/build.gradle.kts
+++ b/okio-bom/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
   constraints {
     api(projects.okio)
+    api(projects.okio.group + ":okio-jvm:" + projects.okio.version)
     api(projects.okioFakefilesystem)
     if (kmpJsEnabled) {
       // No typesafe project accessor as the accessor won't exist if kmpJs is not enabled.


### PR DESCRIPTION
Fixes #1121.

Suggested commit message:
```
Add `okio-jvm` to `okio-bom` (#1256)

Fixes #1121.
```

Verified that it works by:
1. Running `../gradlew publishToMavenLocal` in `okio-bom`.
2. Running `vimdiff ~/.m2/repository/com/squareup/okio/okio-bom/{3.3.0,3.4.0-SNAPSHOT}/*.pom` and comparing the output. 

Relevant output:
```
+ <dependency>                                                                                     
+    <groupId>com.squareup.okio</groupId>                                                           
+    <artifactId>okio-jvm</artifactId>                                                              
+    <version>3.4.0-SNAPSHOT</version>                                                              
+ </dependency>
```