### PR TITLE
Attempt to fix website publishing

### DIFF
--- a/okio-wasifilesystem/build.gradle.kts
+++ b/okio-wasifilesystem/build.gradle.kts
@@ -6,7 +6,9 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 
 plugins {
   kotlin("multiplatform")
-  id("org.jetbrains.dokka")
+  // TODO: Restore Dokka once this issue is resolved.
+  //     https://github.com/Kotlin/dokka/issues/3038
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base")
   id("build-support")
   id("binary-compatibility-validator")


### PR DESCRIPTION
Attempting to run dokkaHtml causes a crash at configuration time that can't be suppressed more precisely.