### PR TITLE
Exclude wasm from the publish job until it's ready

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload Artifacts
         run: |
-          ./gradlew clean publish --stacktrace
+          ./gradlew clean publish -Dkwasm=false --stacktrace
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
Snapshot publications fail because of this. I think we'll remember to take it out once ready to ship?