### PR TITLE
Add heap implementation for AsyncTimeout

### DIFF
--- a/okio/jvm/jmh/src/jmh/java/com/squareup/okio/benchmarks/AsyncTimeoutBenchmark.java
+++ b/okio/jvm/jmh/src/jmh/java/com/squareup/okio/benchmarks/AsyncTimeoutBenchmark.java
@@ -1,0 +1,64 @@
+package com.squareup.okio.benchmarks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import okio.AsyncTimeout;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Fork(1)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class AsyncTimeoutBenchmark {
+
+  @Param({ "1", "10", "100", "1000" })
+  int queueSize;
+
+  List<AsyncTimeout> asyncTimeouts;
+
+  int next = 0;
+
+  @Setup
+  public void setup() {
+    asyncTimeouts = new ArrayList<>(queueSize);
+    for (int i = 0; i < queueSize; i++) {
+      AsyncTimeout timeout = new AsyncTimeout("Node" + i) {
+        @Override protected void timedOut() {
+          // No-op
+        }
+      };
+      timeout.timeout(3600 + i, TimeUnit.SECONDS); // Never time out, insert in order.
+      timeout.enter();
+      asyncTimeouts.add(timeout);
+    }
+  }
+
+  @TearDown
+  public void tearDown() throws InterruptedException {
+    for (AsyncTimeout timeout : asyncTimeouts) {
+      timeout.exit();
+    }
+  }
+
+  @Benchmark
+  public void enterExit() {
+    AsyncTimeout timeout = asyncTimeouts.get(next++);
+    timeout.exit();
+    timeout.enter();
+    next = next % queueSize;
+  }
+}

--- a/okio/src/jvmTest/kotlin/okio/internal/MinHeapTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/internal/MinHeapTest.kt
@@ -1,0 +1,117 @@
+package okio.internal
+
+import assertk.assertThat
+import okio.AsyncTimeout
+import okio.Heap
+import okio.Heap.Companion.compareTo
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class MinHeapTest {
+
+  private val nodes = ArrayDeque<AsyncTimeout>()
+  private lateinit var heap: Heap
+
+  @Before
+  fun before() {
+    // Initialize the heap with 100 random values.
+    (1L..NUMBER_OF_NODES).forEach { i ->
+      AsyncTimeout().let { node ->
+        node.timeout(3600 + i, TIME_UNIT)
+        nodes.add(node)
+      }
+    }
+
+    heap = object : Heap() {
+      override fun signal() {
+        /* No-op */
+      }
+    }
+    heap.head = AsyncTimeout()
+
+    val now = System.nanoTime()
+    nodes.forEachIndexed { i, node ->
+      heap.insertIntoQueue(now, node)
+      validateHeap(heap)
+    }
+  }
+
+  @Test
+  fun heapIsConsistentAfterRemoveFirst() {
+    while (nodes.isNotEmpty()) {
+      val node = nodes.removeFirst()
+      heap.removeFirst(node)
+      validateHeap(heap)
+    }
+  }
+
+  @Test
+  fun minHeapConsistentAfterRandomRemovals() {
+    nodes.shuffle()
+    while (nodes.isNotEmpty()) {
+      val node = nodes.removeFirst()
+      heap.removeFromQueue(node)
+      validateHeap(heap)
+    }
+  }
+
+  @Test
+  fun firstReturnsSmallestElement() {
+    while (nodes.isNotEmpty()) {
+      val node = nodes.removeFirst()
+      assertThat(node === heap.first())
+      heap.removeFirst(node)
+      validateHeap(heap)
+    }
+  }
+
+  companion object {
+    val TIME_UNIT = TimeUnit.SECONDS
+    val NUMBER_OF_NODES = 1000
+  }
+}
+
+internal fun validateHeap(heap: Heap) {
+  val head = heap.head
+  val heapSize = heap.heapSize
+  if (head?.left == null) {
+    assertThat(heapSize == 0) { "Heap root is null but heapSize > 0" }
+    return
+  }
+
+  val queue = ArrayDeque<AsyncTimeout>()
+  queue.add(head.left!!)
+
+  var index = 1
+  while (queue.isNotEmpty()) {
+    val current = queue.removeFirst()
+
+    // Check left child
+    current.left?.let {
+      assertThat(compareTo(it, current) >= 0) {
+        "Heap property violated at node $current: left child $it is smaller."
+      }
+      queue.add(it)
+    }
+
+    // Check right child
+    current.right?.let {
+      assertThat(compareTo(it, current) >= 0) {
+        "Heap property violated at node $current: right child $it is smaller."
+      }
+      queue.add(it)
+    }
+
+    // Ensure the heap is a complete binary tree
+    assertThat(current.left != null || current.right == null) {
+      "Heap structure violated: node $current has a right child but no left child."
+    }
+
+    index++
+  }
+
+  assertThat(index-1 == heapSize) {
+    "Heap size mismatch: expected $index, but got ${heapSize}."
+  }
+}


### PR DESCRIPTION
## Description

AsyncTimeout currently manages timeouts in a linked list structure. This change adds a minHeap implementation for managing timeout nodes with improved runtime performance. Initial performance is looking great for node size > 100.

<img width="564" height="234" alt="Screenshot 2025-07-11 at 9 01 37 PM" src="https://github.com/user-attachments/assets/fab39a81-3300-4073-86d8-0016d9d1051d" />
