### PR TITLE
Set up spotless header configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -169,6 +169,11 @@ subprojects {
     kotlin {
       target("**/*.kt")
       ktlint(libs.versions.ktlint.get())
+      licenseHeaderFile(rootProject.file("gradle/license-header.txt"))
+      targetExcludeIfContentContainsRegex("" +
+        "// Copyright 2019-2023 the Contributors to the WASI Specification|" +
+        "// ktlint-disable filename|" +
+        "Licensed to the Apache Software Foundation \\(ASF\\) under one or more")
     }
   }
 

--- a/gradle/license-header.txt
+++ b/gradle/license-header.txt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradle/license-header.txt
+++ b/gradle/license-header.txt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) $YEAR Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/okio-nodefilesystem/src/main/kotlin/okio/FsJs.kt
+++ b/okio-nodefilesystem/src/main/kotlin/okio/FsJs.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:JsModule("fs")
+@file:JsNonModule
 
 /**
  * This class declares the subset of Node.js file system APIs that we need in Okio.
@@ -69,8 +71,6 @@
  * [Dukat]: https://github.com/kotlin/dukat
  * [kotlinx_nodejs]: https://github.com/Kotlin/kotlinx-nodejs
  */
-@file:JsModule("fs")
-@file:JsNonModule
 
 package okio
 

--- a/okio-testing-support/src/jvmMain/kotlin/okio/TestingExecutors.kt
+++ b/okio-testing-support/src/jvmMain/kotlin/okio/TestingExecutors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Block, Inc.
+ * Copyright (C) 2023 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okio/jvm/jmh/src/jmh/java/com/squareup/okio/benchmarks/BenchmarkUtils.kt
+++ b/okio/jvm/jmh/src/jmh/java/com/squareup/okio/benchmarks/BenchmarkUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Square, Inc. and others.
+ * Copyright (C) 2018 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okio/src/appleMain/kotlin/okio/ByteString.kt
+++ b/okio/src/appleMain/kotlin/okio/ByteString.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import kotlinx.cinterop.UnsafeNumber

--- a/okio/src/commonMain/kotlin/okio/ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/ByteString.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import kotlin.jvm.JvmField

--- a/okio/src/commonMain/kotlin/okio/CommonPlatform.kt
+++ b/okio/src/commonMain/kotlin/okio/CommonPlatform.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/okio/src/commonMain/kotlin/okio/Okio.kt
+++ b/okio/src/commonMain/kotlin/okio/Okio.kt
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/** Essential APIs for working with Okio. */
 @file:JvmMultifileClass
 @file:JvmName("Okio")
+
+/** Essential APIs for working with Okio. */
 
 package okio
 

--- a/okio/src/commonMain/kotlin/okio/PeekSource.kt
+++ b/okio/src/commonMain/kotlin/okio/PeekSource.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 /**

--- a/okio/src/commonMain/kotlin/okio/RealBufferedSink.kt
+++ b/okio/src/commonMain/kotlin/okio/RealBufferedSink.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 internal expect class RealBufferedSink(

--- a/okio/src/commonMain/kotlin/okio/RealBufferedSource.kt
+++ b/okio/src/commonMain/kotlin/okio/RealBufferedSource.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 internal expect class RealBufferedSource(

--- a/okio/src/commonMain/kotlin/okio/Utf8.kt
+++ b/okio/src/commonMain/kotlin/okio/Utf8.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:JvmName("Utf8")
 
 /**
  * Okio assumes most applications use UTF-8 exclusively, and offers optimized implementations of
@@ -61,7 +62,6 @@
  * </tr>
  * </table>
  */
-@file:JvmName("Utf8")
 
 package okio
 

--- a/okio/src/commonMain/kotlin/okio/Util.kt
+++ b/okio/src/commonMain/kotlin/okio/Util.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/okio/src/commonMain/kotlin/okio/internal/ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/ByteString.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/okio/src/commonMain/kotlin/okio/internal/RealBufferedSink.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/RealBufferedSink.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// TODO move to RealBufferedSink class: https://youtrack.jetbrains.com/issue/KT-20427
 @file:Suppress("NOTHING_TO_INLINE")
 
 @file:JvmName("-RealBufferedSink") // A leading '-' hides this class from Java.
+
+// TODO move to RealBufferedSink class: https://youtrack.jetbrains.com/issue/KT-20427
 
 package okio.internal
 

--- a/okio/src/commonMain/kotlin/okio/internal/RealBufferedSource.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/RealBufferedSource.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// TODO move to RealBufferedSource class: https://youtrack.jetbrains.com/issue/KT-20427
 @file:Suppress("NOTHING_TO_INLINE")
 
 @file:JvmName("-RealBufferedSource") // A leading '-' hides this class from Java.
+
+// TODO move to RealBufferedSource class: https://youtrack.jetbrains.com/issue/KT-20427
 
 package okio.internal
 

--- a/okio/src/commonMain/kotlin/okio/internal/SegmentedByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/SegmentedByteString.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// TODO move to SegmentedByteString class: https://youtrack.jetbrains.com/issue/KT-20427
 @file:Suppress("NOTHING_TO_INLINE")
 
 @file:JvmName("-SegmentedByteString") // A leading '-' hides this class from Java.
+
+// TODO move to SegmentedByteString class: https://youtrack.jetbrains.com/issue/KT-20427
 
 package okio.internal
 

--- a/okio/src/commonTest/kotlin/okio/AbstractBufferedSinkTest.kt
+++ b/okio/src/commonTest/kotlin/okio/AbstractBufferedSinkTest.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import kotlin.test.Test

--- a/okio/src/commonTest/kotlin/okio/AbstractBufferedSourceTest.kt
+++ b/okio/src/commonTest/kotlin/okio/AbstractBufferedSourceTest.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import kotlin.test.Test

--- a/okio/src/commonTest/kotlin/okio/BufferedSinkFactory.kt
+++ b/okio/src/commonTest/kotlin/okio/BufferedSinkFactory.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 internal interface BufferedSinkFactory {

--- a/okio/src/commonTest/kotlin/okio/BufferedSourceFactory.kt
+++ b/okio/src/commonTest/kotlin/okio/BufferedSourceFactory.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 interface BufferedSourceFactory {

--- a/okio/src/commonTest/kotlin/okio/ByteStringFactory.kt
+++ b/okio/src/commonTest/kotlin/okio/ByteStringFactory.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import okio.ByteString.Companion.decodeHex

--- a/okio/src/commonTest/kotlin/okio/ByteStringMoreTests.kt
+++ b/okio/src/commonTest/kotlin/okio/ByteStringMoreTests.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import kotlin.test.Test

--- a/okio/src/commonTest/kotlin/okio/ByteStringTest.kt
+++ b/okio/src/commonTest/kotlin/okio/ByteStringTest.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import kotlin.random.Random

--- a/okio/src/commonTest/kotlin/okio/CommonOkioKotlinTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonOkioKotlinTest.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import kotlin.test.Test

--- a/okio/src/commonTest/kotlin/okio/CommonRealBufferedSinkTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonRealBufferedSinkTest.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import kotlin.test.Test

--- a/okio/src/commonTest/kotlin/okio/CommonRealBufferedSourceTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonRealBufferedSourceTest.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import kotlin.test.Test

--- a/okio/src/commonTest/kotlin/okio/HashingTest.kt
+++ b/okio/src/commonTest/kotlin/okio/HashingTest.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 Square Inc.
+ * Copyright (C) 2014 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/okio/src/commonTest/kotlin/okio/Utf8KotlinTest.kt
+++ b/okio/src/commonTest/kotlin/okio/Utf8KotlinTest.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import kotlin.test.Test

--- a/okio/src/hashFunctions/kotlin/okio/internal/HashFunction.kt
+++ b/okio/src/hashFunctions/kotlin/okio/internal/HashFunction.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Square, Inc. and others.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okio/src/hashFunctions/kotlin/okio/internal/Md5.kt
+++ b/okio/src/hashFunctions/kotlin/okio/internal/Md5.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/okio/src/hashFunctions/kotlin/okio/internal/Sha1.kt
+++ b/okio/src/hashFunctions/kotlin/okio/internal/Sha1.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/okio/src/hashFunctions/kotlin/okio/internal/Sha256.kt
+++ b/okio/src/hashFunctions/kotlin/okio/internal/Sha256.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/okio/src/hashFunctions/kotlin/okio/internal/Sha512.kt
+++ b/okio/src/hashFunctions/kotlin/okio/internal/Sha512.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/okio/src/jvmMain/kotlin/okio/ByteString.kt
+++ b/okio/src/jvmMain/kotlin/okio/ByteString.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 Square Inc.
+ * Copyright (C) 2014 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Square, Inc. and others.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Square, Inc. and others.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okio/src/jvmMain/kotlin/okio/DeflaterSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/DeflaterSink.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 @file:JvmName("-DeflaterSinkExtensions")
 @file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
 

--- a/okio/src/jvmMain/kotlin/okio/GzipSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/GzipSink.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 @file:JvmName("-GzipSinkExtensions")
 @file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
 

--- a/okio/src/jvmMain/kotlin/okio/GzipSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/GzipSource.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 @file:JvmName("-GzipSourceExtensions")
 @file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
 

--- a/okio/src/jvmMain/kotlin/okio/InflaterSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/InflaterSource.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 @file:JvmName("-InflaterSourceExtensions")
 @file:Suppress("NOTHING_TO_INLINE") // Aliases to public API.
 

--- a/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/** Essential APIs for working with Okio. */
 @file:JvmMultifileClass
 @file:JvmName("Okio")
+
+/** Essential APIs for working with Okio. */
 
 package okio
 

--- a/okio/src/jvmTest/kotlin/okio/AwaitSignalTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/AwaitSignalTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Block Inc.
+ * Copyright (C) 2023 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okio/src/jvmTest/kotlin/okio/ByteStringJavaTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ByteStringJavaTest.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 Square Inc.
+ * Copyright (C) 2014 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/okio/src/jvmTest/kotlin/okio/CipherAlgorithm.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherAlgorithm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Square, Inc. and others.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Square, Inc. and others.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Square, Inc. and others.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Square, Inc. and others.
+ * Copyright (C) 2020 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okio/src/jvmTest/kotlin/okio/DeflateKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/DeflateKotlinTest.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import java.util.zip.Deflater

--- a/okio/src/jvmTest/kotlin/okio/GzipKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/GzipKotlinTest.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import kotlin.test.assertEquals

--- a/okio/src/jvmTest/kotlin/okio/MessageDigestConsistencyTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/MessageDigestConsistencyTest.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/okio/src/jvmTest/kotlin/okio/OkioKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/OkioKotlinTest.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import java.io.ByteArrayInputStream

--- a/okio/src/nativeMain/kotlin/okio/SizetVariant.kt
+++ b/okio/src/nativeMain/kotlin/okio/SizetVariant.kt
@@ -1,18 +1,18 @@
 /*
-* Copyright (C) 2020 Square, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okio
 
 import kotlinx.cinterop.ByteVar

--- a/okio/src/nonAppleMain/kotlin/okio/ByteString.kt
+++ b/okio/src/nonAppleMain/kotlin/okio/ByteString.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import okio.internal.HashFunction

--- a/okio/src/nonJvmMain/kotlin/okio/NonJvmPlatform.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/NonJvmPlatform.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import okio.internal.commonAsUtf8ToByteArray

--- a/okio/src/nonJvmMain/kotlin/okio/RealBufferedSink.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/RealBufferedSink.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okio
 
 import okio.internal.commonClose

--- a/okio/src/nonWasmTest/kotlin/okio/UseTest.kt
+++ b/okio/src/nonWasmTest/kotlin/okio/UseTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okio
 
 import kotlin.test.Test


### PR DESCRIPTION
The feature I added to spotless makes it a bit easier to exclude files we don't own.
I had to move some comments/documentations below the first JVM instruction to avoid getting it removed.