### PR TITLE
Remove Kotlin/JS IR default parameter workarounds.

### DIFF
--- a/okio/src/commonMain/kotlin/okio/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/Buffer.kt
@@ -103,9 +103,9 @@ expect class Buffer() : BufferedSource, BufferedSink {
   /** Returns an immutable copy of the first `byteCount` bytes of this buffer as a byte string. */
   fun snapshot(byteCount: Int): ByteString
 
-  fun readUnsafe(unsafeCursor: UnsafeCursor = DEFAULT__new_UnsafeCursor): UnsafeCursor
+  fun readUnsafe(unsafeCursor: UnsafeCursor = UnsafeCursor()): UnsafeCursor
 
-  fun readAndWriteUnsafe(unsafeCursor: UnsafeCursor = DEFAULT__new_UnsafeCursor): UnsafeCursor
+  fun readAndWriteUnsafe(unsafeCursor: UnsafeCursor = UnsafeCursor()): UnsafeCursor
 
   override val buffer: Buffer
   override fun close()

--- a/okio/src/commonMain/kotlin/okio/ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/ByteString.kt
@@ -97,7 +97,7 @@ internal constructor(data: ByteArray) : Comparable<ByteString> {
    * `beginIndex` and ends at the specified `endIndex`. Returns this byte string if `beginIndex` is
    * 0 and `endIndex` is the length of this byte string.
    */
-  fun substring(beginIndex: Int = 0, endIndex: Int = DEFAULT__ByteString_size): ByteString
+  fun substring(beginIndex: Int = 0, endIndex: Int = size): ByteString
 
   /**
    * Returns a byte string equal to this byte string, but with the bytes 'a' through 'z' replaced
@@ -164,9 +164,9 @@ internal constructor(data: ByteArray) : Comparable<ByteString> {
   @JvmOverloads
   fun indexOf(other: ByteArray, fromIndex: Int = 0): Int
 
-  fun lastIndexOf(other: ByteString, fromIndex: Int = DEFAULT__ByteString_size): Int
+  fun lastIndexOf(other: ByteString, fromIndex: Int = size): Int
 
-  fun lastIndexOf(other: ByteArray, fromIndex: Int = DEFAULT__ByteString_size): Int
+  fun lastIndexOf(other: ByteArray, fromIndex: Int = size): Int
 
   override fun equals(other: Any?): Boolean
 
@@ -193,7 +193,7 @@ internal constructor(data: ByteArray) : Comparable<ByteString> {
      * starting at `offset`.
      */
     @JvmStatic
-    fun ByteArray.toByteString(offset: Int = 0, byteCount: Int = DEFAULT__ByteString_size): ByteString
+    fun ByteArray.toByteString(offset: Int = 0, byteCount: Int = size): ByteString
 
     /** Returns a new byte string containing the `UTF-8` bytes of this [String]. */
     @JvmStatic

--- a/okio/src/commonMain/kotlin/okio/Util.kt
+++ b/okio/src/commonMain/kotlin/okio/Util.kt
@@ -162,25 +162,3 @@ internal fun Long.toHexString(): String {
 
   return result.concatToString(i, result.size)
 }
-
-// Work around a problem where Kotlin/JS IR can't handle default parameters on expect functions
-// that depend on the receiver. We use well-known, otherwise-impossible values here and must check
-// for them in the receiving function, then swap in the true default value.
-// https://youtrack.jetbrains.com/issue/KT-45542
-
-internal val DEFAULT__new_UnsafeCursor = Buffer.UnsafeCursor()
-internal fun resolveDefaultParameter(unsafeCursor: Buffer.UnsafeCursor): Buffer.UnsafeCursor {
-  if (unsafeCursor === DEFAULT__new_UnsafeCursor) return Buffer.UnsafeCursor()
-  return unsafeCursor
-}
-
-internal val DEFAULT__ByteString_size = -1234567890
-internal fun ByteString.resolveDefaultParameter(position: Int): Int {
-  if (position == DEFAULT__ByteString_size) return size
-  return position
-}
-
-internal fun ByteArray.resolveDefaultParameter(sizeParam: Int): Int {
-  if (sizeParam == DEFAULT__ByteString_size) return size
-  return sizeParam
-}

--- a/okio/src/commonMain/kotlin/okio/internal/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/Buffer.kt
@@ -37,7 +37,6 @@ import okio.and
 import okio.asUtf8ToByteArray
 import okio.checkOffsetAndCount
 import okio.minOf
-import okio.resolveDefaultParameter
 import okio.toHexString
 
 internal val HEX_DIGIT_BYTES = "0123456789abcdef".asUtf8ToByteArray()
@@ -1528,7 +1527,6 @@ internal inline fun Buffer.commonSnapshot(byteCount: Int): ByteString {
 }
 
 internal fun Buffer.commonReadUnsafe(unsafeCursor: UnsafeCursor): UnsafeCursor {
-  val unsafeCursor = resolveDefaultParameter(unsafeCursor)
   check(unsafeCursor.buffer == null) { "already attached to a buffer" }
 
   unsafeCursor.buffer = this
@@ -1537,7 +1535,6 @@ internal fun Buffer.commonReadUnsafe(unsafeCursor: UnsafeCursor): UnsafeCursor {
 }
 
 internal fun Buffer.commonReadAndWriteUnsafe(unsafeCursor: UnsafeCursor): UnsafeCursor {
-  val unsafeCursor = resolveDefaultParameter(unsafeCursor)
   check(unsafeCursor.buffer == null) { "already attached to a buffer" }
 
   unsafeCursor.buffer = this

--- a/okio/src/commonMain/kotlin/okio/internal/ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/ByteString.kt
@@ -30,7 +30,6 @@ import okio.decodeBase64ToArray
 import okio.encodeBase64
 import okio.isIsoControl
 import okio.processUtf8CodePoints
-import okio.resolveDefaultParameter
 import okio.shr
 import okio.toUtf8String
 
@@ -126,7 +125,6 @@ internal inline fun ByteString.commonToAsciiUppercase(): ByteString {
 
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun ByteString.commonSubstring(beginIndex: Int, endIndex: Int): ByteString {
-  val endIndex = resolveDefaultParameter(endIndex)
   require(beginIndex >= 0) { "beginIndex < 0" }
   require(endIndex <= data.size) { "endIndex > length(${data.size})" }
 
@@ -218,7 +216,6 @@ internal inline fun ByteString.commonLastIndexOf(
 
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun ByteString.commonLastIndexOf(other: ByteArray, fromIndex: Int): Int {
-  val fromIndex = resolveDefaultParameter(fromIndex)
   val limit = data.size - other.size
   for (i in minOf(fromIndex, limit) downTo 0) {
     if (arrayRangeEquals(data, i, other, 0, other.size)) {
@@ -270,7 +267,6 @@ internal inline fun commonOf(data: ByteArray) = ByteString(data.copyOf())
 
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun ByteArray.commonToByteString(offset: Int, byteCount: Int): ByteString {
-  val byteCount = resolveDefaultParameter(byteCount)
   checkOffsetAndCount(size.toLong(), offset.toLong(), byteCount.toLong())
   return ByteString(copyOfRange(offset, offset + byteCount))
 }

--- a/okio/src/commonMain/kotlin/okio/internal/SegmentedByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/SegmentedByteString.kt
@@ -28,7 +28,6 @@ import okio.Segment
 import okio.SegmentedByteString
 import okio.arrayRangeEquals
 import okio.checkOffsetAndCount
-import okio.resolveDefaultParameter
 
 internal fun IntArray.binarySearch(value: Int, fromIndex: Int, toIndex: Int): Int {
   var left = fromIndex
@@ -101,7 +100,6 @@ private inline fun SegmentedByteString.forEachSegment(
 // have to call these functions. Remove all this nonsense when expect class allow actual code.
 
 internal inline fun SegmentedByteString.commonSubstring(beginIndex: Int, endIndex: Int): ByteString {
-  val endIndex = resolveDefaultParameter(endIndex)
   require(beginIndex >= 0) { "beginIndex=$beginIndex < 0" }
   require(endIndex <= size) { "endIndex=$endIndex > length($size)" }
 


### PR DESCRIPTION
[KT-45542](https://youtrack.jetbrains.com/issue/KT-45542) was marked as fixed a long time ago.