### PR TITLE
Generalize Sink/Source API to accept BufferedSource/BufferedSink

### DIFF
--- a/okio-nodefilesystem/src/commonMain/kotlin/okio/FileSink.kt
+++ b/okio-nodefilesystem/src/commonMain/kotlin/okio/FileSink.kt
@@ -20,9 +20,9 @@ internal class FileSink(
 ) : Sink {
   private var closed = false
 
-  override fun write(source: Buffer, byteCount: Long) {
+  override fun write(source: BufferedSource, byteCount: Long) {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
-    require(source.size >= byteCount) { "source.size=${source.size} < byteCount=$byteCount" }
+    require(source.buffer.size >= byteCount) { "source.size=${source.buffer.size} < byteCount=$byteCount" }
     check(!closed) { "closed" }
 
     val data = source.readByteArray(byteCount)

--- a/okio-nodefilesystem/src/commonMain/kotlin/okio/FileSource.kt
+++ b/okio-nodefilesystem/src/commonMain/kotlin/okio/FileSource.kt
@@ -21,7 +21,7 @@ internal class FileSource(
   private var position_ = 0L
   private var closed = false
 
-  override fun read(sink: Buffer, byteCount: Long): Long {
+  override fun read(sink: BufferedSink, byteCount: Long): Long {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
     check(!closed) { "closed" }
 

--- a/okio-wasifilesystem/src/wasmWasiMain/kotlin/okio/FileSink.kt
+++ b/okio-wasifilesystem/src/wasmWasiMain/kotlin/okio/FileSink.kt
@@ -30,13 +30,13 @@ internal class FileSink(
   private var closed = false
   private val cursor = Buffer.UnsafeCursor()
 
-  override fun write(source: Buffer, byteCount: Long) {
+  override fun write(source: BufferedSource, byteCount: Long) {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
-    require(source.size >= byteCount) { "source.size=${source.size} < byteCount=$byteCount" }
+    require(source.buffer.size >= byteCount) { "source.size=${source.buffer.size} < byteCount=$byteCount" }
     check(!closed) { "closed" }
 
     var bytesRemaining = byteCount
-    source.readAndWriteUnsafe(cursor)
+    source.buffer.readAndWriteUnsafe(cursor)
     try {
       while (bytesRemaining > 0L) {
         check(cursor.next() != -1)

--- a/okio-wasifilesystem/src/wasmWasiMain/kotlin/okio/FileSource.kt
+++ b/okio-wasifilesystem/src/wasmWasiMain/kotlin/okio/FileSource.kt
@@ -29,14 +29,14 @@ internal class FileSource(
   private val unsafeCursor = Buffer.UnsafeCursor()
   private var closed = false
 
-  override fun read(sink: Buffer, byteCount: Long): Long {
+  override fun read(sink: BufferedSink, byteCount: Long): Long {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
     check(!closed) { "closed" }
-    val sinkInitialSize = sink.size
+    val sinkInitialSize = sink.buffer.size
 
     // Request a writable segment in `sink`. We request at least 1024 bytes, unless the request is
     // for smaller than that, in which case we request only that many bytes.
-    val cursor = sink.readAndWriteUnsafe(unsafeCursor)
+    val cursor = sink.buffer.readAndWriteUnsafe(unsafeCursor)
     val addedCapacityCount = cursor.expandBuffer(minByteCount = minOf(byteCount, 1024L).toInt())
 
     // Now that we have a writable segment, figure out how many bytes to read. This is the smaller

--- a/okio/src/commonMain/kotlin/okio/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/Buffer.kt
@@ -36,7 +36,7 @@ expect class Buffer() : BufferedSource, BufferedSink {
 
   /** Copy `byteCount` bytes from this, starting at `offset`, to `out`.  */
   fun copyTo(
-    out: Buffer,
+    out: BufferedSink,
     offset: Long = 0L,
     byteCount: Long,
   ): Buffer
@@ -124,7 +124,7 @@ expect class Buffer() : BufferedSource, BufferedSink {
   override fun peek(): BufferedSource
   override fun rangeEquals(offset: Long, bytes: ByteString): Boolean
   override fun rangeEquals(offset: Long, bytes: ByteString, bytesOffset: Int, byteCount: Int): Boolean
-  override fun read(sink: Buffer, byteCount: Long): Long
+  override fun read(sink: BufferedSink, byteCount: Long): Long
   override fun read(sink: ByteArray): Int
   override fun read(sink: ByteArray, offset: Int, byteCount: Int): Int
   override fun readAll(sink: Sink): Long
@@ -156,7 +156,7 @@ expect class Buffer() : BufferedSource, BufferedSink {
   override fun timeout(): Timeout
   override fun write(byteString: ByteString): Buffer
   override fun write(byteString: ByteString, offset: Int, byteCount: Int): Buffer
-  override fun write(source: Buffer, byteCount: Long)
+  override fun write(source: BufferedSource, byteCount: Long)
   override fun write(source: ByteArray): Buffer
   override fun write(source: ByteArray, offset: Int, byteCount: Int): Buffer
   override fun write(source: Source, byteCount: Long): Buffer

--- a/okio/src/commonMain/kotlin/okio/FileHandle.kt
+++ b/okio/src/commonMain/kotlin/okio/FileHandle.kt
@@ -330,14 +330,14 @@ abstract class FileHandle(
   @Throws(IOException::class)
   protected abstract fun protectedClose()
 
-  private fun readNoCloseCheck(fileOffset: Long, sink: Buffer, byteCount: Long): Long {
+  private fun readNoCloseCheck(fileOffset: Long, sink: BufferedSink, byteCount: Long): Long {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
 
     var currentOffset = fileOffset
     val targetOffset = fileOffset + byteCount
 
     while (currentOffset < targetOffset) {
-      val tail = sink.writableSegment(1)
+      val tail = sink.buffer.writableSegment(1)
       val readByteCount = protectedRead(
         fileOffset = currentOffset,
         array = tail.data,
@@ -348,7 +348,7 @@ abstract class FileHandle(
       if (readByteCount == -1) {
         if (tail.pos == tail.limit) {
           // We allocated a tail segment, but didn't end up needing it. Recycle!
-          sink.head = tail.pop()
+          sink.buffer.head = tail.pop()
           SegmentPool.recycle(tail)
         }
         if (fileOffset == currentOffset) return -1L // We wanted bytes but didn't return any.
@@ -357,29 +357,29 @@ abstract class FileHandle(
 
       tail.limit += readByteCount
       currentOffset += readByteCount
-      sink.size += readByteCount
+      sink.buffer.size += readByteCount
     }
 
     return currentOffset - fileOffset
   }
 
-  private fun writeNoCloseCheck(fileOffset: Long, source: Buffer, byteCount: Long) {
-    checkOffsetAndCount(source.size, 0L, byteCount)
+  private fun writeNoCloseCheck(fileOffset: Long, source: BufferedSource, byteCount: Long) {
+    checkOffsetAndCount(source.buffer.size, 0L, byteCount)
 
     var currentOffset = fileOffset
     val targetOffset = fileOffset + byteCount
 
     while (currentOffset < targetOffset) {
-      val head = source.head!!
+      val head = source.buffer.head!!
       val toCopy = minOf(targetOffset - currentOffset, head.limit - head.pos).toInt()
       protectedWrite(currentOffset, head.data, head.pos, toCopy)
 
       head.pos += toCopy
       currentOffset += toCopy
-      source.size -= toCopy
+      source.buffer.size -= toCopy
 
       if (head.pos == head.limit) {
-        source.head = head.pop()
+        source.buffer.head = head.pop()
         SegmentPool.recycle(head)
       }
     }
@@ -391,7 +391,7 @@ abstract class FileHandle(
   ) : Sink {
     var closed = false
 
-    override fun write(source: Buffer, byteCount: Long) {
+    override fun write(source: BufferedSource, byteCount: Long) {
       check(!closed) { "closed" }
       fileHandle.writeNoCloseCheck(position, source, byteCount)
       position += byteCount
@@ -421,7 +421,7 @@ abstract class FileHandle(
   ) : Source {
     var closed = false
 
-    override fun read(sink: Buffer, byteCount: Long): Long {
+    override fun read(sink: BufferedSink, byteCount: Long): Long {
       check(!closed) { "closed" }
       val result = fileHandle.readNoCloseCheck(position, sink, byteCount)
       if (result != -1L) position += result

--- a/okio/src/commonMain/kotlin/okio/ForwardingSource.kt
+++ b/okio/src/commonMain/kotlin/okio/ForwardingSource.kt
@@ -26,7 +26,7 @@ expect abstract class ForwardingSource constructor(
   // TODO 'Source by delegate' once https://youtrack.jetbrains.com/issue/KT-23935 is fixed.
 
   @Throws(IOException::class)
-  override fun read(sink: Buffer, byteCount: Long): Long
+  override fun read(sink: BufferedSink, byteCount: Long): Long
 
   override fun timeout(): Timeout
 

--- a/okio/src/commonMain/kotlin/okio/HashingSink.kt
+++ b/okio/src/commonMain/kotlin/okio/HashingSink.kt
@@ -45,7 +45,7 @@ expect class HashingSink : Sink {
   override fun close()
   override fun flush()
   override fun timeout(): Timeout
-  override fun write(source: Buffer, byteCount: Long)
+  override fun write(source: BufferedSource, byteCount: Long)
 
   companion object {
     /**

--- a/okio/src/commonMain/kotlin/okio/HashingSource.kt
+++ b/okio/src/commonMain/kotlin/okio/HashingSource.kt
@@ -44,7 +44,7 @@ expect class HashingSource : Source {
   val hash: ByteString
 
   override fun close()
-  override fun read(sink: Buffer, byteCount: Long): Long
+  override fun read(sink: BufferedSink, byteCount: Long): Long
   override fun timeout(): Timeout
 
   companion object {

--- a/okio/src/commonMain/kotlin/okio/Okio.kt
+++ b/okio/src/commonMain/kotlin/okio/Okio.kt
@@ -43,7 +43,7 @@ fun Sink.buffer(): BufferedSink = RealBufferedSink(this)
 fun blackholeSink(): Sink = BlackholeSink()
 
 private class BlackholeSink : Sink {
-  override fun write(source: Buffer, byteCount: Long) = source.skip(byteCount)
+  override fun write(source: BufferedSource, byteCount: Long) = source.skip(byteCount)
   override fun flush() {}
   override fun timeout() = Timeout.NONE
   override fun close() {}

--- a/okio/src/commonMain/kotlin/okio/PeekSource.kt
+++ b/okio/src/commonMain/kotlin/okio/PeekSource.kt
@@ -35,7 +35,7 @@ internal class PeekSource(
   private var closed = false
   private var pos = 0L
 
-  override fun read(sink: Buffer, byteCount: Long): Long {
+  override fun read(sink: BufferedSink, byteCount: Long): Long {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
     check(!closed) { "closed" }
     // Source becomes invalid if there is an expected Segment and it and the expected position

--- a/okio/src/commonMain/kotlin/okio/RealBufferedSink.kt
+++ b/okio/src/commonMain/kotlin/okio/RealBufferedSink.kt
@@ -30,7 +30,7 @@ internal expect class RealBufferedSink(
   override fun timeout(): Timeout
   override fun write(byteString: ByteString): BufferedSink
   override fun write(byteString: ByteString, offset: Int, byteCount: Int): BufferedSink
-  override fun write(source: Buffer, byteCount: Long)
+  override fun write(source: BufferedSource, byteCount: Long)
   override fun write(source: ByteArray): BufferedSink
   override fun write(source: ByteArray, offset: Int, byteCount: Int): BufferedSink
   override fun write(source: Source, byteCount: Long): BufferedSink

--- a/okio/src/commonMain/kotlin/okio/RealBufferedSource.kt
+++ b/okio/src/commonMain/kotlin/okio/RealBufferedSource.kt
@@ -36,7 +36,7 @@ internal expect class RealBufferedSource(
   override fun peek(): BufferedSource
   override fun rangeEquals(offset: Long, bytes: ByteString): Boolean
   override fun rangeEquals(offset: Long, bytes: ByteString, bytesOffset: Int, byteCount: Int): Boolean
-  override fun read(sink: Buffer, byteCount: Long): Long
+  override fun read(sink: BufferedSink, byteCount: Long): Long
   override fun read(sink: ByteArray): Int
   override fun read(sink: ByteArray, offset: Int, byteCount: Int): Int
   override fun readAll(sink: Sink): Long

--- a/okio/src/commonMain/kotlin/okio/Sink.kt
+++ b/okio/src/commonMain/kotlin/okio/Sink.kt
@@ -45,7 +45,7 @@ package okio
 expect interface Sink : Closeable {
   /** Removes `byteCount` bytes from `source` and appends them to this.  */
   @Throws(IOException::class)
-  fun write(source: Buffer, byteCount: Long)
+  fun write(source: BufferedSource, byteCount: Long)
 
   /** Pushes all buffered bytes to their final destination.  */
   @Throws(IOException::class)

--- a/okio/src/commonMain/kotlin/okio/Source.kt
+++ b/okio/src/commonMain/kotlin/okio/Source.kt
@@ -56,7 +56,7 @@ interface Source : Closeable {
    * the number of bytes read, or -1 if this source is exhausted.
    */
   @Throws(IOException::class)
-  fun read(sink: Buffer, byteCount: Long): Long
+  fun read(sink: BufferedSink, byteCount: Long): Long
 
   /** Returns the timeout for this source.  */
   fun timeout(): Timeout

--- a/okio/src/commonMain/kotlin/okio/internal/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/Buffer.kt
@@ -24,6 +24,8 @@ import kotlin.jvm.JvmName
 import okio.ArrayIndexOutOfBoundsException
 import okio.Buffer
 import okio.Buffer.UnsafeCursor
+import okio.BufferedSink
+import okio.BufferedSource
 import okio.ByteString
 import okio.EOFException
 import okio.Options
@@ -234,7 +236,7 @@ internal fun Buffer.selectPrefix(options: Options, selectTruncated: Boolean = fa
 // have to call these functions. Remove all this nonsense when expect class allow actual code.
 
 internal inline fun Buffer.commonCopyTo(
-  out: Buffer,
+  out: BufferedSink,
   offset: Long,
   byteCount: Long,
 ): Buffer {
@@ -243,7 +245,7 @@ internal inline fun Buffer.commonCopyTo(
   checkOffsetAndCount(size, offset, byteCount)
   if (byteCount == 0L) return this
 
-  out.size += byteCount
+  out.buffer.size += byteCount
 
   // Skip segments that we aren't copying from.
   var s = head
@@ -257,12 +259,12 @@ internal inline fun Buffer.commonCopyTo(
     val copy = s!!.sharedCopy()
     copy.pos += offset.toInt()
     copy.limit = minOf(copy.pos + byteCount.toInt(), copy.limit)
-    if (out.head == null) {
+    if (out.buffer.head == null) {
       copy.prev = copy
       copy.next = copy.prev
-      out.head = copy.next
+      out.buffer.head = copy.next
     } else {
-      out.head!!.prev!!.push(copy)
+      out.buffer.head!!.prev!!.push(copy)
     }
     byteCount -= (copy.limit - copy.pos).toLong()
     offset = 0L
@@ -1148,7 +1150,7 @@ internal inline fun Buffer.commonWriteLong(v: Long): Buffer {
   return this
 }
 
-internal inline fun Buffer.commonWrite(source: Buffer, byteCount: Long) {
+internal inline fun Buffer.commonWrite(source: BufferedSource, byteCount: Long) {
   var byteCount = byteCount
   // Move bytes from the head of the source buffer to the tail of this buffer
   // while balancing two conflicting goals: don't waste CPU and don't waste
@@ -1201,31 +1203,31 @@ internal inline fun Buffer.commonWrite(source: Buffer, byteCount: Long) {
   // yielding sink [51%, 91%, 30%] and source [62%, 82%].
 
   require(source !== this) { "source == this" }
-  checkOffsetAndCount(source.size, 0, byteCount)
+  checkOffsetAndCount(source.buffer.size, 0, byteCount)
 
   while (byteCount > 0L) {
     // Is a prefix of the source's head segment all that we need to move?
-    if (byteCount < source.head!!.limit - source.head!!.pos) {
+    if (byteCount < source.buffer.head!!.limit - source.buffer.head!!.pos) {
       val tail = if (head != null) head!!.prev else null
       if (tail != null && tail.owner &&
         byteCount + tail.limit - (if (tail.shared) 0 else tail.pos) <= Segment.SIZE
       ) {
         // Our existing segments are sufficient. Move bytes from source's head to our tail.
-        source.head!!.writeTo(tail, byteCount.toInt())
-        source.size -= byteCount
+        source.buffer.head!!.writeTo(tail, byteCount.toInt())
+        source.buffer.size -= byteCount
         size += byteCount
         return
       } else {
         // We're going to need another segment. Split the source's head
         // segment in two, then move the first of those two to this buffer.
-        source.head = source.head!!.split(byteCount.toInt())
+        source.buffer.head = source.buffer.head!!.split(byteCount.toInt())
       }
     }
 
     // Remove the source's head segment and append it to our tail.
-    val segmentToMove = source.head
+    val segmentToMove = source.buffer.head
     val movedByteCount = (segmentToMove!!.limit - segmentToMove.pos).toLong()
-    source.head = segmentToMove.pop()
+    source.buffer.head = segmentToMove.pop()
     if (head == null) {
       head = segmentToMove
       segmentToMove.prev = segmentToMove
@@ -1235,13 +1237,13 @@ internal inline fun Buffer.commonWrite(source: Buffer, byteCount: Long) {
       tail = tail!!.push(segmentToMove)
       tail.compact()
     }
-    source.size -= movedByteCount
+    source.buffer.size -= movedByteCount
     size += movedByteCount
     byteCount -= movedByteCount
   }
 }
 
-internal inline fun Buffer.commonRead(sink: Buffer, byteCount: Long): Long {
+internal inline fun Buffer.commonRead(sink: BufferedSink, byteCount: Long): Long {
   var byteCount = byteCount
   require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
   if (size == 0L) return -1L

--- a/okio/src/commonMain/kotlin/okio/internal/RealBufferedSource.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/RealBufferedSource.kt
@@ -23,6 +23,7 @@ package okio.internal
 
 import kotlin.jvm.JvmName
 import okio.Buffer
+import okio.BufferedSink
 import okio.BufferedSource
 import okio.ByteString
 import okio.EOFException
@@ -35,7 +36,7 @@ import okio.buffer
 import okio.checkOffsetAndCount
 import okio.minOf
 
-internal inline fun RealBufferedSource.commonRead(sink: Buffer, byteCount: Long): Long {
+internal inline fun RealBufferedSource.commonRead(sink: BufferedSink, byteCount: Long): Long {
   require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
   check(!closed) { "closed" }
 

--- a/okio/src/commonTest/kotlin/okio/BufferedSourceFactory.kt
+++ b/okio/src/commonTest/kotlin/okio/BufferedSourceFactory.kt
@@ -56,7 +56,7 @@ enum class BufferedSourceFactory {
       return Pipe(
         buffer,
         object : Source by buffer {
-          override fun read(sink: Buffer, byteCount: Long): Long {
+          override fun read(sink: BufferedSink, byteCount: Long): Long {
             // Read one byte into a new buffer, then clone it so that the segment is shared.
             // Shared segments cannot be compacted so we'll get a long chain of short segments.
             val box = Buffer()
@@ -77,7 +77,7 @@ enum class BufferedSourceFactory {
       val buffer = Buffer()
       return Pipe(
         object : Sink by buffer {
-          override fun write(source: Buffer, byteCount: Long) {
+          override fun write(source: BufferedSource, byteCount: Long) {
             // Write each byte into a new buffer, then clone it so that the segments are shared.
             // Shared segments cannot be compacted so we'll get a long chain of short segments.
             for (i in 0 until byteCount) {

--- a/okio/src/commonTest/kotlin/okio/CommonBufferedSinkTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonBufferedSinkTest.kt
@@ -172,7 +172,7 @@ class CommonBufferedSinkTest(
 
   @Test fun writeSourceReadsFully() {
     val source = object : Source by Buffer() {
-      override fun read(sink: Buffer, byteCount: Long): Long {
+      override fun read(sink: BufferedSink, byteCount: Long): Long {
         sink.writeUtf8("abcd")
         return 4
       }
@@ -200,7 +200,7 @@ class CommonBufferedSinkTest(
     // tied to something like a socket which will potentially block trying to read a segment when
     // ultimately we don't want any data.
     val source = object : Source by Buffer() {
-      override fun read(sink: Buffer, byteCount: Long): Long {
+      override fun read(sink: BufferedSink, byteCount: Long): Long {
         throw AssertionError()
       }
     }

--- a/okio/src/commonTest/kotlin/okio/CommonRealBufferedSourceTest.kt
+++ b/okio/src/commonTest/kotlin/okio/CommonRealBufferedSourceTest.kt
@@ -29,7 +29,7 @@ class CommonRealBufferedSourceTest {
     val buffer = Buffer().writeUtf8("abcdef")
     val bufferedSource = (
       object : Source by buffer {
-        override fun read(sink: Buffer, byteCount: Long): Long {
+        override fun read(sink: BufferedSink, byteCount: Long): Long {
           return buffer.read(sink, minOf(1, byteCount))
         }
       }

--- a/okio/src/commonTest/kotlin/okio/ForwardingSourceTest.kt
+++ b/okio/src/commonTest/kotlin/okio/ForwardingSourceTest.kt
@@ -27,7 +27,7 @@ class ForwardingSourceTest {
     val forwarder = "Forwarder"
     val newSource = Buffer().writeUtf8(forwarder)
     val forwardingSource = object : ForwardingSource(source) {
-      override fun read(sink: Buffer, byteCount: Long): Long {
+      override fun read(sink: BufferedSink, byteCount: Long): Long {
         return newSource.read(sink, byteCount)
       }
     }

--- a/okio/src/commonTest/kotlin/okio/MockSink.kt
+++ b/okio/src/commonTest/kotlin/okio/MockSink.kt
@@ -40,7 +40,7 @@ class MockSink : Sink {
     if (exception != null) throw exception
   }
 
-  override fun write(source: Buffer, byteCount: Long) {
+  override fun write(source: BufferedSource, byteCount: Long) {
     log.add("write($source, $byteCount)")
     source.skip(byteCount)
     throwIfScheduled()

--- a/okio/src/jvmMain/kotlin/okio/AsyncTimeout.kt
+++ b/okio/src/jvmMain/kotlin/okio/AsyncTimeout.kt
@@ -129,14 +129,14 @@ open class AsyncTimeout : Timeout() {
    */
   fun sink(sink: Sink): Sink {
     return object : Sink {
-      override fun write(source: Buffer, byteCount: Long) {
-        checkOffsetAndCount(source.size, 0, byteCount)
+      override fun write(source: BufferedSource, byteCount: Long) {
+        checkOffsetAndCount(source.buffer.size, 0, byteCount)
 
         var remaining = byteCount
         while (remaining > 0L) {
           // Count how many bytes to write. This loop guarantees we split on a segment boundary.
           var toWrite = 0L
-          var s = source.head!!
+          var s = source.buffer.head!!
           while (toWrite < TIMEOUT_WRITE_SIZE) {
             val segmentSize = s.limit - s.pos
             toWrite += segmentSize.toLong()
@@ -173,7 +173,7 @@ open class AsyncTimeout : Timeout() {
    */
   fun source(source: Source): Source {
     return object : Source {
-      override fun read(sink: Buffer, byteCount: Long): Long {
+      override fun read(sink: BufferedSink, byteCount: Long): Long {
         return withTimeout { source.read(sink, byteCount) }
       }
 

--- a/okio/src/jvmMain/kotlin/okio/Buffer.kt
+++ b/okio/src/jvmMain/kotlin/okio/Buffer.kt
@@ -175,7 +175,7 @@ actual class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
   }
 
   actual fun copyTo(
-    out: Buffer,
+    out: BufferedSink,
     offset: Long,
     byteCount: Long,
   ): Buffer = commonCopyTo(out, offset, byteCount)
@@ -464,9 +464,9 @@ actual class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
   internal actual fun writableSegment(minimumCapacity: Int): Segment =
     commonWritableSegment(minimumCapacity)
 
-  actual override fun write(source: Buffer, byteCount: Long): Unit = commonWrite(source, byteCount)
+  actual override fun write(source: BufferedSource, byteCount: Long): Unit { commonWrite(source, byteCount) }
 
-  actual override fun read(sink: Buffer, byteCount: Long): Long = commonRead(sink, byteCount)
+  actual override fun read(sink: BufferedSink, byteCount: Long): Long = commonRead(sink, byteCount)
 
   actual override fun indexOf(b: Byte) = indexOf(b, 0, Long.MAX_VALUE)
 

--- a/okio/src/jvmMain/kotlin/okio/CipherSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSink.kt
@@ -31,8 +31,8 @@ class CipherSink(
   }
 
   @Throws(IOException::class)
-  override fun write(source: Buffer, byteCount: Long) {
-    checkOffsetAndCount(source.size, 0, byteCount)
+  override fun write(source: BufferedSource, byteCount: Long) {
+    checkOffsetAndCount(source.buffer.size, 0, byteCount)
     check(!closed) { "closed" }
 
     var remaining = byteCount
@@ -42,8 +42,8 @@ class CipherSink(
     }
   }
 
-  private fun update(source: Buffer, remaining: Long): Int {
-    val head = source.head!!
+  private fun update(source: BufferedSource, remaining: Long): Int {
+    val head = source.buffer.head!!
     var size = minOf(remaining, head.limit - head.pos).toInt()
     val buffer = sink.buffer
 
@@ -76,10 +76,10 @@ class CipherSink(
     sink.emitCompleteSegments()
 
     // Mark those bytes as read.
-    source.size -= size
+    source.buffer.size -= size
     head.pos += size
     if (head.pos == head.limit) {
-      source.head = head.pop()
+      source.buffer.head = head.pop()
       SegmentPool.recycle(head)
     }
 

--- a/okio/src/jvmMain/kotlin/okio/CipherSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/CipherSource.kt
@@ -33,7 +33,7 @@ class CipherSource(
   }
 
   @Throws(IOException::class)
-  override fun read(sink: Buffer, byteCount: Long): Long {
+  override fun read(sink: BufferedSink, byteCount: Long): Long {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
     check(!closed) { "closed" }
     if (byteCount == 0L) return 0L

--- a/okio/src/jvmMain/kotlin/okio/DeflaterSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/DeflaterSink.kt
@@ -29,13 +29,13 @@ actual class DeflaterSink internal actual constructor(
   private var closed = false
 
   @Throws(IOException::class)
-  actual override fun write(source: Buffer, byteCount: Long) {
-    checkOffsetAndCount(source.size, 0, byteCount)
+  actual override fun write(source: BufferedSource, byteCount: Long) {
+    checkOffsetAndCount(source.buffer.size, 0, byteCount)
 
     var remaining = byteCount
     while (remaining > 0) {
       // Share bytes from the head segment of 'source' with the deflater.
-      val head = source.head!!
+      val head = source.buffer.head!!
       val toDeflate = minOf(remaining, head.limit - head.pos).toInt()
       deflater.setInput(head.data, head.pos, toDeflate)
 
@@ -43,10 +43,10 @@ actual class DeflaterSink internal actual constructor(
       deflate(false)
 
       // Mark those bytes as read.
-      source.size -= toDeflate
+      source.buffer.size -= toDeflate
       head.pos += toDeflate
       if (head.pos == head.limit) {
-        source.head = head.pop()
+        source.buffer.head = head.pop()
         SegmentPool.recycle(head)
       }
 

--- a/okio/src/jvmMain/kotlin/okio/ForwardingSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/ForwardingSink.kt
@@ -26,7 +26,7 @@ abstract class ForwardingSink(
   // TODO 'Sink by delegate' once https://youtrack.jetbrains.com/issue/KT-23935 is fixed.
 
   @Throws(IOException::class)
-  override fun write(source: Buffer, byteCount: Long) = delegate.write(source, byteCount)
+  override fun write(source: BufferedSource, byteCount: Long) = delegate.write(source, byteCount)
 
   @Throws(IOException::class)
   override fun flush() = delegate.flush()

--- a/okio/src/jvmMain/kotlin/okio/ForwardingSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/ForwardingSource.kt
@@ -24,7 +24,7 @@ actual abstract class ForwardingSource actual constructor(
   // TODO 'Source by delegate' once https://youtrack.jetbrains.com/issue/KT-23935 is fixed.
 
   @Throws(IOException::class)
-  actual override fun read(sink: Buffer, byteCount: Long): Long = delegate.read(sink, byteCount)
+  actual override fun read(sink: BufferedSink, byteCount: Long): Long = delegate.read(sink, byteCount)
 
   actual override fun timeout() = delegate.timeout()
 

--- a/okio/src/jvmMain/kotlin/okio/HashingSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/HashingSink.kt
@@ -66,12 +66,12 @@ actual class HashingSink : ForwardingSink, Sink { // Need to explicitly declare 
   )
 
   @Throws(IOException::class)
-  actual override fun write(source: Buffer, byteCount: Long) {
-    checkOffsetAndCount(source.size, 0, byteCount)
+  actual override fun write(source: BufferedSource, byteCount: Long) {
+    checkOffsetAndCount(source.buffer.size, 0, byteCount)
 
     // Hash byteCount bytes from the prefix of source.
     var hashedCount = 0L
-    var s = source.head!!
+    var s = source.buffer.head!!
     while (hashedCount < byteCount) {
       val toHash = minOf(byteCount - hashedCount, s.limit - s.pos).toInt()
       if (messageDigest != null) {

--- a/okio/src/jvmMain/kotlin/okio/HashingSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/HashingSource.kt
@@ -67,22 +67,22 @@ actual class HashingSource : ForwardingSource, Source { // Need to explicitly de
   )
 
   @Throws(IOException::class)
-  actual override fun read(sink: Buffer, byteCount: Long): Long {
+  actual override fun read(sink: BufferedSink, byteCount: Long): Long {
     val result = super.read(sink, byteCount)
 
     if (result != -1L) {
-      var start = sink.size - result
+      var start = sink.buffer.size - result
 
       // Find the first segment that has new bytes.
-      var offset = sink.size
-      var s = sink.head!!
+      var offset = sink.buffer.size
+      var s = sink.buffer.head!!
       while (offset > start) {
         s = s.prev!!
         offset -= (s.limit - s.pos).toLong()
       }
 
       // Hash that segment and all the rest until the end.
-      while (offset < sink.size) {
+      while (offset < sink.buffer.size) {
         val pos = (s.pos + start - offset).toInt()
         if (messageDigest != null) {
           messageDigest.update(s.data, pos, s.limit - pos)

--- a/okio/src/jvmMain/kotlin/okio/InflaterSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/InflaterSource.kt
@@ -37,7 +37,7 @@ actual class InflaterSource internal actual constructor(
   actual constructor(source: Source, inflater: Inflater) : this(source.buffer(), inflater)
 
   @Throws(IOException::class)
-  actual override fun read(sink: Buffer, byteCount: Long): Long {
+  actual override fun read(sink: BufferedSink, byteCount: Long): Long {
     while (true) {
       val bytesInflated = readOrInflate(sink, byteCount)
       if (bytesInflated > 0) return bytesInflated
@@ -55,14 +55,14 @@ actual class InflaterSource internal actual constructor(
    * doesn't yield inflated bytes.
    */
   @Throws(IOException::class)
-  fun readOrInflate(sink: Buffer, byteCount: Long): Long {
+  fun readOrInflate(sink: BufferedSink, byteCount: Long): Long {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
     check(!closed) { "closed" }
     if (byteCount == 0L) return 0L
 
     try {
       // Prepare the destination that we'll write into.
-      val tail = sink.writableSegment(1)
+      val tail = sink.buffer.writableSegment(1)
       val toRead = minOf(byteCount, Segment.SIZE - tail.limit).toInt()
 
       // Prepare the source that we'll read from.
@@ -77,13 +77,13 @@ actual class InflaterSource internal actual constructor(
       // Track produced bytes in the destination.
       if (bytesInflated > 0) {
         tail.limit += bytesInflated
-        sink.size += bytesInflated
+        sink.buffer.size += bytesInflated
         return bytesInflated.toLong()
       }
 
       // We allocated a tail segment, but didn't end up needing it. Recycle!
       if (tail.pos == tail.limit) {
-        sink.head = tail.pop()
+        sink.buffer.head = tail.pop()
         SegmentPool.recycle(tail)
       }
 

--- a/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
+++ b/okio/src/jvmMain/kotlin/okio/JvmOkio.kt
@@ -47,21 +47,21 @@ private class OutputStreamSink(
   private val timeout: Timeout,
 ) : Sink {
 
-  override fun write(source: Buffer, byteCount: Long) {
-    checkOffsetAndCount(source.size, 0, byteCount)
+  override fun write(source: BufferedSource, byteCount: Long) {
+    checkOffsetAndCount(source.buffer.size, 0, byteCount)
     var remaining = byteCount
     while (remaining > 0) {
       timeout.throwIfReached()
-      val head = source.head!!
+      val head = source.buffer.head!!
       val toCopy = minOf(remaining, head.limit - head.pos).toInt()
       out.write(head.data, head.pos, toCopy)
 
       head.pos += toCopy
       remaining -= toCopy
-      source.size -= toCopy
+      source.buffer.size -= toCopy
 
       if (head.pos == head.limit) {
-        source.head = head.pop()
+        source.buffer.head = head.pop()
         SegmentPool.recycle(head)
       }
     }
@@ -84,24 +84,24 @@ private open class InputStreamSource(
   private val timeout: Timeout,
 ) : Source {
 
-  override fun read(sink: Buffer, byteCount: Long): Long {
+  override fun read(sink: BufferedSink, byteCount: Long): Long {
     if (byteCount == 0L) return 0L
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
     try {
       timeout.throwIfReached()
-      val tail = sink.writableSegment(1)
+      val tail = sink.buffer.writableSegment(1)
       val maxToCopy = minOf(byteCount, Segment.SIZE - tail.limit).toInt()
       val bytesRead = input.read(tail.data, tail.limit, maxToCopy)
       if (bytesRead == -1) {
         if (tail.pos == tail.limit) {
           // We allocated a tail segment, but didn't end up needing it. Recycle!
-          sink.head = tail.pop()
+          sink.buffer.head = tail.pop()
           SegmentPool.recycle(tail)
         }
         return -1
       }
       tail.limit += bytesRead
-      sink.size += bytesRead
+      sink.buffer.size += bytesRead
       return bytesRead.toLong()
     } catch (e: AssertionError) {
       if (e.isAndroidGetsocknameError) throw IOException(e)

--- a/okio/src/jvmMain/kotlin/okio/Pipe.kt
+++ b/okio/src/jvmMain/kotlin/okio/Pipe.kt
@@ -55,7 +55,7 @@ class Pipe(internal val maxBufferSize: Long) {
   val sink = object : Sink {
     private val timeout = Timeout()
 
-    override fun write(source: Buffer, byteCount: Long) {
+    override fun write(source: BufferedSource, byteCount: Long) {
       var byteCount = byteCount
       var delegate: Sink? = null
       lock.withLock {
@@ -131,7 +131,7 @@ class Pipe(internal val maxBufferSize: Long) {
   val source = object : Source {
     private val timeout = Timeout()
 
-    override fun read(sink: Buffer, byteCount: Long): Long {
+    override fun read(sink: BufferedSink, byteCount: Long): Long {
       lock.withLock {
         check(!sourceClosed) { "closed" }
         if (canceled) throw IOException("canceled")

--- a/okio/src/jvmMain/kotlin/okio/RealBufferedSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/RealBufferedSink.kt
@@ -52,7 +52,7 @@ internal actual class RealBufferedSink actual constructor(
 
   override fun buffer() = bufferField
 
-  actual override fun write(source: Buffer, byteCount: Long) = commonWrite(source, byteCount)
+  actual override fun write(source: BufferedSource, byteCount: Long) : Unit { commonWrite(source, byteCount) }
   actual override fun write(byteString: ByteString) = commonWrite(byteString)
   actual override fun write(byteString: ByteString, offset: Int, byteCount: Int) =
     commonWrite(byteString, offset, byteCount)

--- a/okio/src/jvmMain/kotlin/okio/RealBufferedSource.kt
+++ b/okio/src/jvmMain/kotlin/okio/RealBufferedSource.kt
@@ -64,7 +64,7 @@ internal actual class RealBufferedSource actual constructor(
 
   override fun buffer() = bufferField
 
-  actual override fun read(sink: Buffer, byteCount: Long): Long = commonRead(sink, byteCount)
+  actual override fun read(sink: BufferedSink, byteCount: Long): Long = commonRead(sink, byteCount)
   actual override fun exhausted(): Boolean = commonExhausted()
   actual override fun require(byteCount: Long): Unit = commonRequire(byteCount)
   actual override fun request(byteCount: Long): Boolean = commonRequest(byteCount)

--- a/okio/src/jvmMain/kotlin/okio/Sink.kt
+++ b/okio/src/jvmMain/kotlin/okio/Sink.kt
@@ -21,7 +21,7 @@ import java.io.IOException
 
 actual interface Sink : Closeable, Flushable {
   @Throws(IOException::class)
-  actual fun write(source: Buffer, byteCount: Long)
+  actual fun write(source: BufferedSource, byteCount: Long)
 
   @Throws(IOException::class)
   actual override fun flush()

--- a/okio/src/jvmMain/kotlin/okio/Throttler.kt
+++ b/okio/src/jvmMain/kotlin/okio/Throttler.kt
@@ -133,7 +133,7 @@ class Throttler internal constructor(
   /** Create a Source which honors this Throttler.  */
   fun source(source: Source): Source {
     return object : ForwardingSource(source) {
-      override fun read(sink: Buffer, byteCount: Long): Long {
+      override fun read(sink: BufferedSink, byteCount: Long): Long {
         try {
           val toRead = take(byteCount)
           return super.read(sink, toRead)
@@ -149,7 +149,7 @@ class Throttler internal constructor(
   fun sink(sink: Sink): Sink {
     return object : ForwardingSink(sink) {
       @Throws(IOException::class)
-      override fun write(source: Buffer, byteCount: Long) {
+      override fun write(source: BufferedSource, byteCount: Long) {
         try {
           var remaining = byteCount
           while (remaining > 0L) {

--- a/okio/src/jvmMain/kotlin/okio/internal/DefaultSocket.kt
+++ b/okio/src/jvmMain/kotlin/okio/internal/DefaultSocket.kt
@@ -18,7 +18,8 @@ package okio.internal
 import java.io.IOException
 import java.net.Socket as JavaNetSocket
 import java.util.concurrent.atomic.AtomicInteger
-import okio.Buffer
+import okio.BufferedSink
+import okio.BufferedSource
 import okio.Segment
 import okio.SegmentPool
 import okio.Sink
@@ -51,12 +52,12 @@ internal class DefaultSocket(val socket: JavaNetSocket) : Socket {
     private val outputStream = socket.outputStream
     private val timeout = SocketAsyncTimeout(socket)
 
-    override fun write(source: Buffer, byteCount: Long) {
-      checkOffsetAndCount(source.size, 0, byteCount)
+    override fun write(source: BufferedSource, byteCount: Long) {
+      checkOffsetAndCount(source.buffer.size, 0, byteCount)
       var remaining = byteCount
       while (remaining > 0L) {
         timeout.throwIfReached()
-        val head = source.head!!
+        val head = source.buffer.head!!
         val toCopy = minOf(remaining, head.limit - head.pos).toInt()
         timeout.withTimeout {
           outputStream.write(head.data, head.pos, toCopy)
@@ -64,10 +65,10 @@ internal class DefaultSocket(val socket: JavaNetSocket) : Socket {
 
         head.pos += toCopy
         remaining -= toCopy
-        source.size -= toCopy
+        source.buffer.size -= toCopy
 
         if (head.pos == head.limit) {
-          source.head = head.pop()
+          source.buffer.head = head.pop()
           SegmentPool.recycle(head)
         }
       }
@@ -113,11 +114,11 @@ internal class DefaultSocket(val socket: JavaNetSocket) : Socket {
     private val inputStream = socket.inputStream
     private val timeout = SocketAsyncTimeout(socket)
 
-    override fun read(sink: Buffer, byteCount: Long): Long {
+    override fun read(sink: BufferedSink, byteCount: Long): Long {
       if (byteCount == 0L) return 0L
       require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
       timeout.throwIfReached()
-      val tail = sink.writableSegment(1)
+      val tail = sink.buffer.writableSegment(1)
       val maxToCopy = minOf(byteCount, Segment.Companion.SIZE - tail.limit).toInt()
       val bytesRead = try {
         timeout.withTimeout {
@@ -130,13 +131,13 @@ internal class DefaultSocket(val socket: JavaNetSocket) : Socket {
       if (bytesRead == -1) {
         if (tail.pos == tail.limit) {
           // We allocated a tail segment, but didn't end up needing it. Recycle!
-          sink.head = tail.pop()
+          sink.buffer.head = tail.pop()
           SegmentPool.recycle(tail)
         }
         return -1
       }
       tail.limit += bytesRead
-      sink.size += bytesRead
+      sink.buffer.size += bytesRead
       return bytesRead.toLong()
     }
 

--- a/okio/src/jvmTest/kotlin/okio/AsyncTimeoutTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/AsyncTimeoutTest.kt
@@ -216,7 +216,7 @@ class AsyncTimeoutTest {
   @Test
   fun wrappedSinkTimesOut() {
     val sink: Sink = object : ForwardingSink(Buffer()) {
-      override fun write(source: Buffer, byteCount: Long) {
+      override fun write(source: BufferedSource, byteCount: Long) {
         Thread.sleep(500)
       }
     }
@@ -268,7 +268,7 @@ class AsyncTimeoutTest {
   @Test
   fun wrappedSourceTimesOut() {
     val source: Source = object : ForwardingSource(Buffer()) {
-      override fun read(sink: Buffer, byteCount: Long): Long {
+      override fun read(sink: BufferedSink, byteCount: Long): Long {
         Thread.sleep(500)
         return -1
       }
@@ -303,7 +303,7 @@ class AsyncTimeoutTest {
   @Test
   fun wrappedThrowsWithTimeout() {
     val sink: Sink = object : ForwardingSink(Buffer()) {
-      override fun write(source: Buffer, byteCount: Long) {
+      override fun write(source: BufferedSource, byteCount: Long) {
         Thread.sleep(500)
         throw IOException("exception and timeout")
       }
@@ -324,7 +324,7 @@ class AsyncTimeoutTest {
   @Test
   fun wrappedThrowsWithoutTimeout() {
     val sink: Sink = object : ForwardingSink(Buffer()) {
-      override fun write(source: Buffer, byteCount: Long) {
+      override fun write(source: BufferedSource, byteCount: Long) {
         throw IOException("no timeout occurred")
       }
     }
@@ -354,7 +354,7 @@ class AsyncTimeoutTest {
     val source = bufferWithRandomSegmentLayout(dice, data)
     val target = Buffer()
     val sink: Sink = object : ForwardingSink(Buffer()) {
-      override fun write(source: Buffer, byteCount: Long) {
+      override fun write(source: BufferedSource, byteCount: Long) {
         Thread.sleep(byteCount / 500) // ~500 KiB/s.
         target.write(source, byteCount)
       }

--- a/okio/src/jvmTest/kotlin/okio/BufferedSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferedSinkTest.kt
@@ -236,7 +236,7 @@ class BufferedSinkTest(
   @Test
   fun writeSourceReadsFully() {
     val source: Source = object : ForwardingSource(Buffer()) {
-      override fun read(sink: Buffer, byteCount: Long): Long {
+      override fun read(sink: BufferedSink, byteCount: Long): Long {
         sink.writeUtf8("abcd")
         return 4
       }
@@ -266,7 +266,7 @@ class BufferedSinkTest(
     // tied to something like a socket which will potentially block trying to read a segment when
     // ultimately we don't want any data.
     val source: Source = object : ForwardingSource(Buffer()) {
-      override fun read(sink: Buffer, byteCount: Long): Long {
+      override fun read(sink: BufferedSink, byteCount: Long): Long {
         throw AssertionError()
       }
     }

--- a/okio/src/jvmTest/kotlin/okio/BufferedSourceJavaTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferedSourceJavaTest.kt
@@ -81,7 +81,7 @@ class BufferedSourceJavaTest {
   fun indexOfStopsReadingAtLimit() {
     val buffer = Buffer().writeUtf8("abcdef")
     val bufferedSource = object : ForwardingSource(buffer) {
-      override fun read(sink: Buffer, byteCount: Long): Long {
+      override fun read(sink: BufferedSink, byteCount: Long): Long {
         return super.read(sink, Math.min(1, byteCount))
       }
     }.buffer()

--- a/okio/src/jvmTest/kotlin/okio/BufferedSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferedSourceTest.kt
@@ -78,7 +78,7 @@ class BufferedSourceTest(
         return Pipe(
           sink = buffer,
           source = object : ForwardingSource(buffer) {
-            override fun read(sink: Buffer, byteCount: Long): Long {
+            override fun read(sink: BufferedSink, byteCount: Long): Long {
               // Read one byte into a new buffer, then clone it so that the segment is shared.
               // Shared segments cannot be compacted so we'll get a long chain of short segments.
               val box = Buffer()
@@ -97,7 +97,7 @@ class BufferedSourceTest(
       override fun pipe(): Pipe {
         val buffer = Buffer()
         val sink = object : ForwardingSink(buffer) {
-          override fun write(source: Buffer, byteCount: Long) {
+          override fun write(source: BufferedSource, byteCount: Long) {
             // Write each byte into a new buffer, then clone it so that the segments are shared.
             // Shared segments cannot be compacted so we'll get a long chain of short segments.
             for (i in 0 until byteCount) {

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -175,7 +175,7 @@ class CipherSourceTest(
     SingleByteSource(this)
 
   private class SingleByteSource(source: Source) : ForwardingSource(source) {
-    override fun read(sink: Buffer, byteCount: Long): Long =
+    override fun read(sink: BufferedSink, byteCount: Long): Long =
       delegate.read(sink, 1L)
   }
 }

--- a/okio/src/jvmTest/kotlin/okio/PipeKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/PipeKotlinTest.kt
@@ -133,7 +133,7 @@ class PipeKotlinTest {
     pipe.sink.write(Buffer().write(data), data.size.toLong())
     val foldResult = executorService.submit {
       val sink = object : Sink {
-        override fun write(source: Buffer, byteCount: Long) {
+        override fun write(source: BufferedSource, byteCount: Long) {
           writing.countDown()
           closed.await()
           sinkBuffer.write(source, byteCount)
@@ -565,7 +565,7 @@ class PipeKotlinTest {
       val foldFailure = assertFailsWith<IOException> {
         pipe.fold(
           object : ForwardingSink(blackholeSink()) {
-            override fun write(source: Buffer, byteCount: Long) {
+            override fun write(source: BufferedSource, byteCount: Long) {
               throw IOException("boom")
             }
           },
@@ -592,7 +592,7 @@ class PipeKotlinTest {
     pipeSink.emit()
 
     pipe.fold(object : ForwardingSink(blackholeSink()) {
-      override fun write(source: Buffer, byteCount: Long) {
+      override fun write(source: BufferedSource, byteCount: Long) {
         assertFalse(Thread.holdsLock(pipe.buffer))
       }
     })
@@ -776,7 +776,7 @@ class PipeKotlinTest {
 
     var foldedSinkClosed = false
     val foldedSink = object : ForwardingSink(Buffer()) {
-      override fun write(source: Buffer, byteCount: Long) {
+      override fun write(source: BufferedSource, byteCount: Long) {
         assertEquals("hello", source.readUtf8(byteCount))
 
         // Write bytes to the original pipe so the pipe write doesn't complete!
@@ -828,7 +828,7 @@ class PipeKotlinTest {
       }
     }
 
-    override fun write(source: Buffer, byteCount: Long) {
+    override fun write(source: BufferedSource, byteCount: Long) {
       timeout.enter()
       try {
         synchronized(this) {
@@ -857,7 +857,7 @@ class PipeKotlinTest {
       }
     }
 
-    override fun write(source: Buffer, byteCount: Long) = source.skip(byteCount)
+    override fun write(source: BufferedSource, byteCount: Long) = source.skip(byteCount)
 
     override fun flush() {
       timeout.enter()
@@ -885,7 +885,7 @@ class PipeKotlinTest {
       }
     }
 
-    override fun write(source: Buffer, byteCount: Long) = source.skip(byteCount)
+    override fun write(source: BufferedSource, byteCount: Long) = source.skip(byteCount)
 
     override fun flush() = Unit
 

--- a/okio/src/jvmTest/kotlin/okio/ReadUtf8LineTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ReadUtf8LineTest.kt
@@ -39,7 +39,7 @@ class ReadUtf8LineTest(
       override fun create(data: Buffer): BufferedSource {
         return RealBufferedSource(
           object : ForwardingSource(data) {
-            override fun read(sink: Buffer, byteCount: Long): Long {
+            override fun read(sink: BufferedSink, byteCount: Long): Long {
               return super.read(sink, 1L.coerceAtMost(byteCount))
             }
           },

--- a/okio/src/jvmTest/kotlin/okio/TestUtil.kt
+++ b/okio/src/jvmTest/kotlin/okio/TestUtil.kt
@@ -64,7 +64,7 @@ object TestUtil {
       internal var closed: Boolean = false
 
       @Throws(IOException::class)
-      override fun read(sink: Buffer, byteCount: Long): Long {
+      override fun read(sink: BufferedSink, byteCount: Long): Long {
         var byteCount = byteCount
         if (closed) throw IllegalStateException("closed")
         if (bytesLeft == 0L) return -1L
@@ -72,10 +72,10 @@ object TestUtil {
 
         // If we can read a full segment we can save a copy.
         if (byteCount >= Segment.SIZE) {
-          val segment = sink.writableSegment(Segment.SIZE)
+          val segment = sink.buffer.writableSegment(Segment.SIZE)
           random.nextBytes(segment.data)
           segment.limit += Segment.SIZE
-          sink.size += Segment.SIZE.toLong()
+          sink.buffer.size += Segment.SIZE.toLong()
           bytesLeft -= Segment.SIZE.toLong()
           return Segment.SIZE.toLong()
         } else {

--- a/okio/src/nativeMain/kotlin/okio/DataProcessor.kt
+++ b/okio/src/nativeMain/kotlin/okio/DataProcessor.kt
@@ -77,7 +77,7 @@ internal abstract class DataProcessor : Closeable {
    */
   @Throws(IOException::class)
   fun writeBytesFromSource(
-    source: Buffer?,
+    source: BufferedSource?,
     sourceExactByteCount: Long,
     target: BufferedSink,
   ) {
@@ -116,7 +116,7 @@ internal abstract class DataProcessor : Closeable {
   fun readBytesToTarget(
     source: BufferedSource,
     targetMaxByteCount: Long,
-    target: Buffer,
+    target: BufferedSink,
   ): Long {
     check(!closed) { "closed" }
 
@@ -154,7 +154,7 @@ internal abstract class DataProcessor : Closeable {
 
   /** Tell the processor to read up to [maxByteCount] bytes from the source's first segment. */
   private fun prepareSource(
-    source: Buffer?,
+    source: BufferedSource?,
     maxByteCount: Long = Long.MAX_VALUE,
   ): Segment? {
     val head = source?.buffer?.head
@@ -177,7 +177,7 @@ internal abstract class DataProcessor : Closeable {
    * Returns the number of consumed bytes.
    */
   private fun updateSource(
-    source: Buffer?,
+    source: BufferedSource?,
     sourceHead: Segment?,
   ): Int {
     if (sourceLimit == 0) return 0
@@ -185,11 +185,11 @@ internal abstract class DataProcessor : Closeable {
     source!!
     val consumedByteCount = sourcePos - sourceHead!!.pos
     sourceHead.pos = sourcePos
-    source.size -= consumedByteCount
+    source.buffer.size -= consumedByteCount
 
     // If we used up the head segment, recycle it.
     if (sourceHead.pos == sourceHead.limit) {
-      source.head = sourceHead.pop()
+      source.buffer.head = sourceHead.pop()
       SegmentPool.recycle(sourceHead)
     }
 

--- a/okio/src/nativeMain/kotlin/okio/DeflaterSink.kt
+++ b/okio/src/nativeMain/kotlin/okio/DeflaterSink.kt
@@ -29,8 +29,8 @@ actual class DeflaterSink internal actual constructor(
   ) : this(sink.buffer(), deflater)
 
   @Throws(IOException::class)
-  actual override fun write(source: Buffer, byteCount: Long) {
-    checkOffsetAndCount(source.size, 0, byteCount)
+  actual override fun write(source: BufferedSource, byteCount: Long) {
+    checkOffsetAndCount(source.buffer.size, 0, byteCount)
 
     deflater.flush = Z_NO_FLUSH
     deflater.dataProcessor.writeBytesFromSource(

--- a/okio/src/nativeMain/kotlin/okio/FileSink.kt
+++ b/okio/src/nativeMain/kotlin/okio/FileSink.kt
@@ -32,17 +32,17 @@ internal class FileSink(
   private var closed = false
 
   override fun write(
-    source: Buffer,
+    source: BufferedSource,
     byteCount: Long,
   ) {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
-    require(source.size >= byteCount) { "source.size=${source.size} < byteCount=$byteCount" }
+    require(source.buffer.size >= byteCount) { "source.size=${source.buffer.size} < byteCount=$byteCount" }
     check(!closed) { "closed" }
 
     var byteCount = byteCount
     while (byteCount > 0) {
       // Get the first segment, which we will read a contiguous range of bytes from.
-      val cursor = source.readUnsafe(unsafeCursor)
+      val cursor = source.buffer.readUnsafe(unsafeCursor)
       val segmentReadableByteCount = cursor.next()
       val attemptCount = minOf(byteCount, segmentReadableByteCount.toLong()).toInt()
 

--- a/okio/src/nativeMain/kotlin/okio/InflaterSource.kt
+++ b/okio/src/nativeMain/kotlin/okio/InflaterSource.kt
@@ -25,7 +25,7 @@ actual class InflaterSource internal actual constructor(
   ) : this(source.buffer(), inflater)
 
   @Throws(IOException::class)
-  actual override fun read(sink: Buffer, byteCount: Long): Long {
+  actual override fun read(sink: BufferedSink, byteCount: Long): Long {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
 
     return inflater.dataProcessor.readBytesToTarget(

--- a/okio/src/nativeTest/kotlin/okio/DeflaterSinkTest.kt
+++ b/okio/src/nativeTest/kotlin/okio/DeflaterSinkTest.kt
@@ -87,7 +87,7 @@ class DeflaterSinkTest {
     var nextException: Throwable? = null
     var closed = false
 
-    override fun write(source: Buffer, byteCount: Long) {
+    override fun write(source: BufferedSource, byteCount: Long) {
       nextException?.let { nextException = null; throw it }
       data.write(source, byteCount)
     }

--- a/okio/src/nativeTest/kotlin/okio/InflaterSourceTest.kt
+++ b/okio/src/nativeTest/kotlin/okio/InflaterSourceTest.kt
@@ -159,7 +159,7 @@ class InflaterSourceTest {
     var nextException: Throwable? = null
     var closed = false
 
-    override fun read(sink: Buffer, byteCount: Long): Long {
+    override fun read(sink: BufferedSink, byteCount: Long): Long {
       nextException?.let { nextException = null; throw it }
       return data.read(sink, byteCount)
     }

--- a/okio/src/nonJvmMain/kotlin/okio/Buffer.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/Buffer.kt
@@ -207,9 +207,9 @@ actual class Buffer : BufferedSource, BufferedSink {
   actual override fun writeHexadecimalUnsignedLong(v: Long): Buffer =
     commonWriteHexadecimalUnsignedLong(v)
 
-  actual override fun write(source: Buffer, byteCount: Long): Unit = commonWrite(source, byteCount)
+  actual override fun write(source: BufferedSource, byteCount: Long): Unit { commonWrite(source, byteCount) }
 
-  actual override fun read(sink: Buffer, byteCount: Long): Long = commonRead(sink, byteCount)
+  actual override fun read(sink: BufferedSink, byteCount: Long): Long = commonRead(sink, byteCount)
 
   actual override fun indexOf(b: Byte): Long = indexOf(b, 0, Long.MAX_VALUE)
 

--- a/okio/src/nonJvmMain/kotlin/okio/ForwardingSource.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/ForwardingSource.kt
@@ -21,7 +21,7 @@ actual abstract class ForwardingSource actual constructor(
   // TODO 'Source by delegate' once https://youtrack.jetbrains.com/issue/KT-23935 is fixed.
 
   @Throws(IOException::class)
-  actual override fun read(sink: Buffer, byteCount: Long): Long = delegate.read(sink, byteCount)
+  actual override fun read(sink: BufferedSink, byteCount: Long): Long = delegate.read(sink, byteCount)
 
   actual override fun timeout() = delegate.timeout()
 

--- a/okio/src/nonJvmMain/kotlin/okio/HashingSink.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/HashingSink.kt
@@ -27,12 +27,12 @@ actual class HashingSink internal constructor(
   private val hashFunction: HashFunction,
 ) : Sink {
 
-  actual override fun write(source: Buffer, byteCount: Long) {
-    checkOffsetAndCount(source.size, 0, byteCount)
+  actual override fun write(source: BufferedSource, byteCount: Long) {
+    checkOffsetAndCount(source.buffer.size, 0, byteCount)
 
     // Hash byteCount bytes from the prefix of source.
     var hashedCount = 0L
-    var s = source.head!!
+    var s = source.buffer.head!!
     while (hashedCount < byteCount) {
       val toHash = minOf(byteCount - hashedCount, s.limit - s.pos).toInt()
       hashFunction.update(s.data, s.pos, toHash)

--- a/okio/src/nonJvmMain/kotlin/okio/HashingSource.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/HashingSource.kt
@@ -27,7 +27,7 @@ actual class HashingSource internal constructor(
   private val hashFunction: HashFunction,
 ) : Source {
 
-  actual override fun read(sink: Buffer, byteCount: Long): Long {
+  actual override fun read(sink: BufferedSink, byteCount: Long): Long {
     val result = source.read(sink, byteCount)
 
     if (result != -1L) {

--- a/okio/src/nonJvmMain/kotlin/okio/RealBufferedSink.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/RealBufferedSink.kt
@@ -42,7 +42,7 @@ internal actual class RealBufferedSink actual constructor(
   actual var closed: Boolean = false
   actual override val buffer = Buffer()
 
-  actual override fun write(source: Buffer, byteCount: Long) = commonWrite(source, byteCount)
+  actual override fun write(source: BufferedSource, byteCount: Long) = commonWrite(source, byteCount)
   actual override fun write(byteString: ByteString) = commonWrite(byteString)
   actual override fun write(byteString: ByteString, offset: Int, byteCount: Int) =
     commonWrite(byteString, offset, byteCount)

--- a/okio/src/nonJvmMain/kotlin/okio/RealBufferedSource.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/RealBufferedSource.kt
@@ -52,7 +52,7 @@ internal actual class RealBufferedSource actual constructor(
   actual var closed: Boolean = false
   actual override val buffer: Buffer = Buffer()
 
-  actual override fun read(sink: Buffer, byteCount: Long): Long = commonRead(sink, byteCount)
+  actual override fun read(sink: BufferedSink, byteCount: Long): Long = commonRead(sink, byteCount)
   actual override fun exhausted(): Boolean = commonExhausted()
   actual override fun require(byteCount: Long): Unit = commonRequire(byteCount)
   actual override fun request(byteCount: Long): Boolean = commonRequest(byteCount)

--- a/okio/src/nonJvmMain/kotlin/okio/Sink.kt
+++ b/okio/src/nonJvmMain/kotlin/okio/Sink.kt
@@ -17,7 +17,7 @@ package okio
 
 actual interface Sink : Closeable {
   @Throws(IOException::class)
-  actual fun write(source: Buffer, byteCount: Long)
+  actual fun write(source: BufferedSink, byteCount: Long)
 
   @Throws(IOException::class)
   actual fun flush()

--- a/okio/src/zlibMain/kotlin/okio/DeflaterSink.kt
+++ b/okio/src/zlibMain/kotlin/okio/DeflaterSink.kt
@@ -48,7 +48,7 @@ internal constructor(
 
   internal fun finishDeflate()
 
-  override fun write(source: Buffer, byteCount: Long)
+  override fun write(source: BufferedSource, byteCount: Long)
   override fun flush()
   override fun timeout(): Timeout
   override fun close()

--- a/okio/src/zlibMain/kotlin/okio/GzipSink.kt
+++ b/okio/src/zlibMain/kotlin/okio/GzipSink.kt
@@ -70,7 +70,7 @@ class GzipSink(sink: Sink) : Sink {
   }
 
   @Throws(IOException::class)
-  override fun write(source: Buffer, byteCount: Long) {
+  override fun write(source: BufferedSource, byteCount: Long) {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
     if (byteCount == 0L) return
 
@@ -123,8 +123,8 @@ class GzipSink(sink: Sink) : Sink {
   }
 
   /** Updates the CRC with the given bytes. */
-  private fun updateCrc(buffer: Buffer, byteCount: Long) {
-    var head = buffer.head!!
+  private fun updateCrc(buffer: BufferedSource, byteCount: Long) {
+    var head = buffer.buffer.head!!
     var remaining = byteCount
     while (remaining > 0) {
       val segmentLength = minOf(remaining, head.limit - head.pos).toInt()

--- a/okio/src/zlibMain/kotlin/okio/GzipSource.kt
+++ b/okio/src/zlibMain/kotlin/okio/GzipSource.kt
@@ -51,7 +51,7 @@ class GzipSource(source: Source) : Source {
   private val crc = CRC32()
 
   @Throws(IOException::class)
-  override fun read(sink: Buffer, byteCount: Long): Long {
+  override fun read(sink: BufferedSink, byteCount: Long): Long {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
     if (byteCount == 0L) return 0L
 
@@ -63,7 +63,7 @@ class GzipSource(source: Source) : Source {
 
     // Attempt to read at least a byte of the body. If we do, we're done.
     if (section == SECTION_BODY) {
-      val offset = sink.size
+      val offset = sink.buffer.size
       val result = inflaterSource.read(sink, byteCount)
       if (result != -1L) {
         updateCrc(sink, offset, result)
@@ -169,11 +169,11 @@ class GzipSource(source: Source) : Source {
   override fun close() = inflaterSource.close()
 
   /** Updates the CRC with the given bytes.  */
-  private fun updateCrc(buffer: Buffer, offset: Long, byteCount: Long) {
+  private fun updateCrc(buffer: BufferedSink, offset: Long, byteCount: Long) {
     var offset = offset
     var byteCount = byteCount
     // Skip segments that we aren't checksumming.
-    var s = buffer.head!!
+    var s = buffer.buffer.head!!
     while (offset >= s.limit - s.pos) {
       offset -= s.limit - s.pos
       s = s.next!!

--- a/okio/src/zlibMain/kotlin/okio/InflaterSource.kt
+++ b/okio/src/zlibMain/kotlin/okio/InflaterSource.kt
@@ -34,7 +34,7 @@ internal constructor(
 ) : Source {
   constructor(source: Source, inflater: Inflater)
 
-  override fun read(sink: Buffer, byteCount: Long): Long
+  override fun read(sink: BufferedSink, byteCount: Long): Long
   override fun timeout(): Timeout
   override fun close()
 }

--- a/okio/src/zlibMain/kotlin/okio/internal/FixedLengthSource.kt
+++ b/okio/src/zlibMain/kotlin/okio/internal/FixedLengthSource.kt
@@ -16,6 +16,7 @@
 package okio.internal
 
 import okio.Buffer
+import okio.BufferedSink
 import okio.ForwardingSource
 import okio.IOException
 import okio.Source
@@ -35,7 +36,7 @@ internal class FixedLengthSource(
 ) : ForwardingSource(delegate) {
   private var bytesReceived = 0L
 
-  override fun read(sink: Buffer, byteCount: Long): Long {
+  override fun read(sink: BufferedSink, byteCount: Long): Long {
     // Figure out how many bytes to attempt to read.
     //
     // If we're truncating, we never attempt to read more than what's remaining.
@@ -60,7 +61,7 @@ internal class FixedLengthSource(
     if ((bytesReceived < size && result == -1L) || bytesReceived > size) {
       if (result > 0L && bytesReceived > size) {
         // If we received bytes beyond the limit, don't return them to the caller.
-        sink.truncateToSize(sink.size - (bytesReceived - size))
+        sink.buffer.truncateToSize(sink.buffer.size - (bytesReceived - size))
       }
       throw IOException("expected $size bytes but got $bytesReceived")
     }

--- a/okio/src/zlibTest/kotlin/okio/GzipSourceTest.kt
+++ b/okio/src/zlibTest/kotlin/okio/GzipSourceTest.kt
@@ -213,7 +213,7 @@ class GzipSourceTest {
   internal class ExhaustableSource(private val source: Source) : Source {
     var exhausted = false
 
-    override fun read(sink: Buffer, byteCount: Long): Long {
+    override fun read(sink: BufferedSink, byteCount: Long): Long {
       val result = source.read(sink, byteCount)
       if (result == -1L) exhausted = true
       return result

--- a/samples/src/jvmMain/kotlin/okio/samples/TeeSink.kt
+++ b/samples/src/jvmMain/kotlin/okio/samples/TeeSink.kt
@@ -16,6 +16,7 @@
 package okio.samples
 
 import okio.Buffer
+import okio.BufferedSource
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import okio.Sink
@@ -32,11 +33,11 @@ class TeeSink(
 ) : Sink {
   private val timeout = Timeout()
 
-  override fun write(source: Buffer, byteCount: Long) {
+  override fun write(source: BufferedSource, byteCount: Long) {
     // Writing to sink mutates source. Work around that.
     sinkA.timeout().intersectWith(timeout) {
       val buffer = Buffer()
-      source.copyTo(buffer, byteCount = byteCount)
+      source.buffer.copyTo(buffer, byteCount = byteCount)
       sinkA.write(buffer, byteCount)
     }
 


### PR DESCRIPTION
Change `Sink.write(source: Buffer, byteCount: Long)` to accept `BufferedSource` and `Source.read(sink: Buffer, byteCount: Long)` to accept `BufferedSink`. Since `Buffer` implements both interfaces this is backward-compatible, but it removes the unnecessary constraint that callers must use a `Buffer` specifically.

Fixes #1808