### PR TITLE
Correct documentation links in ZipFileSystem.kt

### DIFF
--- a/okio/src/zlibMain/kotlin/okio/ZipFileSystem.kt
+++ b/okio/src/zlibMain/kotlin/okio/ZipFileSystem.kt
@@ -24,7 +24,7 @@ import okio.internal.readLocalHeader
 import okio.internal.skipLocalHeader
 
 /**
- * Read only access to a [zip file][zip_format] and common [extra fields][extra_fields].
+ * Read only access to a [zip file](zip_format) and common [extra fields](extra_fields).
  *
  * [zip_format]: https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE_6.2.0.txt
  * [extra_fields]: https://opensource.apple.com/source/zip/zip-6/unzip/unzip/proginfo/extra.fld

--- a/okio/src/zlibMain/kotlin/okio/ZipFileSystem.kt
+++ b/okio/src/zlibMain/kotlin/okio/ZipFileSystem.kt
@@ -24,10 +24,8 @@ import okio.internal.readLocalHeader
 import okio.internal.skipLocalHeader
 
 /**
- * Read only access to a [zip file](zip_format) and common [extra fields](extra_fields).
- *
- * [zip_format]: https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE_6.2.0.txt
- * [extra_fields]: https://opensource.apple.com/source/zip/zip-6/unzip/unzip/proginfo/extra.fld
+ * Read only access to a [zip file](https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE_6.2.0.txt)
+ * and common [extra fields](https://opensource.apple.com/source/zip/zip-6/unzip/unzip/proginfo/extra.fld).
  */
 internal class ZipFileSystem internal constructor(
   private val zipPath: Path,


### PR DESCRIPTION
Currently, it just seems broken:

<img width="410" alt="Screenshot 2024-03-28 at 10 41 16" src="https://github.com/square/okio/assets/5759366/b3804b53-1f60-432d-8343-e8095a40353e">

But I think this should fix it.