### PR TITLE
Add `ByteString.equals(other, constantTime)` overload

### DIFF
--- a/okio/api/okio.api
+++ b/okio/api/okio.api
@@ -314,6 +314,7 @@ public class okio/ByteString : java/io/Serializable, java/lang/Comparable {
 	public final fun endsWith (Lokio/ByteString;)Z
 	public final fun endsWith ([B)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun equals (Lokio/ByteString;Z)Z
 	public final fun getByte (I)B
 	public fun hashCode ()I
 	public fun hex ()Ljava/lang/String;

--- a/okio/src/appleMain/kotlin/okio/ByteString.kt
+++ b/okio/src/appleMain/kotlin/okio/ByteString.kt
@@ -35,6 +35,7 @@ import okio.internal.commonDecodeHex
 import okio.internal.commonEncodeUtf8
 import okio.internal.commonEndsWith
 import okio.internal.commonEquals
+import okio.internal.commonEqualsConstantTime
 import okio.internal.commonGetByte
 import okio.internal.commonGetSize
 import okio.internal.commonHashCode
@@ -167,6 +168,8 @@ internal actual constructor(
   actual open fun lastIndexOf(other: ByteArray, fromIndex: Int) = commonLastIndexOf(other, fromIndex)
 
   actual override fun equals(other: Any?) = commonEquals(other)
+
+  actual fun equals(other: ByteString, constantTime: Boolean) = commonEqualsConstantTime(other)
 
   actual override fun hashCode() = commonHashCode()
 

--- a/okio/src/appleMain/kotlin/okio/ByteString.kt
+++ b/okio/src/appleMain/kotlin/okio/ByteString.kt
@@ -169,7 +169,8 @@ internal actual constructor(
 
   actual override fun equals(other: Any?) = commonEquals(other)
 
-  actual fun equals(other: ByteString, constantTime: Boolean) = commonEqualsConstantTime(other)
+  actual fun equals(other: ByteString, constantTime: Boolean) =
+    if (constantTime) commonEqualsConstantTime(other) else this == other
 
   actual override fun hashCode() = commonHashCode()
 

--- a/okio/src/commonMain/kotlin/okio/ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/ByteString.kt
@@ -171,10 +171,11 @@ internal constructor(data: ByteArray) : Comparable<ByteString> {
   override fun equals(other: Any?): Boolean
 
   /**
-   * Returns true if the bytes of this equal the bytes of `other`. Unlike [equals], this always
-   * inspects every byte and does not short-circuit on the first mismatch, so its running time does
-   * not depend on where the byte strings differ. Use this for timing-safe comparison of secrets
-   * like hashes or message authentication codes.
+   * Returns true if the bytes of this equal the bytes of `other`. If [constantTime] is true this
+   * always inspects every byte and does not short-circuit on the first mismatch, so its running
+   * time does not depend on where the byte strings differ. Use that for timing-safe comparison of
+   * secrets like hashes or message authentication codes. If [constantTime] is false this behaves
+   * like [equals] and may return as soon as a mismatch is found.
    */
   fun equals(other: ByteString, constantTime: Boolean): Boolean
 

--- a/okio/src/commonMain/kotlin/okio/ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/ByteString.kt
@@ -170,6 +170,14 @@ internal constructor(data: ByteArray) : Comparable<ByteString> {
 
   override fun equals(other: Any?): Boolean
 
+  /**
+   * Returns true if the bytes of this equal the bytes of `other`. Unlike [equals], this always
+   * inspects every byte and does not short-circuit on the first mismatch, so its running time does
+   * not depend on where the byte strings differ. Use this for timing-safe comparison of secrets
+   * like hashes or message authentication codes.
+   */
+  fun equals(other: ByteString, constantTime: Boolean): Boolean
+
   override fun hashCode(): Int
 
   override fun compareTo(other: ByteString): Int

--- a/okio/src/commonMain/kotlin/okio/internal/ByteString.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/ByteString.kt
@@ -234,6 +234,16 @@ internal inline fun ByteString.commonEquals(other: Any?): Boolean {
   }
 }
 
+internal fun ByteString.commonEqualsConstantTime(other: ByteString): Boolean {
+  if (other === this) return true
+  if (other.size != size) return false
+  var result = 0
+  for (i in 0 until size) {
+    result = result or (this[i].toInt() xor other[i].toInt())
+  }
+  return result == 0
+}
+
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun ByteString.commonHashCode(): Int {
   val result = hashCode

--- a/okio/src/commonTest/kotlin/okio/ByteStringTest.kt
+++ b/okio/src/commonTest/kotlin/okio/ByteStringTest.kt
@@ -201,6 +201,21 @@ class ByteStringTest(
     assertEquals(ByteString.of(), factory.decodeHex(""))
   }
 
+  @Test fun equalsConstantTime() {
+    val byteString = factory.decodeHex("000102")
+    assertTrue(byteString.equals(byteString, constantTime = true))
+    assertTrue(byteString.equals("000102".decodeHex(), constantTime = true))
+    assertFalse(byteString.equals("800102".decodeHex(), constantTime = true))
+    assertFalse(byteString.equals("000180".decodeHex(), constantTime = true))
+    assertFalse(byteString.equals("0001".decodeHex(), constantTime = true))
+    assertFalse(byteString.equals("00010203".decodeHex(), constantTime = true))
+  }
+
+  @Test fun equalsConstantTimeEmptyTest() {
+    assertTrue(factory.decodeHex("").equals(ByteString.EMPTY, constantTime = true))
+    assertFalse(factory.decodeHex("").equals("00".decodeHex(), constantTime = true))
+  }
+
   private val bronzeHorseman = "На берегу пустынных волн"
 
   @Test fun utf8() {

--- a/okio/src/commonTest/kotlin/okio/ByteStringTest.kt
+++ b/okio/src/commonTest/kotlin/okio/ByteStringTest.kt
@@ -216,6 +216,16 @@ class ByteStringTest(
     assertFalse(factory.decodeHex("").equals("00".decodeHex(), constantTime = true))
   }
 
+  @Test fun equalsNotConstantTime() {
+    val byteString = factory.decodeHex("000102")
+    assertTrue(byteString.equals(byteString, constantTime = false))
+    assertTrue(byteString.equals("000102".decodeHex(), constantTime = false))
+    assertFalse(byteString.equals("800102".decodeHex(), constantTime = false))
+    assertFalse(byteString.equals("000180".decodeHex(), constantTime = false))
+    assertFalse(byteString.equals("0001".decodeHex(), constantTime = false))
+    assertFalse(byteString.equals("00010203".decodeHex(), constantTime = false))
+  }
+
   private val bronzeHorseman = "На берегу пустынных волн"
 
   @Test fun utf8() {

--- a/okio/src/jvmMain/kotlin/okio/ByteString.kt
+++ b/okio/src/jvmMain/kotlin/okio/ByteString.kt
@@ -190,7 +190,8 @@ internal actual constructor(
 
   actual override fun equals(other: Any?) = commonEquals(other)
 
-  actual fun equals(other: ByteString, constantTime: Boolean) = commonEqualsConstantTime(other)
+  actual fun equals(other: ByteString, constantTime: Boolean) =
+    if (constantTime) commonEqualsConstantTime(other) else this == other
 
   actual override fun hashCode() = commonHashCode()
 

--- a/okio/src/jvmMain/kotlin/okio/ByteString.kt
+++ b/okio/src/jvmMain/kotlin/okio/ByteString.kt
@@ -37,6 +37,7 @@ import okio.internal.commonDecodeHex
 import okio.internal.commonEncodeUtf8
 import okio.internal.commonEndsWith
 import okio.internal.commonEquals
+import okio.internal.commonEqualsConstantTime
 import okio.internal.commonGetByte
 import okio.internal.commonGetSize
 import okio.internal.commonHashCode
@@ -188,6 +189,8 @@ internal actual constructor(
   actual open fun lastIndexOf(other: ByteArray, fromIndex: Int) = commonLastIndexOf(other, fromIndex)
 
   actual override fun equals(other: Any?) = commonEquals(other)
+
+  actual fun equals(other: ByteString, constantTime: Boolean) = commonEqualsConstantTime(other)
 
   actual override fun hashCode() = commonHashCode()
 

--- a/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
@@ -15,8 +15,8 @@
  */
 package okio
 
-import kotlin.test.Test
-import kotlin.test.assertTrue
+import org.junit.Assert.assertTrue
+import org.junit.Test
 
 /**
  * Statistical timing test for [ByteString.equals] with [constantTime]=true.
@@ -33,8 +33,8 @@ class ConstantTimeEqualsTimingTest {
   fun constantTimeEqualsDoesNotShortCircuit() {
     val n = 1_000_000
     val aBytes = ByteArray(n) { 0 }
-    val bBytes = ByteArray(n) { 0 }          // identical to a
-    val cBytes = ByteArray(n) { 0 }.also { it[0] = 1 }  // differs at byte 0
+    val bBytes = ByteArray(n) { 0 } // identical to a
+    val cBytes = ByteArray(n) { 0 }.also { it[0] = 1 } // differs at byte 0
 
     val a = aBytes.toByteString()
     val b = bBytes.toByteString()
@@ -56,18 +56,26 @@ class ConstantTimeEqualsTimingTest {
     val normalMismatch = median(iterations) { a == c }
 
     // CT(match) and CT(mismatch) should be within 3x of each other: neither short-circuits.
-    val ctRatio = if (ctMatch > ctMismatch) ctMatch.toDouble() / ctMismatch else ctMismatch.toDouble() / ctMatch
-    assertTrue(ctRatio < 3.0,
-      "CT(match)=$ctMatch ns and CT(mismatch)=$ctMismatch ns differ by ${ctRatio}x (expected <3x)")
+    val ctRatio =
+      if (ctMatch > ctMismatch) ctMatch.toDouble() / ctMismatch else ctMismatch.toDouble() / ctMatch
+    assertTrue(
+      "CT(match)=$ctMatch ns and CT(mismatch)=$ctMismatch ns differ by ${ctRatio}x (expected <3x)",
+      ctRatio < 3.0,
+    )
 
     // CT(match) and normal(match) should be in the same ballpark: both scan all n bytes.
-    val matchRatio = if (ctMatch > normalMatch) ctMatch.toDouble() / normalMatch else normalMatch.toDouble() / ctMatch
-    assertTrue(matchRatio < 5.0,
-      "CT(match)=$ctMatch ns and normal(match)=$normalMatch ns differ by ${matchRatio}x (expected <5x)")
+    val matchRatio =
+      if (ctMatch > normalMatch) ctMatch.toDouble() / normalMatch else normalMatch.toDouble() / ctMatch
+    assertTrue(
+      "CT(match)=$ctMatch ns and normal(match)=$normalMatch ns differ by ${matchRatio}x (expected <5x)",
+      matchRatio < 5.0,
+    )
 
     // normal(mismatch) must be significantly faster than CT(mismatch): normal short-circuits at byte 0.
-    assertTrue(normalMismatch * 50L < ctMismatch,
-      "normal(mismatch)=$normalMismatch ns should be <2% of CT(mismatch)=$ctMismatch ns (short-circuit at byte 0)")
+    assertTrue(
+      "normal(mismatch)=$normalMismatch ns should be <2% of CT(mismatch)=$ctMismatch ns (short-circuit at byte 0)",
+      normalMismatch * 50L < ctMismatch,
+    )
   }
 
   private inline fun median(n: Int, block: () -> Unit): Long {

--- a/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
@@ -15,6 +15,7 @@
  */
 package okio
 
+import okio.ByteString.Companion.toByteString
 import org.junit.Assert.assertTrue
 import org.junit.Test
 

--- a/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Statistical timing test for [ByteString.equals] with [constantTime]=true.
+ *
+ * Given two very large byte strings:
+ * - When equal, constant-time equals takes the same time as normal equals (both scan all bytes).
+ * - When not equal, constant-time equals takes the same time as when equal (no short-circuit).
+ * - When not equal, normal equals takes statistically significantly less time than when equal
+ *   (short-circuits at the first differing byte).
+ */
+class ConstantTimeEqualsTimingTest {
+
+  @Test
+  fun constantTimeEqualsDoesNotShortCircuit() {
+    val n = 1_000_000
+    val aBytes = ByteArray(n) { 0 }
+    val bBytes = ByteArray(n) { 0 }          // identical to a
+    val cBytes = ByteArray(n) { 0 }.also { it[0] = 1 }  // differs at byte 0
+
+    val a = aBytes.toByteString()
+    val b = bBytes.toByteString()
+    val c = cBytes.toByteString()
+
+    // Warm up the JIT.
+    repeat(200) {
+      a.equals(b, constantTime = true)
+      a.equals(c, constantTime = true)
+      a == b
+      a == c
+    }
+
+    val iterations = 500
+
+    val ctMatch = median(iterations) { a.equals(b, constantTime = true) }
+    val ctMismatch = median(iterations) { a.equals(c, constantTime = true) }
+    val normalMatch = median(iterations) { a == b }
+    val normalMismatch = median(iterations) { a == c }
+
+    // CT(match) and CT(mismatch) should be within 3x of each other: neither short-circuits.
+    val ctRatio = if (ctMatch > ctMismatch) ctMatch.toDouble() / ctMismatch else ctMismatch.toDouble() / ctMatch
+    assertTrue(ctRatio < 3.0,
+      "CT(match)=$ctMatch ns and CT(mismatch)=$ctMismatch ns differ by ${ctRatio}x (expected <3x)")
+
+    // CT(match) and normal(match) should be in the same ballpark: both scan all n bytes.
+    val matchRatio = if (ctMatch > normalMatch) ctMatch.toDouble() / normalMatch else normalMatch.toDouble() / ctMatch
+    assertTrue(matchRatio < 5.0,
+      "CT(match)=$ctMatch ns and normal(match)=$normalMatch ns differ by ${matchRatio}x (expected <5x)")
+
+    // normal(mismatch) must be significantly faster than CT(mismatch): normal short-circuits at byte 0.
+    assertTrue(normalMismatch * 50L < ctMismatch,
+      "normal(mismatch)=$normalMismatch ns should be <2% of CT(mismatch)=$ctMismatch ns (short-circuit at byte 0)")
+  }
+
+  private inline fun median(n: Int, block: () -> Unit): Long {
+    val times = LongArray(n)
+    repeat(n) { i ->
+      val t0 = System.nanoTime()
+      block()
+      times[i] = System.nanoTime() - t0
+    }
+    times.sort()
+    return times[n / 2]
+  }
+}

--- a/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
@@ -23,7 +23,6 @@ import org.junit.Test
  * Statistical timing test for [ByteString.equals] with [constantTime]=true.
  *
  * Given two very large byte strings:
- * - When equal, constant-time equals takes the same time as normal equals (both scan all bytes).
  * - When not equal, constant-time equals takes the same time as when equal (no short-circuit).
  * - When not equal, normal equals takes statistically significantly less time than when equal
  *   (short-circuits at the first differing byte).
@@ -53,7 +52,6 @@ class ConstantTimeEqualsTimingTest {
 
     val ctMatch = median(iterations) { a.equals(b, constantTime = true) }
     val ctMismatch = median(iterations) { a.equals(c, constantTime = true) }
-    val normalMatch = median(iterations) { a == b }
     val normalMismatch = median(iterations) { a == c }
 
     // CT(match) and CT(mismatch) should be within 3x of each other: neither short-circuits.
@@ -62,14 +60,6 @@ class ConstantTimeEqualsTimingTest {
     assertTrue(
       "CT(match)=$ctMatch ns and CT(mismatch)=$ctMismatch ns differ by ${ctRatio}x (expected <3x)",
       ctRatio < 3.0,
-    )
-
-    // CT(match) and normal(match) should be in the same ballpark: both scan all n bytes.
-    val matchRatio =
-      if (ctMatch > normalMatch) ctMatch.toDouble() / normalMatch else normalMatch.toDouble() / ctMatch
-    assertTrue(
-      "CT(match)=$ctMatch ns and normal(match)=$normalMatch ns differ by ${matchRatio}x (expected <5x)",
-      matchRatio < 5.0,
     )
 
     // normal(mismatch) must be significantly faster than CT(mismatch): normal short-circuits at byte 0.

--- a/okio/src/nonAppleMain/kotlin/okio/ByteString.kt
+++ b/okio/src/nonAppleMain/kotlin/okio/ByteString.kt
@@ -163,7 +163,8 @@ internal actual constructor(
 
   actual override fun equals(other: Any?) = commonEquals(other)
 
-  actual fun equals(other: ByteString, constantTime: Boolean) = commonEqualsConstantTime(other)
+  actual fun equals(other: ByteString, constantTime: Boolean) =
+    if (constantTime) commonEqualsConstantTime(other) else this == other
 
   actual override fun hashCode() = commonHashCode()
 

--- a/okio/src/nonAppleMain/kotlin/okio/ByteString.kt
+++ b/okio/src/nonAppleMain/kotlin/okio/ByteString.kt
@@ -31,6 +31,7 @@ import okio.internal.commonDecodeHex
 import okio.internal.commonEncodeUtf8
 import okio.internal.commonEndsWith
 import okio.internal.commonEquals
+import okio.internal.commonEqualsConstantTime
 import okio.internal.commonGetByte
 import okio.internal.commonGetSize
 import okio.internal.commonHashCode
@@ -161,6 +162,8 @@ internal actual constructor(
   actual open fun lastIndexOf(other: ByteArray, fromIndex: Int) = commonLastIndexOf(other, fromIndex)
 
   actual override fun equals(other: Any?) = commonEquals(other)
+
+  actual fun equals(other: ByteString, constantTime: Boolean) = commonEqualsConstantTime(other)
 
   actual override fun hashCode() = commonHashCode()
 


### PR DESCRIPTION
Adds a constant-time `ByteString.equals(other, constantTime)` overload for timing-safe comparison of secrets like hashes and MACs, as requested in #1797. After a length check it XORs every byte and never short-circuits, so the running time does not depend on where the byte strings differ. Implemented in `commonMain` so it works on all targets, and tested across the basic and segmented byte string variants.

Closes #1797. Closes #1799