### PR TITLE
Use a state machine to implement AsyncTimeout

### DIFF
--- a/okio/api/okio.api
+++ b/okio/api/okio.api
@@ -44,7 +44,6 @@ public final class okio/-InflaterSourceExtensions {
 }
 
 public class okio/AsyncTimeout : okio/Timeout {
-	public static final field Companion Lokio/AsyncTimeout$Companion;
 	public fun <init> ()V
 	public final fun access$newTimeoutException (Ljava/io/IOException;)Ljava/io/IOException;
 	public fun cancel ()V
@@ -55,11 +54,6 @@ public class okio/AsyncTimeout : okio/Timeout {
 	public final fun source (Lokio/Source;)Lokio/Source;
 	protected fun timedOut ()V
 	public final fun withTimeout (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-}
-
-public final class okio/AsyncTimeout$Companion {
-	public final fun getCondition ()Ljava/util/concurrent/locks/Condition;
-	public final fun getLock ()Ljava/util/concurrent/locks/ReentrantLock;
 }
 
 public final class okio/Buffer : java/lang/Cloneable, java/nio/channels/ByteChannel, okio/BufferedSink, okio/BufferedSource {


### PR DESCRIPTION
Previously we had 3 boolean state variables to track 4 possible states. That was more complex than necessary.