### PR TITLE
Make GzipSink and GzipSource multiplatform

### DIFF
--- a/okio/src/nativeMain/kotlin/okio/internal/-ZlibNative.kt
+++ b/okio/src/nativeMain/kotlin/okio/internal/-ZlibNative.kt
@@ -1,4 +1,3 @@
-// ktlint-disable filename
 /*
  * Copyright (C) 2024 Square, Inc.
  *
@@ -16,6 +15,4 @@
  */
 package okio.internal
 
-internal actual val DEFAULT_COMPRESSION = java.util.zip.Deflater.DEFAULT_COMPRESSION
-
-internal actual typealias CRC32 = java.util.zip.CRC32
+internal actual val DEFAULT_COMPRESSION: Int = platform.zlib.Z_DEFAULT_COMPRESSION

--- a/okio/src/nativeMain/kotlin/okio/internal/-ZlibNative.kt
+++ b/okio/src/nativeMain/kotlin/okio/internal/-ZlibNative.kt
@@ -1,3 +1,4 @@
+// ktlint-disable filename
 /*
  * Copyright (C) 2024 Square, Inc.
  *

--- a/okio/src/zlibMain/kotlin/okio/GzipSink.kt
+++ b/okio/src/zlibMain/kotlin/okio/GzipSink.kt
@@ -19,10 +19,9 @@
 
 package okio
 
-import java.io.IOException
-import java.util.zip.CRC32
-import java.util.zip.Deflater
-import java.util.zip.Deflater.DEFAULT_COMPRESSION
+import kotlin.jvm.JvmName
+import okio.internal.CRC32
+import okio.internal.DEFAULT_COMPRESSION
 
 /**
  * A sink that uses [GZIP](http://www.ietf.org/rfc/rfc1952.txt) to
@@ -119,8 +118,8 @@ class GzipSink(sink: Sink) : Sink {
   }
 
   private fun writeFooter() {
-    sink.writeIntLe(crc.value.toInt()) // CRC of original data.
-    sink.writeIntLe(deflater.bytesRead.toInt()) // Length of original data.
+    sink.writeIntLe(crc.getValue().toInt()) // CRC of original data.
+    sink.writeIntLe(deflater.getBytesRead().toInt()) // Length of original data.
   }
 
   /** Updates the CRC with the given bytes. */

--- a/okio/src/zlibMain/kotlin/okio/GzipSource.kt
+++ b/okio/src/zlibMain/kotlin/okio/GzipSource.kt
@@ -19,10 +19,8 @@
 
 package okio
 
-import java.io.EOFException
-import java.io.IOException
-import java.util.zip.CRC32
-import java.util.zip.Inflater
+import kotlin.jvm.JvmName
+import okio.internal.CRC32
 
 /**
  * A source that uses [GZIP](http://www.ietf.org/rfc/rfc1952.txt) to
@@ -150,7 +148,7 @@ class GzipSource(source: Source) : Source {
     // | CRC16 |
     // +---+---+
     if (fhcrc) {
-      checkEqual("FHCRC", source.readShortLe().toInt(), crc.value.toShort().toInt())
+      checkEqual("FHCRC", source.readShortLe().toInt(), crc.getValue().toShort().toInt())
       crc.reset()
     }
   }
@@ -161,8 +159,8 @@ class GzipSource(source: Source) : Source {
     // +---+---+---+---+---+---+---+---+
     // |     CRC32     |     ISIZE     |
     // +---+---+---+---+---+---+---+---+
-    checkEqual("CRC", source.readIntLe(), crc.value.toInt())
-    checkEqual("ISIZE", source.readIntLe(), inflater.bytesWritten.toInt())
+    checkEqual("CRC", source.readIntLe(), crc.getValue().toInt())
+    checkEqual("ISIZE", source.readIntLe(), inflater.getBytesWritten().toInt())
   }
 
   override fun timeout(): Timeout = source.timeout()
@@ -194,7 +192,11 @@ class GzipSource(source: Source) : Source {
 
   private fun checkEqual(name: String, expected: Int, actual: Int) {
     if (actual != expected) {
-      throw IOException("%s: actual 0x%08x != expected 0x%08x".format(name, actual, expected))
+      throw IOException(
+        "$name: " +
+        "actual 0x${actual.toHexString().padStart(8, '0')} != " +
+        "expected 0x${expected.toHexString().padStart(8, '0')}"
+      )
     }
   }
 }

--- a/okio/src/zlibMain/kotlin/okio/GzipSource.kt
+++ b/okio/src/zlibMain/kotlin/okio/GzipSource.kt
@@ -194,8 +194,8 @@ class GzipSource(source: Source) : Source {
     if (actual != expected) {
       throw IOException(
         "$name: " +
-        "actual 0x${actual.toHexString().padStart(8, '0')} != " +
-        "expected 0x${expected.toHexString().padStart(8, '0')}"
+          "actual 0x${actual.toHexString().padStart(8, '0')} != " +
+          "expected 0x${expected.toHexString().padStart(8, '0')}",
       )
     }
   }

--- a/okio/src/zlibMain/kotlin/okio/internal/-Zlib.kt
+++ b/okio/src/zlibMain/kotlin/okio/internal/-Zlib.kt
@@ -1,4 +1,3 @@
-// ktlint-disable filename
 /*
  * Copyright (C) 2024 Square, Inc.
  *
@@ -16,6 +15,4 @@
  */
 package okio.internal
 
-internal actual val DEFAULT_COMPRESSION = java.util.zip.Deflater.DEFAULT_COMPRESSION
-
-internal actual typealias CRC32 = java.util.zip.CRC32
+internal expect val DEFAULT_COMPRESSION: Int

--- a/okio/src/zlibMain/kotlin/okio/internal/-Zlib.kt
+++ b/okio/src/zlibMain/kotlin/okio/internal/-Zlib.kt
@@ -1,3 +1,4 @@
+// ktlint-disable filename
 /*
  * Copyright (C) 2024 Square, Inc.
  *

--- a/okio/src/zlibTest/kotlin/okio/GzipKotlinTest.kt
+++ b/okio/src/zlibTest/kotlin/okio/GzipKotlinTest.kt
@@ -16,9 +16,9 @@
 
 package okio
 
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import okio.ByteString.Companion.decodeHex
-import org.junit.Test
 
 class GzipKotlinTest {
   @Test fun sink() {

--- a/okio/src/zlibTest/kotlin/okio/GzipSinkTest.kt
+++ b/okio/src/zlibTest/kotlin/okio/GzipSinkTest.kt
@@ -15,11 +15,9 @@
  */
 package okio
 
-import java.io.IOException
-import okio.TestUtil.SEGMENT_SIZE
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class GzipSinkTest {
   @Test
@@ -41,7 +39,7 @@ class GzipSinkTest {
     mockSink.scheduleThrow(0, IOException("first"))
     mockSink.scheduleThrow(1, IOException("second"))
     val gzipSink = GzipSink(mockSink)
-    gzipSink.write(Buffer().writeUtf8("a".repeat(SEGMENT_SIZE)), SEGMENT_SIZE.toLong())
+    gzipSink.write(Buffer().writeUtf8("a".repeat(Segment.SIZE)), Segment.SIZE.toLong())
     try {
       gzipSink.close()
       fail()

--- a/okio/src/zlibTest/kotlin/okio/GzipSourceTest.kt
+++ b/okio/src/zlibTest/kotlin/okio/GzipSourceTest.kt
@@ -15,17 +15,15 @@
  */
 package okio
 
-import java.io.IOException
-import java.util.zip.CRC32
-import kotlin.text.Charsets.UTF_8
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
 import okio.ByteString.Companion.decodeHex
+import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.of
-import okio.TestUtil.reverseBytes
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Test
+import okio.internal.CRC32
 
 class GzipSourceTest {
   @Test
@@ -44,7 +42,7 @@ class GzipSourceTest {
     hcrc.update(gzipHeader.toByteArray())
     val gzipped = Buffer()
     gzipped.write(gzipHeader)
-    gzipped.writeShort(hcrc.value.toShort().reverseBytes().toInt()) // little endian
+    gzipped.writeShort(hcrc.getValue().toShort().reverseBytes().toInt()) // little endian
     gzipped.write(deflated)
     gzipped.write(gzipTrailer)
     assertGzipped(gzipped)
@@ -55,7 +53,7 @@ class GzipSourceTest {
     val gzipped = Buffer()
     gzipped.write(gzipHeaderWithFlags(0x04.toByte()))
     gzipped.writeShort(7.toShort().reverseBytes().toInt()) // little endian extra length
-    gzipped.write("blubber".toByteArray(UTF_8), 0, 7)
+    gzipped.write("blubber".encodeUtf8().toByteArray(), 0, 7)
     gzipped.write(deflated)
     gzipped.write(gzipTrailer)
     assertGzipped(gzipped)
@@ -65,7 +63,7 @@ class GzipSourceTest {
   fun gunzip_withName() {
     val gzipped = Buffer()
     gzipped.write(gzipHeaderWithFlags(0x08.toByte()))
-    gzipped.write("foo.txt".toByteArray(UTF_8), 0, 7)
+    gzipped.write("foo.txt".encodeUtf8().toByteArray(), 0, 7)
     gzipped.writeByte(0) // zero-terminated
     gzipped.write(deflated)
     gzipped.write(gzipTrailer)
@@ -76,7 +74,7 @@ class GzipSourceTest {
   fun gunzip_withComment() {
     val gzipped = Buffer()
     gzipped.write(gzipHeaderWithFlags(0x10.toByte()))
-    gzipped.write("rubbish".toByteArray(UTF_8), 0, 7)
+    gzipped.write("rubbish".encodeUtf8().toByteArray(), 0, 7)
     gzipped.writeByte(0) // zero-terminated
     gzipped.write(deflated)
     gzipped.write(gzipTrailer)
@@ -92,10 +90,10 @@ class GzipSourceTest {
     val gzipped = Buffer()
     gzipped.write(gzipHeaderWithFlags(0x1c.toByte()))
     gzipped.writeShort(7.toShort().reverseBytes().toInt()) // little endian extra length
-    gzipped.write("blubber".toByteArray(UTF_8), 0, 7)
-    gzipped.write("foo.txt".toByteArray(UTF_8), 0, 7)
+    gzipped.write("blubber".encodeUtf8().toByteArray(), 0, 7)
+    gzipped.write("foo.txt".encodeUtf8().toByteArray(), 0, 7)
     gzipped.writeByte(0) // zero-terminated
-    gzipped.write("rubbish".toByteArray(UTF_8), 0, 7)
+    gzipped.write("rubbish".encodeUtf8().toByteArray(), 0, 7)
     gzipped.writeByte(0) // zero-terminated
     gzipped.write(deflated)
     gzipped.write(gzipTrailer)


### PR DESCRIPTION
This layers on top of the newly-multiplatformed Inflater, Deflater, and CRC32.