### PR TITLE
Re-implement Buffer.rangeEquals on Buffer.indexOf

### DIFF
--- a/okio/src/commonTest/kotlin/okio/CommonBufferedSourceTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonBufferedSourceTest.kt
@@ -716,7 +716,7 @@ class CommonBufferedSourceTest(
     var e = assertFailsWith<IllegalArgumentException> {
       source.indexOf(ByteString.of())
     }
-    assertEquals("bytes is empty", e.message)
+    assertEquals("byteCount == 0", e.message)
 
     e = assertFailsWith<IllegalArgumentException> {
       source.indexOf("hi".encodeUtf8(), -1)

--- a/okio/src/jvmMain/kotlin/okio/Buffer.kt
+++ b/okio/src/jvmMain/kotlin/okio/Buffer.kt
@@ -477,17 +477,18 @@ actual class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
   actual override fun indexOf(b: Byte, fromIndex: Long) = indexOf(b, fromIndex, Long.MAX_VALUE)
 
   actual override fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long =
-    commonIndexOf(b, fromIndex, toIndex)
+    commonIndexOf(b, fromIndex = fromIndex, toIndex = toIndex)
 
   @Throws(IOException::class)
   actual override fun indexOf(bytes: ByteString): Long = indexOf(bytes, 0)
 
   @Throws(IOException::class)
-  actual override fun indexOf(bytes: ByteString, fromIndex: Long): Long = commonIndexOf(bytes, fromIndex)
+  actual override fun indexOf(bytes: ByteString, fromIndex: Long): Long =
+    indexOf(bytes, fromIndex, Long.MAX_VALUE)
 
   @Throws(IOException::class)
   actual override fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long =
-    commonIndexOf(bytes, fromIndex, toIndex)
+    commonIndexOf(bytes, fromIndex = fromIndex, toIndex = toIndex)
 
   actual override fun indexOfElement(targetBytes: ByteString) = indexOfElement(targetBytes, 0L)
 

--- a/okio/src/jvmMain/kotlin/okio/RealBufferedSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/RealBufferedSource.kt
@@ -122,13 +122,13 @@ internal actual class RealBufferedSource actual constructor(
   actual override fun indexOf(b: Byte, fromIndex: Long): Long =
     indexOf(b, fromIndex, Long.MAX_VALUE)
   actual override fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long =
-    commonIndexOf(b, fromIndex, toIndex)
+    commonIndexOf(b, fromIndex = fromIndex, toIndex = toIndex)
 
   actual override fun indexOf(bytes: ByteString): Long = indexOf(bytes, 0L)
   actual override fun indexOf(bytes: ByteString, fromIndex: Long): Long =
-    commonIndexOf(bytes, fromIndex)
+    indexOf(bytes, fromIndex, Long.MAX_VALUE)
   actual override fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long =
-    commonIndexOf(bytes, fromIndex, toIndex)
+    commonIndexOf(bytes, fromIndex = fromIndex, toIndex = toIndex)
   actual override fun indexOfElement(targetBytes: ByteString): Long =
     indexOfElement(targetBytes, 0L)
   actual override fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long =

--- a/okio/src/jvmTest/kotlin/okio/BufferedSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferedSourceTest.kt
@@ -803,7 +803,7 @@ class BufferedSourceTest(
       source.indexOf(ByteString.of())
       fail()
     } catch (e: IllegalArgumentException) {
-      assertEquals("bytes is empty", e.message)
+      assertEquals("byteCount == 0", e.message)
     }
     try {
       source.indexOf("hi".encodeUtf8(), -1)

--- a/okio/src/nonJvmMain/kotlin/okio/Buffer.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/Buffer.kt
@@ -216,14 +216,15 @@ actual class Buffer : BufferedSource, BufferedSink {
   actual override fun indexOf(b: Byte, fromIndex: Long): Long = indexOf(b, fromIndex, Long.MAX_VALUE)
 
   actual override fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long =
-    commonIndexOf(b, fromIndex, toIndex)
+    commonIndexOf(b, fromIndex = fromIndex, toIndex = toIndex)
 
   actual override fun indexOf(bytes: ByteString): Long = indexOf(bytes, 0)
 
-  actual override fun indexOf(bytes: ByteString, fromIndex: Long): Long = commonIndexOf(bytes, fromIndex)
+  actual override fun indexOf(bytes: ByteString, fromIndex: Long): Long =
+    indexOf(bytes, fromIndex, Long.MAX_VALUE)
 
   actual override fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long =
-    commonIndexOf(bytes, fromIndex, toIndex)
+    commonIndexOf(bytes, fromIndex = fromIndex, toIndex = toIndex)
 
   actual override fun indexOfElement(targetBytes: ByteString): Long = indexOfElement(targetBytes, 0L)
 

--- a/okio/src/nonJvmMain/kotlin/okio/RealBufferedSource.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/RealBufferedSource.kt
@@ -90,12 +90,13 @@ internal actual class RealBufferedSource actual constructor(
   actual override fun indexOf(b: Byte, fromIndex: Long): Long =
     indexOf(b, fromIndex, Long.MAX_VALUE)
   actual override fun indexOf(b: Byte, fromIndex: Long, toIndex: Long): Long =
-    commonIndexOf(b, fromIndex, toIndex)
+    commonIndexOf(b, fromIndex = fromIndex, toIndex = toIndex)
 
   actual override fun indexOf(bytes: ByteString): Long = indexOf(bytes, 0L)
-  actual override fun indexOf(bytes: ByteString, fromIndex: Long): Long = commonIndexOf(bytes, fromIndex)
+  actual override fun indexOf(bytes: ByteString, fromIndex: Long): Long =
+    indexOf(bytes, fromIndex, Long.MAX_VALUE)
   actual override fun indexOf(bytes: ByteString, fromIndex: Long, toIndex: Long): Long =
-    commonIndexOf(bytes, fromIndex, toIndex)
+    commonIndexOf(bytes, fromIndex = fromIndex, toIndex = toIndex)
   actual override fun indexOfElement(targetBytes: ByteString): Long =
     indexOfElement(targetBytes, 0L)
   actual override fun indexOfElement(targetBytes: ByteString, fromIndex: Long): Long =


### PR DESCRIPTION
The old rangeEquals function was embarassingly inefficient, using a full scan of the segments linked-list for each element. That optimization is already done in indexOf(), which has almost all of what we need for rangeEquals().

This adds an offset and count slice to the input ByteString in indexOf(), and then leverages that to simplify rangeEquals().