### PR TITLE
Fix conversion of signed constants to unsigned

### DIFF
--- a/okio/src/nativeMain/kotlin/okio/SizetVariant.kt
+++ b/okio/src/nativeMain/kotlin/okio/SizetVariant.kt
@@ -29,11 +29,11 @@ internal fun variantFread(
   target: CPointer<ByteVarOf<Byte>>,
   byteCount: UInt,
   file: CPointer<FILE>,
-): UInt = fread(target, 1, byteCount.convert(), file).convert()
+): UInt = fread(target, 1u, byteCount.convert(), file).convert()
 
 @OptIn(UnsafeNumber::class)
 internal fun variantFwrite(
   source: CPointer<ByteVar>,
   byteCount: UInt,
   file: CPointer<FILE>,
-): UInt = fwrite(source, 1, byteCount.convert(), file).convert()
+): UInt = fwrite(source, 1u, byteCount.convert(), file).convert()


### PR DESCRIPTION
Signed integer constant cannot be automatically converted to unsigned integer anymore after Kotlin 1.9.0.

See https://youtrack.jetbrains.com/issue/KT-56583 for detail