### PR TITLE
New API, inMemorySocketPair()

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/internal/PipeSocket.kt
+++ b/okio/src/jvmMain/kotlin/okio/internal/PipeSocket.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.internal
+
+import okio.Pipe
+import okio.Sink
+import okio.Socket
+import okio.Source
+
+internal class PipeSocket(val sinkPipe: Pipe, val sourcePipe: Pipe) : Socket {
+  override val source: Source
+    get() = sourcePipe.source
+
+  override val sink: Sink
+    get() = sinkPipe.sink
+
+  override fun cancel() {
+    sourcePipe.cancel()
+    sinkPipe.cancel()
+  }
+}


### PR DESCRIPTION
I'm using Array<Socket> instead of Pair<Socket, Socket> because Array is _slightly_ more friendly to Java-language consumers.