### PR TITLE
Add FileSystem.lock (#1869)

### DIFF
--- a/okio-fakefilesystem/api/okio-fakefilesystem.api
+++ b/okio-fakefilesystem/api/okio-fakefilesystem.api
@@ -25,6 +25,7 @@ public final class okio/fakefilesystem/FakeFileSystem : okio/FileSystem {
 	public final fun getWorkingDirectory ()Lokio/Path;
 	public fun list (Lokio/Path;)Ljava/util/List;
 	public fun listOrNull (Lokio/Path;)Ljava/util/List;
+	public fun lock (Lokio/Path;Lokio/LockMode;)Lokio/FileLock;
 	public fun metadataOrNull (Lokio/Path;)Lokio/FileMetadata;
 	public final fun openPaths ()Ljava/util/List;
 	public fun openReadOnly (Lokio/Path;)Lokio/FileHandle;
@@ -40,5 +41,10 @@ public final class okio/fakefilesystem/FakeFileSystem : okio/FileSystem {
 	public fun sink (Lokio/Path;Z)Lokio/Sink;
 	public fun source (Lokio/Path;)Lokio/Source;
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class okio/fakefilesystem/FakeFileSystemLock {
+	public fun <init> (Lokio/Path;)V
+	public final fun lock (Lokio/LockMode;)Lokio/FileLock;
 }
 

--- a/okio-fakefilesystem/src/jvmMain/kotlin/okio/fakefilesystem/FakeFileSystemLock.jvm.kt
+++ b/okio-fakefilesystem/src/jvmMain/kotlin/okio/fakefilesystem/FakeFileSystemLock.jvm.kt
@@ -24,7 +24,7 @@ import okio.LockMode
 import okio.Path
 
 actual class FakeFileSystemLock actual constructor(
-  private val path: Path
+  private val path: Path,
 ) {
   private val readWriteLock = StampedLock()
 

--- a/okio-fakefilesystem/src/jvmMain/kotlin/okio/fakefilesystem/FakeFileSystemLock.jvm.kt
+++ b/okio-fakefilesystem/src/jvmMain/kotlin/okio/fakefilesystem/FakeFileSystemLock.jvm.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package okio.fakefilesystem
+
+import java.util.concurrent.locks.StampedLock
+import okio.FileLock
+import okio.IOException
+import okio.LockMode
+import okio.Path
+
+actual class FakeFileSystemLock actual constructor(
+  private val path: Path
+) {
+  private val readWriteLock = StampedLock()
+
+  actual fun lock(mode: LockMode): FileLock {
+    val stamp = when (mode) {
+      LockMode.Shared -> readWriteLock.tryReadLock()
+      LockMode.Exclusive -> readWriteLock.tryWriteLock()
+    }
+
+    if (stamp == 0L) {
+      throw IOException("Could not lock $path")
+    }
+
+    return object : FileLock {
+      override val isShared: Boolean
+        get() = mode == LockMode.Shared
+
+      override val isValid: Boolean
+        get() = readWriteLock.validate(stamp)
+
+      override fun close() {
+        readWriteLock.unlock(stamp)
+      }
+    }
+  }
+}

--- a/okio-fakefilesystem/src/nonJvmMain/kotlin/okio/fakefilesystem/FakeFileSystemLock.nonJvm.kt
+++ b/okio-fakefilesystem/src/nonJvmMain/kotlin/okio/fakefilesystem/FakeFileSystemLock.nonJvm.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.fakefilesystem
+
+import okio.FileLock
+import okio.LockMode
+import okio.Path
+
+actual class FakeFileSystemLock actual constructor(path: Path) {
+  actual fun lock(mode: LockMode): FileLock {
+    TODO("Not yet implemented")
+  }
+}

--- a/okio/api/okio.api
+++ b/okio/api/okio.api
@@ -432,6 +432,12 @@ public abstract class okio/FileHandle : java/io/Closeable {
 	public final fun write (J[BII)V
 }
 
+public abstract interface class okio/FileLock : java/lang/AutoCloseable {
+	public fun getFileHandle ()Lokio/FileHandle;
+	public abstract fun isShared ()Z
+	public abstract fun isValid ()Z
+}
+
 public final class okio/FileMetadata {
 	public fun <init> ()V
 	public fun <init> (ZZLokio/Path;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Map;)V
@@ -486,6 +492,8 @@ public abstract class okio/FileSystem : java/io/Closeable {
 	public final fun listRecursively (Lokio/Path;)Lkotlin/sequences/Sequence;
 	public fun listRecursively (Lokio/Path;Z)Lkotlin/sequences/Sequence;
 	public static synthetic fun listRecursively$default (Lokio/FileSystem;Lokio/Path;ZILjava/lang/Object;)Lkotlin/sequences/Sequence;
+	public fun lock (Lokio/Path;Lokio/LockMode;)Lokio/FileLock;
+	public static synthetic fun lock$default (Lokio/FileSystem;Lokio/Path;Lokio/LockMode;ILjava/lang/Object;)Lokio/FileLock;
 	public final fun metadata (Lokio/Path;)Lokio/FileMetadata;
 	public abstract fun metadataOrNull (Lokio/Path;)Lokio/FileMetadata;
 	public abstract fun openReadOnly (Lokio/Path;)Lokio/FileHandle;
@@ -636,6 +644,14 @@ public final class okio/InflaterSource : okio/Source {
 	public final fun readOrInflate (Lokio/Buffer;J)J
 	public final fun refill ()Z
 	public fun timeout ()Lokio/Timeout;
+}
+
+public final class okio/LockMode : java/lang/Enum {
+	public static final field Exclusive Lokio/LockMode;
+	public static final field Shared Lokio/LockMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lokio/LockMode;
+	public static fun values ()[Lokio/LockMode;
 }
 
 public final class okio/Okio {

--- a/okio/src/commonMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/commonMain/kotlin/okio/FileSystem.kt
@@ -391,6 +391,19 @@ expect abstract class FileSystem() : Closeable {
   @Throws(IOException::class)
   override fun close()
 
+  /**
+   * Obtain an Exclusive or Shared Lock on [path].
+   *
+   * @throws IOException if [path] does not exist, the FileSystem or the path does not
+   * support file locking, or the lock cannot be acquired. This method does not wait for the lock
+   * to become available.
+   */
+  @Throws(IOException::class)
+  open fun lock(
+    path: Path,
+    mode: LockMode = LockMode.Exclusive,
+  ): FileLock
+
   companion object {
     /**
      * Returns a writable temporary directory on [SYSTEM].
@@ -407,4 +420,17 @@ expect abstract class FileSystem() : Closeable {
      */
     val SYSTEM_TEMPORARY_DIRECTORY: Path
   }
+}
+
+enum class LockMode {
+  Exclusive,
+  Shared,
+}
+
+interface FileLock : AutoCloseable {
+  val isShared: Boolean
+  val isValid: Boolean
+
+  val fileHandle: FileHandle
+    get() = TODO()
 }

--- a/okio/src/commonTest/kotlin/okio/BaseFileLockTest.kt
+++ b/okio/src/commonTest/kotlin/okio/BaseFileLockTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+abstract class BaseFileLockTest {
+  abstract val fileSystem: FileSystem
+  abstract val file1: Path
+
+  abstract fun isSupported(): Boolean
+
+  abstract fun isSharedLockSupported(): Boolean
+
+  @BeforeTest
+  fun createFile() {
+    fileSystem.write(file1) {}
+  }
+
+  @Test
+  fun testLockAndUnlock() {
+    if (!isSupported()) {
+      return
+    }
+
+    val lock = fileSystem.lock(file1, mode = LockMode.Exclusive)
+
+    assertTrue(lock.isValid)
+    assertFalse(lock.isShared)
+
+    lock.close()
+    assertFalse(lock.isValid)
+  }
+
+  @Test
+  fun testExclusiveLock() {
+    if (!isSupported()) {
+      return
+    }
+
+    val lock1 = fileSystem.lock(file1, mode = LockMode.Exclusive)
+
+    assertTrue(lock1.isValid)
+
+    val x2 = assertFailsWith<IOException> { fileSystem.lock(file1, mode = LockMode.Exclusive) }
+    assertLockFailure(x2, file1)
+
+    val x3 = assertFailsWith<IOException> { fileSystem.lock(file1, mode = LockMode.Shared) }
+    assertLockFailure(x3, file1)
+
+    lock1.close()
+
+    val lock4 = fileSystem.lock(file1, mode = LockMode.Exclusive)
+    assertTrue(lock4.isValid)
+  }
+
+  @Test
+  fun testSharedLock() {
+    if (!isSupported()) {
+      return
+    }
+
+    val lock1 = fileSystem.lock(file1, mode = LockMode.Shared)
+
+    assertTrue(lock1.isValid)
+    val x2 = assertFailsWith<IOException> { fileSystem.lock(file1, mode = LockMode.Exclusive) }
+    assertLockFailure(x2, file1)
+
+    val lock3 = if (isSharedLockSupported()) {
+      val lock3 = fileSystem.lock(file1, mode = LockMode.Shared)
+      assertTrue(lock3.isValid)
+      lock3
+    } else {
+      val x3 = assertFailsWith<IOException> { fileSystem.lock(file1, mode = LockMode.Shared) }
+      assertLockFailure(x3, file1)
+      null
+    }
+
+    assertTrue(lock1.isValid)
+
+    lock1.close()
+
+    if (lock3 != null) {
+      val x4 = assertFailsWith<IOException> { fileSystem.lock(file1, mode = LockMode.Exclusive) }
+      assertLockFailure(x4, file1)
+
+      lock3.close()
+    }
+
+    val lock5 = fileSystem.lock(file1, mode = LockMode.Exclusive)
+    assertTrue(lock5.isValid)
+  }
+
+  abstract fun assertLockFailure(ex: Exception, path: Path)
+}

--- a/okio/src/jsMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/jsMain/kotlin/okio/FileSystem.kt
@@ -98,6 +98,13 @@ actual abstract class FileSystem : Closeable {
   actual override fun close() {
   }
 
+  actual open fun lock(
+    path: Path,
+    mode: LockMode,
+  ): FileLock {
+    throw IOException("This file system does not support locking.")
+  }
+
   actual companion object {
     actual val SYSTEM_TEMPORARY_DIRECTORY: Path = tmpdir.toPath()
   }

--- a/okio/src/jvmMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/FileSystem.kt
@@ -16,6 +16,7 @@
 package okio
 
 import java.nio.file.FileSystem as JavaNioFileSystem
+import kotlin.Throws
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import okio.Path.Companion.toPath
@@ -141,6 +142,14 @@ actual abstract class FileSystem : Closeable {
 
   @Throws(IOException::class)
   actual override fun close() {
+  }
+
+  @Throws(IOException::class)
+  actual open fun lock(
+    path: Path,
+    mode: LockMode,
+  ): FileLock {
+    throw IOException("This file system does not support locking.")
   }
 
   actual companion object {

--- a/okio/src/jvmMain/kotlin/okio/NioFileSystemWrappingFileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/NioFileSystemWrappingFileSystem.kt
@@ -192,4 +192,11 @@ internal class NioFileSystemWrappingFileSystem(private val nioFileSystem: NioFil
   }
 
   override fun toString() = nioFileSystem::class.simpleName!!
+
+  @Suppress("NewApi")
+  @Throws(IOException::class)
+  override fun lock(
+    path: Path,
+    mode: LockMode,
+  ): FileLock = lock(path.resolve(), mode)
 }

--- a/okio/src/jvmTest/kotlin/okio/FakeFileLockTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/FakeFileLockTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import kotlin.test.assertEquals
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+
+class FakeFileLockTest : BaseFileLockTest() {
+  override val fileSystem: FileSystem = FakeFileSystem()
+
+  override val file1: Path
+    get() = "/file1".toPath()
+
+  override fun isSupported(): Boolean = true
+
+  override fun isSharedLockSupported(): Boolean = true
+
+  override fun assertLockFailure(ex: Exception, path: Path) {
+    assertEquals("Could not lock $path", ex.message)
+  }
+}

--- a/okio/src/jvmTest/kotlin/okio/JvmFileLockTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/JvmFileLockTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import kotlin.test.assertContains
+import okio.Path.Companion.toOkioPath
+import okio.TestUtil.isWindows
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+class JvmFileLockTest() : BaseFileLockTest() {
+  @JvmField
+  @Rule
+  var temporaryFolder = TemporaryFolder()
+
+  override val fileSystem: FileSystem
+    get() = FileSystem.SYSTEM
+
+  override val file1: Path by lazy { temporaryFolder.newFile("file1").toOkioPath() }
+
+  override fun isSupported(): Boolean = true
+
+  override fun isSharedLockSupported(): Boolean = !isWindows()
+
+  override fun assertLockFailure(ex: Exception, path: Path) {
+    assertContains(ex.message!!, "Could not lock $path")
+  }
+}

--- a/okio/src/jvmTest/kotlin/okio/TestUtil.kt
+++ b/okio/src/jvmTest/kotlin/okio/TestUtil.kt
@@ -294,5 +294,8 @@ object TestUtil {
     return reversed.toShort()
   }
 
-  fun assumeNotWindows() = Assume.assumeFalse(System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win"))
+  fun assumeNotWindows() = Assume.assumeFalse(isWindows())
+
+  fun isWindows(): Boolean =
+    System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win")
 }

--- a/okio/src/nativeMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/nativeMain/kotlin/okio/FileSystem.kt
@@ -117,6 +117,14 @@ actual abstract class FileSystem : Closeable {
   actual override fun close() {
   }
 
+  @Throws(IOException::class)
+  actual open fun lock(
+    path: Path,
+    mode: LockMode,
+  ): FileLock {
+    throw IOException("This file system does not support locking.")
+  }
+
   actual companion object {
     /**
      * The current process's host file system. Use this instance directly, or dependency inject a

--- a/okio/src/wasmMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/wasmMain/kotlin/okio/FileSystem.kt
@@ -99,6 +99,14 @@ actual abstract class FileSystem : Closeable {
   actual override fun close() {
   }
 
+  @Throws(IOException::class)
+  actual open fun lock(
+    path: Path,
+    mode: LockMode,
+  ): FileLock {
+    throw IOException("This file system does not support locking.")
+  }
+
   actual companion object {
     actual val SYSTEM_TEMPORARY_DIRECTORY: Path = "/tmp".toPath()
   }


### PR DESCRIPTION
This commit introduces file locking capabilities to the Okio FileSystem.

For discussion of https://github.com/square/okio/issues/1464

TODO

- [ ] Consider blocking for availability
- [ ] Demonstrate API for reading/writing exclusively within a lock. Fail if outside.
- [ ] Consider upgrade from Shared to Exclusive
- [ ] Implement for Node - npm `proper-lockfile` ?

Key changes:
- Added `FileSystem.lock()` method to acquire exclusive or shared locks on files.
- Implemented `FileLock` interface for managing lock state and lifecycle.
- Provided JVM-specific implementation using `java.nio.channels.FileChannel.lock()`.
- Added `FakeFileSystemLock` for testing purposes.
- Included base and platform-specific tests for file locking functionality.
- Default implementations in common, JS, Native, and Wasm `FileSystem` throw `IOException` as locking is not supported on these platforms by default.
- Updated `NioFileSystemWrappingFileSystem` and `JvmSystemFileSystem` to delegate to the new locking mechanism.