### PR TITLE
Fix FileHandle read/write with empty array

### DIFF
--- a/okio-testing-support/src/nonWasmMain/kotlin/okio/AbstractFileSystemTest.kt
+++ b/okio-testing-support/src/nonWasmMain/kotlin/okio/AbstractFileSystemTest.kt
@@ -18,6 +18,7 @@ package okio
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
@@ -1679,6 +1680,23 @@ abstract class AbstractFileSystemTest(
     }
 
     assertEquals(writtenBytes, readBytes)
+  }
+
+  @Test fun fileHandleEmptyArrayWriteAndRead() {
+    val path = base / "file-handle-empty-array-write-and-read"
+
+    val writtenBytes = ByteArray(0)
+    fileSystem.openReadWrite(path).use { handle ->
+      handle.write(0, writtenBytes, 0, writtenBytes.size)
+    }
+
+    val readBytes = fileSystem.openReadWrite(path).use { handle ->
+      val byteArray = ByteArray(writtenBytes.size)
+      handle.read(0, byteArray, 0, byteArray.size)
+      return@use byteArray
+    }
+
+    assertContentEquals(writtenBytes, readBytes)
   }
 
   @Test fun fileHandleSinkPosition() {

--- a/okio/src/mingwX64Main/kotlin/okio/WindowsFileHandle.kt
+++ b/okio/src/mingwX64Main/kotlin/okio/WindowsFileHandle.kt
@@ -57,8 +57,12 @@ internal class WindowsFileHandle(
     arrayOffset: Int,
     byteCount: Int,
   ): Int {
-    val bytesRead = array.usePinned { pinned ->
-      variantPread(pinned.addressOf(arrayOffset), byteCount, fileOffset)
+    val bytesRead = if (array.isNotEmpty()) {
+      array.usePinned { pinned ->
+        variantPread(pinned.addressOf(arrayOffset), byteCount, fileOffset)
+      }
+    } else {
+      0
     }
     if (bytesRead == 0) return -1
     return bytesRead
@@ -93,8 +97,12 @@ internal class WindowsFileHandle(
     arrayOffset: Int,
     byteCount: Int,
   ) {
-    val bytesWritten = array.usePinned { pinned ->
-      variantPwrite(pinned.addressOf(arrayOffset), byteCount, fileOffset)
+    val bytesWritten = if (array.isNotEmpty()) {
+      array.usePinned { pinned ->
+        variantPwrite(pinned.addressOf(arrayOffset), byteCount, fileOffset)
+      }
+    } else {
+      0
     }
     if (bytesWritten != byteCount) throw IOException("bytesWritten=$bytesWritten")
   }

--- a/okio/src/unixMain/kotlin/okio/UnixFileHandle.kt
+++ b/okio/src/unixMain/kotlin/okio/UnixFileHandle.kt
@@ -50,8 +50,12 @@ internal class UnixFileHandle(
     arrayOffset: Int,
     byteCount: Int,
   ): Int {
-    val bytesRead = array.usePinned { pinned ->
-      variantPread(file, pinned.addressOf(arrayOffset), byteCount, fileOffset)
+    val bytesRead = if (array.isNotEmpty()) {
+      array.usePinned { pinned ->
+        variantPread(file, pinned.addressOf(arrayOffset), byteCount, fileOffset)
+      }
+    } else {
+      0
     }
     if (bytesRead == -1) throw errnoToIOException(errno)
     if (bytesRead == 0) return -1
@@ -64,8 +68,12 @@ internal class UnixFileHandle(
     arrayOffset: Int,
     byteCount: Int,
   ) {
-    val bytesWritten = array.usePinned { pinned ->
-      variantPwrite(file, pinned.addressOf(arrayOffset), byteCount, fileOffset)
+    val bytesWritten = if (array.isNotEmpty()) {
+      array.usePinned { pinned ->
+        variantPwrite(file, pinned.addressOf(arrayOffset), byteCount, fileOffset)
+      }
+    } else {
+      0
     }
     if (bytesWritten != byteCount) throw errnoToIOException(errno)
   }


### PR DESCRIPTION
If you try to use `FileHandle.read/write` with empty ByteArray on Native, method crashes with kotlin.ArrayIndexOutOfBoundsException.