### PR TITLE
Invert supportsFileHandle and supportsSymlink

### DIFF
--- a/okio-testing-support/src/commonMain/kotlin/okio/AbstractFileSystemTest.kt
+++ b/okio-testing-support/src/commonMain/kotlin/okio/AbstractFileSystemTest.kt
@@ -2312,14 +2312,9 @@ abstract class AbstractFileSystemTest(
 
   private fun supportsFileHandle(): Boolean {
     return when (fileSystem::class.simpleName) {
-      "FakeFileSystem",
-      "JvmSystemFileSystem",
-      "NioSystemFileSystem",
-      "NioFileSystemWrappingFileSystem",
-      "PosixFileSystem",
-      "NodeJsFileSystem",
-      -> true
-      else -> false
+      "AddFileSystemNameIfNotSupportingAny",
+      -> false
+      else -> true
     }
   }
 
@@ -2327,13 +2322,10 @@ abstract class AbstractFileSystemTest(
     if (fileSystem is FakeFileSystem) return fileSystem.allowSymlinks
     if (windowsLimitations) return false
     return when (fileSystem::class.simpleName) {
-      "NodeJsFileSystem",
-      "PosixFileSystem",
-      "NioSystemFileSystem",
-      // TODO(Benoit) We have troubles with relative symlinks.
-      // "NioFileSystemWrappingFileSystem",
-      -> true
-      else -> false
+      "JvmSystemFileSystem",
+      "NioFileSystemWrappingFileSystem",
+      -> false
+      else -> true
     }
   }
 


### PR DESCRIPTION
This will force new implementation to pay attention.