### PR TITLE
Add support for wasmJs in okio-fakefilesystem.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ androidx-test-runner = { module = "androidx.test:runner", version = "1.5.2" }
 binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.13.2" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit" }
-kotlin-time = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.4.1" }
+kotlin-time = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.5.0" }
 jmh-gradle-plugin = { module = "me.champeau.jmh:jmh-gradle-plugin", version = "0.7.2" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
 jmh-generator = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }

--- a/okio-fakefilesystem/build.gradle.kts
+++ b/okio-fakefilesystem/build.gradle.kts
@@ -37,11 +37,18 @@ kotlin {
     configureOrCreateNativePlatforms()
   }
   sourceSets {
-    commonMain {
+    val commonMain by getting {
       dependencies {
         api(libs.kotlin.time)
         api(projects.okio)
       }
+    }
+    val commonTest by getting
+    if (kmpWasmEnabled) {
+      // Add support for wasmWasi when https://github.com/Kotlin/kotlinx-datetime/issues/324 is resolved.
+      configureOrCreateWasmPlatform(wasi = false)
+      createSourceSet("wasmMain", parent = commonMain, children = listOf("wasmJs"))
+      createSourceSet("wasmTest", parent = commonTest, children = listOf("wasmJs"))
     }
   }
 }


### PR DESCRIPTION
Partially addresses: https://github.com/square/okio/issues/1388

Support for `wasmWasi` is blocked by `kotlinx.datetime` support: https://github.com/Kotlin/kotlinx-datetime/issues/324