### PR TITLE
Remove @JvmField uses from commonMain

### DIFF
--- a/okio/src/commonMain/kotlin/okio/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/Buffer.kt
@@ -15,8 +15,6 @@
  */
 package okio
 
-import kotlin.jvm.JvmField
-
 /**
  * A collection of bytes in memory.
  *
@@ -341,19 +339,19 @@ expect class Buffer() : BufferedSource, BufferedSink {
    * [Buffer.readAndWriteUnsafe] that take a cursor and close it after use.
    */
   class UnsafeCursor constructor() : Closeable {
-    @JvmField var buffer: Buffer?
+    var buffer: Buffer?
 
-    @JvmField var readWrite: Boolean
+    var readWrite: Boolean
 
     internal var segment: Segment?
 
-    @JvmField var offset: Long
+    var offset: Long
 
-    @JvmField var data: ByteArray?
+    var data: ByteArray?
 
-    @JvmField var start: Int
+    var start: Int
 
-    @JvmField var end: Int
+    var end: Int
 
     /**
      * Seeks to the next range of bytes, advancing the offset by `end - start`. Returns the size of

--- a/okio/src/commonMain/kotlin/okio/ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/ByteString.kt
@@ -16,7 +16,6 @@
 
 package okio
 
-import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
@@ -183,7 +182,6 @@ internal constructor(data: ByteArray) : Comparable<ByteString> {
 
   companion object {
     /** A singleton empty `ByteString`. */
-    @JvmField
     val EMPTY: ByteString
 
     /** Returns a new byte string containing a clone of the bytes of `data`. */


### PR DESCRIPTION
These annotations are unnecessary and break under Kotlin -language-mode=2.0