### PR TITLE
Implement AsyncTimeout.cancel()

### DIFF
--- a/okio/api/okio.api
+++ b/okio/api/okio.api
@@ -47,6 +47,7 @@ public class okio/AsyncTimeout : okio/Timeout {
 	public static final field Companion Lokio/AsyncTimeout$Companion;
 	public fun <init> ()V
 	public final fun access$newTimeoutException (Ljava/io/IOException;)Ljava/io/IOException;
+	public fun cancel ()V
 	public final fun enter ()V
 	public final fun exit ()Z
 	protected fun newTimeoutException (Ljava/io/IOException;)Ljava/io/IOException;


### PR DESCRIPTION
This is a simple implementation that uses 3 booleans to keep state (inQueue, isCanceled, hadTimeoutWhenCanceled). I'd like to do a follow-up change to replace 3 booleans with a proper state variable, especially since that eliminates some impossible states (like inQueue and isCanceled).