### PR TITLE
Get Socket.inputStream and outputStream eagerly

### DIFF
--- a/okio/src/jvmTest/kotlin/okio/SocketTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/SocketTest.kt
@@ -25,6 +25,7 @@ import java.io.InterruptedIOException
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.ServerSocket
+import java.net.SocketException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import javax.net.SocketFactory
@@ -251,6 +252,24 @@ class SocketTest(val factory: Factory = Factory.Default) {
     socket.sink.close()
     assertThat(javaNetSocket.isOutputShutdown).isTrue()
     assertThat(javaNetSocket.isClosed).isFalse()
+  }
+
+  @Test
+  fun cannotCreateOkioSocketFromClosedJavaNetSocket() {
+    val javaNetSocket = (this.socket as? DefaultSocket)?.socket ?: return
+    javaNetSocket.close()
+
+    assertFailsWith<SocketException> {
+      javaNetSocket.asOkioSocket()
+    }
+  }
+
+  @Test
+  fun cannotCreateOkioSocketFromUnconnectedJavaNetSocket() {
+    val unconnected = SocketFactory.getDefault().createSocket()
+    assertFailsWith<SocketException> {
+      unconnected.asOkioSocket()
+    }
   }
 
   @Suppress("ktlint:trailing-comma-on-declaration-site")


### PR DESCRIPTION
I was looking into migrating OkHttp to use Okio's
Socket internally and I came across a small behavior change - previously we were getting the stream once and reusing it on each call, but now Okio is getting the stream on each access.

With this change the Socket.asOkioSocket() API behaves more consistently with Socket.source() and Socket.sink().