### PR TITLE
Update to kotlinx-datetime:0.7.0 and fix binary incompatible changes.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ jmh-gradle-plugin = { module = "me.champeau.jmh:jmh-gradle-plugin", version = "0
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit" }
-kotlin-time = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.2" }
+kotlin-time = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.7.0" }
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "7.0.4" }
 test-assertj = { module = "org.assertj:assertj-core", version = "3.27.3" }
 test-assertk = "com.willowtreeapps.assertk:assertk:0.28.1"

--- a/okio-fakefilesystem/build.gradle.kts
+++ b/okio-fakefilesystem/build.gradle.kts
@@ -35,6 +35,11 @@ kotlin {
     configureOrCreateNativePlatforms()
   }
   sourceSets {
+    all {
+      languageSettings.apply {
+        optIn("kotlin.time.ExperimentalTime")
+      }
+    }
     val commonMain by getting {
       dependencies {
         api(libs.kotlin.time)

--- a/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
+++ b/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
@@ -18,8 +18,8 @@ package okio.fakefilesystem
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
 import okio.ArrayIndexOutOfBoundsException
 import okio.Buffer
 import okio.ByteString

--- a/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FileMetadataCommon.kt
+++ b/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FileMetadataCommon.kt
@@ -19,7 +19,7 @@ package okio.fakefilesystem
 
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import okio.FileMetadata
 import okio.Path
 

--- a/okio-nodefilesystem/build.gradle.kts
+++ b/okio-nodefilesystem/build.gradle.kts
@@ -25,9 +25,6 @@ kotlin {
     }
   }
   sourceSets {
-    all {
-      languageSettings.optIn("kotlin.RequiresOptIn")
-    }
     matching { it.name.endsWith("Test") }.all {
       languageSettings {
         optIn("kotlin.time.ExperimentalTime")

--- a/okio-nodefilesystem/src/commonTest/kotlin/okio/NodeJsFileSystemTest.kt
+++ b/okio-nodefilesystem/src/commonTest/kotlin/okio/NodeJsFileSystemTest.kt
@@ -15,7 +15,7 @@
  */
 package okio
 
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 class NodeJsFileSystemTest : AbstractFileSystemTest(
   clock = Clock.System,

--- a/okio-testing-support/src/nonWasmMain/kotlin/okio/TestingNonWasm.kt
+++ b/okio-testing-support/src/nonWasmMain/kotlin/okio/TestingNonWasm.kt
@@ -17,9 +17,9 @@ package okio
 
 import okio.fakefilesystem.FakeFileSystem
 
-actual typealias Clock = kotlinx.datetime.Clock
+actual typealias Clock = kotlin.time.Clock
 
-actual typealias Instant = kotlinx.datetime.Instant
+actual typealias Instant = kotlin.time.Instant
 
 actual fun fromEpochSeconds(
   epochSeconds: Long,

--- a/okio/build.gradle.kts
+++ b/okio/build.gradle.kts
@@ -63,6 +63,11 @@ kotlin {
         optIn("kotlin.contracts.ExperimentalContracts")
       }
     }
+    matching { it.name.endsWith("Test") }.all {
+      languageSettings {
+        optIn("kotlin.time.ExperimentalTime")
+      }
+    }
 
     val commonMain by getting
     val commonTest by getting {

--- a/okio/src/jvmTest/kotlin/okio/FileHandleFileSystemTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/FileHandleFileSystemTest.kt
@@ -18,7 +18,7 @@ package okio
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import java.nio.file.FileSystems
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import okio.FileHandleFileSystemTest.FileHandleTestingFileSystem
 import okio.FileSystem.Companion.asOkioFileSystem
 

--- a/okio/src/jvmTest/kotlin/okio/JvmSystemFileSystemTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/JvmSystemFileSystemTest.kt
@@ -22,7 +22,7 @@ import java.nio.file.FileSystems
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.fail
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import okio.FileSystem.Companion.asOkioFileSystem
 import org.junit.Test
 

--- a/okio/src/nativeTest/kotlin/okio/NativeSystemFileSystemTest.kt
+++ b/okio/src/nativeTest/kotlin/okio/NativeSystemFileSystemTest.kt
@@ -15,7 +15,7 @@
  */
 package okio
 
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 class NativeSystemFileSystemTest : AbstractFileSystemTest(
   clock = Clock.System,

--- a/okio/src/nonWasmTest/kotlin/okio/ForwardingFileSystemTest.kt
+++ b/okio/src/nonWasmTest/kotlin/okio/ForwardingFileSystemTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 

--- a/okio/src/zlibTest/kotlin/okio/ZipFileSystemGoTest.kt
+++ b/okio/src/zlibTest/kotlin/okio/ZipFileSystemGoTest.kt
@@ -17,7 +17,7 @@ package okio
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import okio.Path.Companion.toPath
 
 /**

--- a/okio/src/zlibTest/kotlin/okio/ZipFileSystemTest.kt
+++ b/okio/src/zlibTest/kotlin/okio/ZipFileSystemTest.kt
@@ -28,7 +28,7 @@ import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import okio.ByteString.Companion.encodeUtf8
 import okio.Path.Companion.toPath
 


### PR DESCRIPTION
`kotlinx-datetime:0.7.0` completely removes `kotlinx.datetime.Clock` and `kotlinx.datetime.Instant` in favour of the `kotlin.time` versions ([more info](https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)). This creates a couple issues:

- We currently use `kotlinx.datetime.Instant` in `FakeFileSystem`'s public API. We probably have to take a binary incompatible change here and update to the new class.
- `kotlin.time` classes are marked with `@ExperimentalTime` which will propagate to our `FakeFileSystem`'s constructor  unless we add a secondary constructor: `constructor() : this(Clock.System)` that hides the experimental arg.
- Currently all okio consumers have to use `0.7.0-0.6.x-compat` (a compat version that retains the removed classes) if they want to update to `0.7.0` and use `FakeFileSystem`.