### PR TITLE
Do not recycle head Segment in DeflaterSink

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/DeflaterSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/DeflaterSink.kt
@@ -44,7 +44,7 @@ actual class DeflaterSink internal actual constructor(
       // Mark those bytes as read.
       source.size -= toDeflate
       head.pos += toDeflate
-      if (head.pos == head.limit) {
+      if (head.pos == head.limit && closed) {
         source.head = head.pop()
         SegmentPool.recycle(head)
       }

--- a/okio/src/jvmMain/kotlin/okio/DeflaterSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/DeflaterSink.kt
@@ -44,9 +44,8 @@ actual class DeflaterSink internal actual constructor(
       // Mark those bytes as read.
       source.size -= toDeflate
       head.pos += toDeflate
-      if (head.pos == head.limit && closed) {
+      if (head.pos == head.limit) {
         source.head = head.pop()
-        SegmentPool.recycle(head)
       }
 
       remaining -= toDeflate


### PR DESCRIPTION
This change only recycles `head` Segment when the sink is closed, to avoid the risk of using the same buffer for both input and output for Java's Deflater calls.

Fixes bug: https://github.com/square/okio/issues/1608