### PR TITLE
Fix a bug where xlen larger than 0x7fff was rejected

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/GzipSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/GzipSource.kt
@@ -117,7 +117,7 @@ class GzipSource(source: Source) : Source {
     if (flags.getBit(FEXTRA)) {
       source.require(2)
       if (fhcrc) updateCrc(source.buffer, 0, 2)
-      val xlen = source.buffer.readShortLe().toLong()
+      val xlen = (source.buffer.readShortLe().toInt() and 0xffff).toLong()
       source.require(xlen)
       if (fhcrc) updateCrc(source.buffer, 0, xlen)
       source.skip(xlen)


### PR DESCRIPTION
We treated this short value as unsigned and it should have been treated as signed.