### PR TITLE
Catch `FileNotFoundException` in `AssetFileSystem.existsInternal`

### DIFF
--- a/okio-assetfilesystem/src/main/kotlin/okio/assetfilesystem/AssetFileSystem.kt
+++ b/okio-assetfilesystem/src/main/kotlin/okio/assetfilesystem/AssetFileSystem.kt
@@ -67,7 +67,13 @@ private class AssetFileSystem(
     // Both non-existent paths and paths to existing files return an empty array when listing.
     // Determine if a path exists by checking if its name is present in the parent's list.
     val parent = checkNotNull(parent) { "Path has no parent. Did you canonicalize? $this" }
-    val children = assets.list(parent.toAssetRelativePathString()).orEmpty()
+
+    val children = try {
+      assets.list(parent.toAssetRelativePathString()).orEmpty()
+    } catch (_: FileNotFoundException) {
+      emptyArray()
+    }
+
     return name in children
   }
 


### PR DESCRIPTION
Under certain circumstances, the native asset manager implementation can throw a `FileNotFoundException` if the asset directory cannot be opened for listing (see https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/jni/android_util_AssetManager.cpp#475)

This can, for example, cause `AssetFileSystem.exists()` to throw instead of returning `false` which is (arguably?) different from the behaviour of other `FileSystem` implementations.