### PR TITLE
Don't check buffer exhaustion while filling ints

### DIFF
--- a/okio/src/commonMain/kotlin/okio/Options.kt
+++ b/okio/src/commonMain/kotlin/okio/Options.kt
@@ -71,10 +71,8 @@ class Options private constructor(
       val trieBytes = Buffer()
       buildTrieRecursive(node = trieBytes, byteStrings = list, indexes = indexes)
 
-      val trie = IntArray(trieBytes.intCount.toInt())
-      var i = 0
-      while (!trieBytes.exhausted()) {
-        trie[i++] = trieBytes.readInt()
+      val trie = IntArray(trieBytes.intCount.toInt()) {
+        trieBytes.readInt()
       }
 
       return Options(byteStrings.copyOf() /* Defensive copy. */, trie)


### PR DESCRIPTION
The array size is already derived from the buffer size.