### PR TITLE
Handle JDK Deflater throwing NPE

### DIFF
--- a/okio/src/jvmTest/kotlin/okio/DeflaterSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/DeflaterSinkTest.kt
@@ -129,9 +129,8 @@ class DeflaterSinkTest {
   }
 
   /**
-   * This test deflates a single segment of without compression because that's
-   * the easiest way to force close() to emit a large amount of data to the
-   * underlying sink.
+   * This test confirms that we swallow NullPointerException from Deflater and
+   * rethrow as an IOException.
    */
   @Test
   fun rethrowNullPointerAsIOException() {


### PR DESCRIPTION
From https://github.com/square/okhttp/issues/6719

Not sure it isn't a programming bug, but even if so, IOException seems appropriate.