### PR TITLE
NioFS: fix relative paths when listing a dir

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/NioFileSystemWrappingFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/NioFileSystemWrappingFileSystem.kt
@@ -74,7 +74,7 @@ internal class NioFileSystemWrappingFileSystem(private val nioFileSystem: NioFil
         return null
       }
     }
-    val result = entries.mapTo(mutableListOf()) { entry -> dir / entry.toString() }
+    val result = entries.mapTo(mutableListOf()) { entry -> entry.toOkioPath() }
     result.sort()
     return result
   }


### PR DESCRIPTION
which was not detected before because relative tests uses DOT