### PR TITLE
Don't use a NodeJS canary build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -229,29 +229,6 @@ subprojects {
 }
 
 /**
- * Select a NodeJS version with WASI and WASM GC.
- * https://github.com/Kotlin/kotlin-wasm-examples/blob/main/wasi-example/build.gradle.kts
- */
-plugins.withType<NodeJsRootPlugin> {
-  extensions.getByType<NodeJsRootExtension>().apply {
-    if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows) {
-      // We're waiting for a Windows build of NodeJS that can do WASM GC + WASI.
-      nodeVersion = "21.4.0"
-    } else {
-      nodeVersion = "21.0.0-v8-canary202309143a48826a08"
-      nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
-    }
-  }
-  // Suppress an error because yarn doesn't like our Node version string.
-  //   warning You are using Node "21.0.0-v8-canary202309143a48826a08" which is not supported and
-  //   may encounter bugs or unexpected behavior.
-  //   error typescript@5.0.4: The engine "node" is incompatible with this module.
-  tasks.withType<KotlinNpmInstallTask>().all {
-    args += "--ignore-engines"
-  }
-}
-
-/**
  * Set the `OKIO_ROOT` environment variable for tests to access it.
  * https://publicobject.com/2023/04/16/read-a-project-file-in-a-kotlin-multiplatform-test/
  */


### PR DESCRIPTION
We get Wasm GC in the standard distribution now.