### PR TITLE
Pass preopen-relative paths to WASI `path_*` functions

### DIFF
--- a/okio-wasifilesystem/src/wasmWasiMain/kotlin/okio/WasiFileSystem.kt
+++ b/okio-wasifilesystem/src/wasmWasiMain/kotlin/okio/WasiFileSystem.kt
@@ -142,8 +142,8 @@ object WasiFileSystem : FileSystem() {
   override fun metadataOrNull(path: Path): FileMetadata? {
     withScopedMemoryAllocator { allocator ->
       val returnPointer = allocator.allocate(64)
-      val preopen = preopenForPath(path) ?: return null
-      val (pathAddress, pathSize) = allocator.write(preopen.relativePath(path))
+      val (preopen, relativePath) = preopenForPath(path) ?: return null
+      val (pathAddress, pathSize) = allocator.write(relativePath)
 
       val errno = path_filestat_get(
         fd = preopen.fd,
@@ -358,8 +358,9 @@ object WasiFileSystem : FileSystem() {
 
   override fun createDirectory(dir: Path, mustCreate: Boolean) {
     withScopedMemoryAllocator { allocator ->
-      val preopen = preopenForPath(dir) ?: throw FileNotFoundException("no preopen: $dir")
-      val (pathAddress, pathSize) = allocator.write(preopen.relativePath(dir))
+      val (preopen, relativePath) = preopenForPath(dir)
+        ?: throw FileNotFoundException("no preopen: $dir")
+      val (pathAddress, pathSize) = allocator.write(relativePath)
 
       val errno = path_create_directory(
         fd = preopen.fd,
@@ -377,12 +378,12 @@ object WasiFileSystem : FileSystem() {
 
   override fun atomicMove(source: Path, target: Path) {
     withScopedMemoryAllocator { allocator ->
-      val sourcePreopen = preopenForPath(source)
+      val (sourcePreopen, sourceRelativePath) = preopenForPath(source)
         ?: throw FileNotFoundException("no preopen: $source")
-      val targetPreopen = preopenForPath(target)
+      val (targetPreopen, targetRelativePath) = preopenForPath(target)
         ?: throw FileNotFoundException("no preopen: $target")
-      val (sourcePathAddress, sourcePathSize) = allocator.write(sourcePreopen.relativePath(source))
-      val (targetPathAddress, targetPathSize) = allocator.write(targetPreopen.relativePath(target))
+      val (sourcePathAddress, sourcePathSize) = allocator.write(sourceRelativePath)
+      val (targetPathAddress, targetPathSize) = allocator.write(targetRelativePath)
 
       val errno = path_rename(
         fd = sourcePreopen.fd,
@@ -402,8 +403,9 @@ object WasiFileSystem : FileSystem() {
 
   override fun delete(path: Path, mustExist: Boolean) {
     withScopedMemoryAllocator { allocator ->
-      val preopen = preopenForPath(path) ?: throw FileNotFoundException("no preopen: $path")
-      val (pathAddress, pathSize) = allocator.write(preopen.relativePath(path))
+      val (preopen, relativePath) = preopenForPath(path)
+        ?: throw FileNotFoundException("no preopen: $path")
+      val (pathAddress, pathSize) = allocator.write(relativePath)
 
       var errno = path_unlink_file(
         fd = preopen.fd,
@@ -433,7 +435,7 @@ object WasiFileSystem : FileSystem() {
 
   override fun createSymlink(source: Path, target: Path) {
     withScopedMemoryAllocator { allocator ->
-      val sourcePreopen = preopenForPath(source)
+      val (sourcePreopen, sourceRelativePath) = preopenForPath(source)
         ?: throw FileNotFoundException("no preopen: $source")
 
       // Always create symlinks relative to their source. Absolute symlinks are trouble because the
@@ -445,7 +447,7 @@ object WasiFileSystem : FileSystem() {
         else -> target.relativeTo(sourceParent)
       }
 
-      val (sourcePathAddress, sourcePathSize) = allocator.write(sourcePreopen.relativePath(source))
+      val (sourcePathAddress, sourcePathSize) = allocator.write(sourceRelativePath)
       val (targetPathAddress, targetPathSize) = allocator.write(targetRelative.toString())
 
       val errno = path_symlink(
@@ -466,8 +468,9 @@ object WasiFileSystem : FileSystem() {
     fdflags: fdflags = 0,
   ): fd {
     withScopedMemoryAllocator { allocator ->
-      val preopen = preopenForPath(path) ?: throw FileNotFoundException("no preopen: $path")
-      val (pathAddress, pathSize) = allocator.write(preopen.relativePath(path))
+      val (preopen, relativePath) = preopenForPath(path)
+        ?: throw FileNotFoundException("no preopen: $path")
+      val (pathAddress, pathSize) = allocator.write(relativePath)
 
       val returnPointer: Pointer = allocator.allocate(4) // fd is u32.
       val errno = path_open(
@@ -491,20 +494,22 @@ object WasiFileSystem : FileSystem() {
 
   /**
    * Returns the preopen whose path is either an ancestor of [path], or whose path [path] is an
-   * ancestor of.
+   * ancestor of, paired with [path] made relative to that preopen.
    *
    * If [path] is an ancestor of our preopen, then operating on the path will ultimately fail with a
    * `notcapable` errno.
    */
-  private fun preopenForPath(path: Path): Preopen? {
-    if (path.isRelative) return relativePathPreopen
+  private fun preopenForPath(path: Path): Pair<Preopen, String>? {
+    if (path.isRelative) return relativePathPreopen to relativePathPreopen.relativePath(path)
 
     val pathSegmentsBytes = path.segmentsBytes
 
-    return preopens.firstOrNull { preopen ->
+    val preopen = preopens.firstOrNull { preopen ->
       val commonSize = minOf(pathSegmentsBytes.size, preopen.segmentsBytes.size)
       preopen.segmentsBytes.subList(0, commonSize) == pathSegmentsBytes.subList(0, commonSize)
-    }
+    } ?: return null
+
+    return preopen to preopen.relativePath(path)
   }
 
   override fun toString() = "okio.WasiFileSystem"

--- a/okio-wasifilesystem/src/wasmWasiMain/kotlin/okio/WasiFileSystem.kt
+++ b/okio-wasifilesystem/src/wasmWasiMain/kotlin/okio/WasiFileSystem.kt
@@ -143,7 +143,7 @@ object WasiFileSystem : FileSystem() {
     withScopedMemoryAllocator { allocator ->
       val returnPointer = allocator.allocate(64)
       val preopen = preopenForPath(path) ?: return null
-      val (pathAddress, pathSize) = allocator.write(path.toString())
+      val (pathAddress, pathSize) = allocator.write(preopen.relativePath(path))
 
       val errno = path_filestat_get(
         fd = preopen.fd,
@@ -358,10 +358,11 @@ object WasiFileSystem : FileSystem() {
 
   override fun createDirectory(dir: Path, mustCreate: Boolean) {
     withScopedMemoryAllocator { allocator ->
-      val (pathAddress, pathSize) = allocator.write(dir.toString())
+      val preopen = preopenForPath(dir) ?: throw FileNotFoundException("no preopen: $dir")
+      val (pathAddress, pathSize) = allocator.write(preopen.relativePath(dir))
 
       val errno = path_create_directory(
-        fd = preopenForPath(dir)?.fd ?: throw FileNotFoundException("no preopen: $dir"),
+        fd = preopen.fd,
         path = pathAddress.address.toInt(),
         pathSize = pathSize,
       )
@@ -376,14 +377,18 @@ object WasiFileSystem : FileSystem() {
 
   override fun atomicMove(source: Path, target: Path) {
     withScopedMemoryAllocator { allocator ->
-      val (sourcePathAddress, sourcePathSize) = allocator.write(source.toString())
-      val (targetPathAddress, targetPathSize) = allocator.write(target.toString())
+      val sourcePreopen = preopenForPath(source)
+        ?: throw FileNotFoundException("no preopen: $source")
+      val targetPreopen = preopenForPath(target)
+        ?: throw FileNotFoundException("no preopen: $target")
+      val (sourcePathAddress, sourcePathSize) = allocator.write(sourcePreopen.relativePath(source))
+      val (targetPathAddress, targetPathSize) = allocator.write(targetPreopen.relativePath(target))
 
       val errno = path_rename(
-        fd = preopenForPath(source)?.fd ?: throw FileNotFoundException("no preopen: $source"),
+        fd = sourcePreopen.fd,
         old_path = sourcePathAddress.address.toInt(),
         old_pathSize = sourcePathSize,
-        new_fd = preopenForPath(target)?.fd ?: throw FileNotFoundException("no preopen: $target"),
+        new_fd = targetPreopen.fd,
         new_path = targetPathAddress.address.toInt(),
         new_pathSize = targetPathSize,
       )
@@ -397,11 +402,11 @@ object WasiFileSystem : FileSystem() {
 
   override fun delete(path: Path, mustExist: Boolean) {
     withScopedMemoryAllocator { allocator ->
-      val (pathAddress, pathSize) = allocator.write(path.toString())
-      val preopenFd = preopenForPath(path) ?: throw FileNotFoundException("no preopen: $path")
+      val preopen = preopenForPath(path) ?: throw FileNotFoundException("no preopen: $path")
+      val (pathAddress, pathSize) = allocator.write(preopen.relativePath(path))
 
       var errno = path_unlink_file(
-        fd = preopenFd.fd,
+        fd = preopen.fd,
         path = pathAddress.address.toInt(),
         pathSize = pathSize,
       )
@@ -416,7 +421,7 @@ object WasiFileSystem : FileSystem() {
         Errno.isdir.ordinal,
         -> {
           errno = path_remove_directory(
-            fd = preopenFd.fd,
+            fd = preopen.fd,
             path = pathAddress.address.toInt(),
             pathSize = pathSize,
           )
@@ -440,7 +445,7 @@ object WasiFileSystem : FileSystem() {
         else -> target.relativeTo(sourceParent)
       }
 
-      val (sourcePathAddress, sourcePathSize) = allocator.write(source.toString())
+      val (sourcePathAddress, sourcePathSize) = allocator.write(sourcePreopen.relativePath(source))
       val (targetPathAddress, targetPathSize) = allocator.write(targetRelative.toString())
 
       val errno = path_symlink(
@@ -461,12 +466,12 @@ object WasiFileSystem : FileSystem() {
     fdflags: fdflags = 0,
   ): fd {
     withScopedMemoryAllocator { allocator ->
-      val preopenFd = preopenForPath(path) ?: throw FileNotFoundException("no preopen: $path")
-      val (pathAddress, pathSize) = allocator.write(path.toString())
+      val preopen = preopenForPath(path) ?: throw FileNotFoundException("no preopen: $path")
+      val (pathAddress, pathSize) = allocator.write(preopen.relativePath(path))
 
       val returnPointer: Pointer = allocator.allocate(4) // fd is u32.
       val errno = path_open(
-        fd = preopenFd.fd,
+        fd = preopen.fd,
         dirflags = 0,
         path = pathAddress.address.toInt(),
         pathSize = pathSize,
@@ -508,5 +513,15 @@ object WasiFileSystem : FileSystem() {
     val path: Path,
     val segmentsBytes: List<ByteString>,
     val fd: fd,
-  )
+  ) {
+    /**
+     * Returns [target] as a path string relative to this preopen. WASI resolves path arguments
+     * against the preopen's file descriptor, and Node.js rejects absolute paths (`notcapable`), so
+     * the absolute path must be made relative before it is passed to a WASI path function.
+     */
+    fun relativePath(target: Path): String = when {
+      target.isRelative -> target.toString()
+      else -> target.relativeTo(path).toString()
+    }
+  }
 }


### PR DESCRIPTION
`WasiFileSystem` passes absolute paths to the WASI `path_*` functions, which resolve their argument against a preopened directory. After nodejs/node#59791, Node.js no longer accepts absolute paths there, so every file operation fails with `notcapable`.

Each path is now made relative to its preopen before the call, matching `createSymlink`.

okio's CI uses the Node bundled with Kotlin 2.2.21 (Node 22), which accepts absolute paths, so tests pass either way. On Node 26.3.0 the fix drops `notcapable` failures from 169 to 2. The other two are a separate Node restriction on `..` in symlink targets.

Closes #1746
