### PR TITLE
Don't use Clock.System on an JVM release

### DIFF
--- a/okio-fakefilesystem/build.gradle.kts
+++ b/okio-fakefilesystem/build.gradle.kts
@@ -53,6 +53,21 @@ kotlin {
       createSourceSet("wasmMain", parent = commonMain, children = listOf("wasmJs"))
       createSourceSet("wasmTest", parent = commonTest, children = listOf("wasmJs"))
     }
+
+    val nonJvmMain by creating {
+      dependsOn(commonMain)
+    }
+    if (kmpJsEnabled) {
+      getByName("jsMain").dependsOn(nonJvmMain)
+    }
+    if (kmpNativeEnabled) {
+      for (childTarget in nativeTargets) {
+        get("${childTarget}Main").dependsOn(nonJvmMain)
+      }
+    }
+    if (kmpWasmEnabled) {
+      getByName("wasmMain").dependsOn(nonJvmMain)
+    }
   }
 }
 

--- a/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
+++ b/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
@@ -75,12 +75,12 @@ class FakeFileSystem private constructor(
     clockNowMillis = { clock.now().toEpochMilliseconds() },
   )
 
+  // Avoid calling kotlinx.datetime.Clock.System.now() because it crashes at runtime if the Kotlin
+  // stdlib isn't 2.1.20+. (That'll be the case when running in Gradle 8.x.)
   @Deprecated(
     "Use the constructor that accepts a kotlin.time.Clock, or the no-args constructor",
     level = DeprecationLevel.HIDDEN,
   )
-  // Avoid calling kotlinx.datetime.Clock.System.now() because it crashes at runtime if the Kotlin
-  // stdlib isn't 2.1.20+. (That'll be the case when running in Gradle 8.x.)
   constructor(clock: Clock = Clock.System) : this(
     when {
       clock === Clock.System -> defaultClockNowMillis

--- a/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
+++ b/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FakeFileSystem.kt
@@ -79,8 +79,15 @@ class FakeFileSystem private constructor(
     "Use the constructor that accepts a kotlin.time.Clock, or the no-args constructor",
     level = DeprecationLevel.HIDDEN,
   )
+  // Avoid calling kotlinx.datetime.Clock.System.now() because it crashes at runtime if the Kotlin
+  // stdlib isn't 2.1.20+. (That'll be the case when running in Gradle 8.x.)
   constructor(clock: Clock = Clock.System) : this(
-    clockNowMillis = { clock.now().toEpochMilliseconds() },
+    when {
+      clock === Clock.System -> defaultClockNowMillis
+      else -> {
+        { clock.now().toEpochMilliseconds() }
+      }
+    },
   )
 
   /** Returns the clock used to timestamp files. */

--- a/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FileMetadataCommon.kt
+++ b/okio-fakefilesystem/src/commonMain/kotlin/okio/fakefilesystem/FileMetadataCommon.kt
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:JvmMultifileClass
 @file:JvmName("-Time")
 
 package okio.fakefilesystem
 
+import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import okio.FileMetadata
 import okio.Path
@@ -48,19 +49,9 @@ internal fun FileMetadata(
 }
 
 /**
- * Get the time from the best available Clock.
+ * Get the time from the best available clock.
  *
- *  * If it's Kotlin 2.1.20+, this uses kotlin.time.Clock.
- *  * Otherwise it uses kotlinx.time.Clock.
- *
- * We support earlier Kotlin versions because Okio in Gradle won't have 2.1.20+.
+ * We'd prefer `kotlin.time.Clock` but it requires Kotlin 2.1.20+ and that isn't available to
+ * Gradle plugins (at least for Gradle 8.x).
  */
-internal val defaultClockNowMillis: () -> Long by lazy {
-  try {
-    val delegate = kotlin.time.Clock.System
-    return@lazy { delegate.now().toEpochMilliseconds() }
-  } catch (_: Throwable) {
-    val delegate = Clock.System
-    return@lazy { delegate.now().toEpochMilliseconds() }
-  }
-}
+internal expect val defaultClockNowMillis: () -> Long

--- a/okio-fakefilesystem/src/jvmMain/kotlin/okio/fakefilesystem/FileMetadataJvm.kt
+++ b/okio-fakefilesystem/src/jvmMain/kotlin/okio/fakefilesystem/FileMetadataJvm.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmMultifileClass
+@file:JvmName("-Time")
+package okio.fakefilesystem
+
+internal actual val defaultClockNowMillis: () -> Long = { System.currentTimeMillis() }

--- a/okio-fakefilesystem/src/jvmMain/kotlin/okio/fakefilesystem/FileMetadataJvm.kt
+++ b/okio-fakefilesystem/src/jvmMain/kotlin/okio/fakefilesystem/FileMetadataJvm.kt
@@ -15,6 +15,7 @@
  */
 @file:JvmMultifileClass
 @file:JvmName("-Time")
+
 package okio.fakefilesystem
 
 internal actual val defaultClockNowMillis: () -> Long = { System.currentTimeMillis() }

--- a/okio-fakefilesystem/src/nonJvmMain/kotlin/okio/fakefilesystem/FileMetadataNonJvm.kt
+++ b/okio-fakefilesystem/src/nonJvmMain/kotlin/okio/fakefilesystem/FileMetadataNonJvm.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.fakefilesystem
+
+import kotlin.time.Clock
+
+internal actual val defaultClockNowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() }


### PR DESCRIPTION
Okio was broken when running on Kotlin before 2.1.20. The failure mode was too severe - a crash at runtime! And this is for code that worked just fine on Kotlin 2.0.x.

    java.lang.NoSuchMethodError: 'kotlin.time.Clock kotlin.internal.PlatformImplementations.getSystemClock()'
	at kotlin.time.InstantJvmKt.<clinit>(InstantJvm.kt:12)
	at kotlin.time.Clock$System.now(Clock.kt:60)
	at kotlinx.datetime.Clock$System.now(DeprecatedClock.kt:89)
	at okio.fakefilesystem.-Time.defaultClockNowMillis_delegate$lambda$2(FileMetadataCommon.kt:70)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at okio.fakefilesystem.-Time.getDefaultClockNowMillis(FileMetadataCommon.kt:65)
	at okio.fakefilesystem.FakeFileSystem.<init>(FakeFileSystem.kt:72)

The failure would occur anywhere we were running Okio's FakeFileSystem inside a Gradle plugin.

With this change FakeFileSystem works inside a Gradle plugin, even if the runtime Kotlin version doesn't have
kotlin.time.Clock.