### PR TITLE
Fix compareTo function for priority queue in Asynctimeout

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/AsyncTimeout.kt
+++ b/okio/src/jvmMain/kotlin/okio/AsyncTimeout.kt
@@ -49,7 +49,8 @@ open class AsyncTimeout : Timeout() {
   @JvmField internal var index: Int = -1
 
   /** If scheduled, this is the time that the watchdog should time this out.  */
-  private var timeoutAt: Long = 0L
+  internal var timeoutAt: Long = 0L
+    private set
 
   fun enter() {
     val timeoutNanos = timeoutNanos()
@@ -96,9 +97,6 @@ open class AsyncTimeout : Timeout() {
    * elapsed and the timeout should occur immediately.
    */
   internal fun remainingNanos(now: Long) = timeoutAt - now
-
-  /** If scheduled, this is the expiration time of this timeout  */
-  internal fun timeoutAt(): Long = timeoutAt
 
   /**
    * Sets the timeoutAt value as a sum of [now] and the time to wait for this timeout.
@@ -508,8 +506,8 @@ internal class PriorityQueue {
    */
   @Suppress("NOTHING_TO_INLINE")
   private inline operator fun AsyncTimeout.compareTo(other: AsyncTimeout): Int {
-    val a = timeoutAt()
-    val b = other.timeoutAt()
+    val a = timeoutAt
+    val b = other.timeoutAt
     return 0L.compareTo(b - a)
   }
 }

--- a/okio/src/jvmTest/kotlin/okio/internal/PriorityQueueTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/internal/PriorityQueueTest.kt
@@ -19,7 +19,6 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import java.lang.Integer.numberOfTrailingZeros
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeUnit.NANOSECONDS
 import kotlin.time.Duration.Companion.nanoseconds
 import okio.AsyncTimeout
 import okio.PriorityQueue
@@ -268,7 +267,7 @@ class PriorityQueueTest {
         ) {
           append(".".repeat(nodeWidth))
         } else {
-          val nodeValue = array[index++]!!.timeoutAt().toString()
+          val nodeValue = array[index++]!!.timeoutAt.toString()
           append(".".repeat(nodeWidth - nodeValue.length))
           append(nodeValue)
         }


### PR DESCRIPTION
## Description

Fixes: https://github.com/square/okio/issues/1737

The  priority queue used by the async timeout class should return the timeout with earliest expiration time, but it was instead returning the timeout with the smallest `timeoutNanos` value.

This PR fixes that issue by updating the `AsyncTimeout.CompareTo` function compare the `timeoutAt` value instead of the `timeoutNanos` value.