### PR TITLE
Drop `isWasm()` early return workaround for KT-60212.

### DIFF
--- a/okio-testing-support/src/commonMain/kotlin/okio/TestingCommon.kt
+++ b/okio-testing-support/src/commonMain/kotlin/okio/TestingCommon.kt
@@ -40,8 +40,6 @@ fun randomToken(length: Int) = Random.nextBytes(length).toByteString(0, length).
 
 expect fun isBrowser(): Boolean
 
-expect fun isWasm(): Boolean
-
 val FileMetadata.createdAt: Instant?
   get() {
     val createdAt = createdAtMillis ?: return null

--- a/okio-testing-support/src/jsMain/kotlin/okio/TestingJs.kt
+++ b/okio-testing-support/src/jsMain/kotlin/okio/TestingJs.kt
@@ -19,7 +19,5 @@ actual fun isBrowser(): Boolean {
   return js("""(globalThis.window || null)""") != null
 }
 
-actual fun isWasm() = false
-
 actual fun getEnv(name: String): String? =
   js("globalThis.process.env[name]") as String?

--- a/okio-testing-support/src/jvmMain/kotlin/okio/TestingJvm.kt
+++ b/okio-testing-support/src/jvmMain/kotlin/okio/TestingJvm.kt
@@ -17,6 +17,4 @@ package okio
 
 actual fun isBrowser() = false
 
-actual fun isWasm() = false
-
 actual fun getEnv(name: String): String? = System.getenv(name)

--- a/okio-testing-support/src/nativeMain/kotlin/okio/TestingNative.kt
+++ b/okio-testing-support/src/nativeMain/kotlin/okio/TestingNative.kt
@@ -21,7 +21,5 @@ import platform.posix.getenv
 
 actual fun isBrowser() = false
 
-actual fun isWasm() = false
-
 @OptIn(ExperimentalForeignApi::class)
 actual fun getEnv(name: String): String? = getenv(name)?.toKString()

--- a/okio-testing-support/src/wasmMain/kotlin/okio/TestingWasm.kt
+++ b/okio-testing-support/src/wasmMain/kotlin/okio/TestingWasm.kt
@@ -21,8 +21,6 @@ import kotlin.time.ExperimentalTime
 
 actual fun isBrowser() = false
 
-actual fun isWasm() = true
-
 actual val FileSystem.isFakeFileSystem: Boolean
   get() = false
 

--- a/okio/src/commonTest/kotlin/okio/CommonBufferedSourceTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonBufferedSourceTest.kt
@@ -962,10 +962,6 @@ class CommonBufferedSourceTest(
   }
 
   @Test fun codePoints() {
-    // TODO: remove this suppression once this issue is fixed.
-    // https://youtrack.jetbrains.com/issue/KT-60212
-    if (isWasm()) return
-
     sink.write("7f".decodeHex())
     sink.emit()
     assertEquals(0x7f, source.readUtf8CodePoint().toLong())


### PR DESCRIPTION
[KT-60212](https://youtrack.jetbrains.com/issue/KT-60212) was fixed a long time ago!