### PR TITLE
Fix file leak when using `metadata` functions

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/ZipFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/ZipFileSystem.kt
@@ -99,10 +99,11 @@ internal class ZipFileSystem internal constructor(
       return basicMetadata
     }
 
-    val source = fileSystem.openReadOnly(zipPath).use { fileHandle ->
-      fileHandle.source(entry.offset).buffer()
+    return fileSystem.openReadOnly(zipPath).use { fileHandle ->
+      return@use fileHandle.source(entry.offset).buffer().use { source ->
+        source.readLocalHeader(basicMetadata)
+      }
     }
-    return source.readLocalHeader(basicMetadata)
   }
 
   override fun openReadOnly(file: Path): FileHandle {

--- a/okio/src/jvmTest/kotlin/okio/FileLeakTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/FileLeakTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2023 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class FileLeakTest {
+
+  private lateinit var fakeFileSystem: FakeFileSystem
+  private val fakeZip = "/test.zip".toPath()
+  private val fakeEntry = "some.file".toPath()
+
+  @Before
+  fun setup() {
+    fakeFileSystem = FakeFileSystem()
+    with(fakeFileSystem) {
+      write(fakeZip) {
+        writeZip {
+          putEntry(fakeEntry.name) {
+            writeUtf8("FooBar")
+          }
+        }
+      }
+    }
+  }
+
+  @After
+  fun tearDown() {
+    fakeFileSystem.checkNoOpenFiles()
+  }
+
+  @Test
+  fun zipFileSystemExistsTest() {
+    val zipFileSystem = fakeFileSystem.openZip(fakeZip)
+    assertTrue(zipFileSystem.exists(fakeEntry))
+    fakeFileSystem.checkNoOpenFiles()
+  }
+
+  @Test
+  fun zipFileSystemMetadataTest() {
+    val zipFileSystem = fakeFileSystem.openZip(fakeZip)
+    assertNotNull(zipFileSystem.metadataOrNull(fakeEntry))
+    fakeFileSystem.checkNoOpenFiles()
+  }
+
+  @Test
+  fun zipFileSystemSourceTest() {
+    val zipFileSystem = fakeFileSystem.openZip(fakeZip)
+    zipFileSystem.source(fakeEntry).use { source ->
+      assertEquals("FooBar", source.buffer().readUtf8())
+    }
+    fakeFileSystem.checkNoOpenFiles()
+  }
+}
+
+/**
+ * Writes a ZIP file to a [BufferedSink].
+ */
+private inline fun <R> BufferedSink.writeZip(action: ZipOutputStream.() -> R): R {
+  return ZipOutputStream(outputStream()).use(action)
+}
+
+/**
+ * Adds a new ZIP entry named [name], populates it with [action], and closes the entry.
+ */
+private inline fun <R> ZipOutputStream.putEntry(name: String, action: BufferedSink.() -> R): R {
+  putNextEntry(ZipEntry(name).apply { time = 0L })
+  val sink = sink().buffer()
+  return try {
+    sink.action()
+  } finally {
+    sink.flush()
+    closeEntry()
+  }
+}


### PR DESCRIPTION
Discovered this issue via the [wire](https://github.com/square/wire) project.

The issue here is that the `ZipFileSystem` creates a `Source` object, which is then returned out of the `use` lambda, which the lambda is supposed to close the `FileHandle` that is created, however, because the `Source` object had not been closed, the `FileHandle` remains open.
```kotlin
val source = fileSystem.openReadOnly(zipPath).use { fileHandle ->
  fileHandle.source(entry.offset).buffer()
}
return source.readLocalHeader(basicMetadata)
```

Going into a bit more detail, the `openStreamCount` is not `0` because the `Source` object wasn't closed, so we never close the underlying `RandomAccessFile` that was opened.
```kotlin
@Throws(IOException::class)
final override fun close() {
  lock.withLock {
    if (closed) return
    closed = true
    if (openStreamCount != 0) return
  }
  protectedClose()
}
```

This fix ensures the `Source` object is closed once the metadata has been extracted. This issue also occurs when calling `exists()` in the `ZipFileSystem`.

Closes #1356