### PR TITLE
New API, BufferedSource.indexOf(ByteString, fromIndex, toIndex)

### DIFF
--- a/okio/api/okio.api
+++ b/okio/api/okio.api
@@ -93,6 +93,7 @@ public final class okio/Buffer : java/lang/Cloneable, java/nio/channels/ByteChan
 	public fun indexOf (BJJ)J
 	public fun indexOf (Lokio/ByteString;)J
 	public fun indexOf (Lokio/ByteString;J)J
+	public fun indexOf (Lokio/ByteString;JJ)J
 	public fun indexOfElement (Lokio/ByteString;)J
 	public fun indexOfElement (Lokio/ByteString;J)J
 	public fun inputStream ()Ljava/io/InputStream;
@@ -250,6 +251,7 @@ public abstract interface class okio/BufferedSource : java/nio/channels/Readable
 	public abstract fun indexOf (BJJ)J
 	public abstract fun indexOf (Lokio/ByteString;)J
 	public abstract fun indexOf (Lokio/ByteString;J)J
+	public abstract fun indexOf (Lokio/ByteString;JJ)J
 	public abstract fun indexOfElement (Lokio/ByteString;)J
 	public abstract fun indexOfElement (Lokio/ByteString;J)J
 	public abstract fun inputStream ()Ljava/io/InputStream;

--- a/okio/src/commonMain/kotlin/okio/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/Buffer.kt
@@ -118,6 +118,7 @@ expect class Buffer() : BufferedSource, BufferedSink {
   override fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long
   override fun indexOf(bytes: ByteString): Long
   override fun indexOf(bytes: ByteString, fromIndex: Long): Long
+  override fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long
   override fun indexOfElement(targetBytes: ByteString): Long
   override fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long
   override fun peek(): BufferedSource

--- a/okio/src/commonMain/kotlin/okio/BufferedSource.kt
+++ b/okio/src/commonMain/kotlin/okio/BufferedSource.kt
@@ -514,6 +514,28 @@ expect sealed interface BufferedSource : Source {
    */
   fun indexOf(bytes: ByteString, fromIndex: Long): Long
 
+  /**
+   * Returns the index of the first match for `bytes` in the buffer that is at or after `fromIndex`,
+   * and that is also less than `toIndex`. Returns -1 if `bytes` isn't found in that range. If
+   * `fromIndex == toIndex` then search range is empty and -1 is returned.
+   *
+   * This may attempt to expand the buffer. It won't attempt to expand the buffer if doing so
+   * couldn't change the result.
+   *
+   * ```java
+   * ByteString MOVE = ByteString.encodeUtf8("move");
+   *
+   * Buffer buffer = new Buffer();
+   * buffer.writeUtf8("Don't move! He can't see us if we don't move.");
+   *
+   * assertEquals( 6, buffer.indexOf(MOVE, 0,  40));
+   * assertEquals( 6, buffer.indexOf(MOVE, 0, 100));
+   * assertEquals(-1, buffer.indexOf(MOVE, 7,  40));
+   * assertEquals(40, buffer.indexOf(MOVE, 7, 100));
+   * ```
+   */
+  fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long
+
   /** Equivalent to [indexOfElement(targetBytes, 0)][indexOfElement]. */
   fun indexOfElement(targetBytes: ByteString): Long
 

--- a/okio/src/commonMain/kotlin/okio/RealBufferedSource.kt
+++ b/okio/src/commonMain/kotlin/okio/RealBufferedSource.kt
@@ -30,6 +30,7 @@ internal expect class RealBufferedSource(
   override fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long
   override fun indexOf(bytes: ByteString): Long
   override fun indexOf(bytes: ByteString, fromIndex: Long): Long
+  override fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long
   override fun indexOfElement(targetBytes: ByteString): Long
   override fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long
   override fun peek(): BufferedSource

--- a/okio/src/commonMain/kotlin/okio/internal/RealBufferedSource.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/RealBufferedSource.kt
@@ -382,8 +382,9 @@ private fun matchPossibleByExpandingBuffer(
   if (buffer.size < toIndex) return true
 
   // Load new data if a prefix of 'bytes' matches a suffix of 'buffer'.
+  val begin = maxOf(1, buffer.size - toIndex + 1).toInt()
   val limit = minOf(bytes.size, buffer.size - fromIndex + 1).toInt()
-  for (i in limit - 1 downTo 1) {
+  for (i in limit - 1 downTo begin) {
     if (buffer.rangeEquals(buffer.size - i, bytes, 0, i)) {
       return true
     }

--- a/okio/src/jvmMain/kotlin/okio/Buffer.kt
+++ b/okio/src/jvmMain/kotlin/okio/Buffer.kt
@@ -485,6 +485,10 @@ actual class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
   @Throws(IOException::class)
   actual override fun indexOf(bytes: ByteString, fromIndex: Long): Long = commonIndexOf(bytes, fromIndex)
 
+  @Throws(IOException::class)
+  actual override fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long =
+    commonIndexOf(bytes, fromIndex, toIndex)
+
   actual override fun indexOfElement(targetBytes: ByteString) = indexOfElement(targetBytes, 0L)
 
   actual override fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long =

--- a/okio/src/jvmMain/kotlin/okio/BufferedSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/BufferedSource.kt
@@ -148,6 +148,9 @@ actual sealed interface BufferedSource : Source, ReadableByteChannel {
   actual fun indexOf(bytes: ByteString, fromIndex: Long): Long
 
   @Throws(IOException::class)
+  actual fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long
+
+  @Throws(IOException::class)
   actual fun indexOfElement(targetBytes: ByteString): Long
 
   @Throws(IOException::class)

--- a/okio/src/jvmMain/kotlin/okio/RealBufferedSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/RealBufferedSource.kt
@@ -127,6 +127,8 @@ internal actual class RealBufferedSource actual constructor(
   actual override fun indexOf(bytes: ByteString): Long = indexOf(bytes, 0L)
   actual override fun indexOf(bytes: ByteString, fromIndex: Long): Long =
     commonIndexOf(bytes, fromIndex)
+  actual override fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long =
+    commonIndexOf(bytes, fromIndex, toIndex)
   actual override fun indexOfElement(targetBytes: ByteString): Long =
     indexOfElement(targetBytes, 0L)
   actual override fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long =

--- a/okio/src/jvmTest/kotlin/okio/BufferedSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferedSourceTest.kt
@@ -1047,6 +1047,38 @@ class BufferedSourceTest(
   }
 
   @Test
+  fun indexOfHonorsToIndexWhenAvoidingLoadsAndDoesNotLoad() {
+    assumeTrue(factory === Factory.OneByteAtATimeSource) // Other sources read in chunks anyway.
+
+    sink.writeUtf8("A man, a plan, a canal. Panama.")
+    sink.emit()
+    source.require(2) // Source buffer contains 'A '
+    assertEquals(-1L, source.indexOf(" man".encodeUtf8(), 0L, 1L))
+    assertEquals("A ", source.buffer.readUtf8())
+  }
+
+  @Test
+  fun indexOfHonorsFromIndexWhenAvoidingLoads() {
+    assumeTrue(factory === Factory.OneByteAtATimeSource) // Other sources read in chunks anyway.
+
+    sink.writeUtf8("A man, a plan, a canal. Panama.")
+    sink.emit()
+    assertEquals(-1, source.indexOf("Panama.".encodeUtf8(), 25L, 27L))
+    assertEquals("A man, a plan, a canal. Pan", source.buffer.readUtf8())
+  }
+
+  @Test
+  fun indexOfHonorsToIndexWhenAvoidingLoadsAndLoads() {
+    assumeTrue(factory === Factory.OneByteAtATimeSource) // Other sources read in chunks anyway.
+
+    sink.writeUtf8("A man, a plan, a canal. Panama.")
+    sink.emit()
+    source.require(2) // Source buffer contains 'A '
+    assertEquals(0L, source.indexOf("A ma".encodeUtf8(), 0L, 1L))
+    assertEquals("A ma", source.buffer.readUtf8())
+  }
+
+  @Test
   fun indexOfElementWithFromIndex() {
     sink.writeUtf8("aaa")
     sink.emit()

--- a/okio/src/nonJvmMain/kotlin/okio/Buffer.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/Buffer.kt
@@ -222,6 +222,9 @@ actual class Buffer : BufferedSource, BufferedSink {
 
   actual override fun indexOf(bytes: ByteString, fromIndex: Long): Long = commonIndexOf(bytes, fromIndex)
 
+  actual override fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long =
+    commonIndexOf(bytes, fromIndex, toIndex)
+
   actual override fun indexOfElement(targetBytes: ByteString): Long = indexOfElement(targetBytes, 0L)
 
   actual override fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long =

--- a/okio/src/nonJvmMain/kotlin/okio/BufferedSource.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/BufferedSource.kt
@@ -88,6 +88,8 @@ actual sealed interface BufferedSource : Source {
 
   actual fun indexOf(bytes: ByteString, fromIndex: Long): Long
 
+  actual fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long
+
   actual fun indexOfElement(targetBytes: ByteString): Long
 
   actual fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long

--- a/okio/src/nonJvmMain/kotlin/okio/RealBufferedSource.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/RealBufferedSource.kt
@@ -94,6 +94,8 @@ internal actual class RealBufferedSource actual constructor(
 
   actual override fun indexOf(bytes: ByteString): Long = indexOf(bytes, 0L)
   actual override fun indexOf(bytes: ByteString, fromIndex: Long): Long = commonIndexOf(bytes, fromIndex)
+  actual override fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long =
+    commonIndexOf(bytes, fromIndex, toIndex)
   actual override fun indexOfElement(targetBytes: ByteString): Long =
     indexOfElement(targetBytes, 0L)
   actual override fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long =


### PR DESCRIPTION
This is surprisingly interesting. To minimize unnecessary reads for toIndex it is necessary to check whether a prefix of the query matches a suffix of the currently-loaded data.

This read-avoidance is useful in practice. When doing HTTP multipart decoding the caller may scan for a boundary separator with a bounded range, and we don't want to block reading when doing so won't impact the result of the call.