### PR TITLE
New API, BufferedSink.utf8Appendable()

### DIFF
--- a/okio/api/okio.api
+++ b/okio/api/okio.api
@@ -169,6 +169,7 @@ public final class okio/Buffer : java/lang/Cloneable, java/nio/channels/ByteChan
 	public final fun snapshot (I)Lokio/ByteString;
 	public fun timeout ()Lokio/Timeout;
 	public fun toString ()Ljava/lang/String;
+	public fun utf8Appendable ()Ljava/lang/Appendable;
 	public fun write (Ljava/nio/ByteBuffer;)I
 	public fun write (Lokio/Buffer;J)V
 	public fun write (Lokio/ByteString;)Lokio/Buffer;
@@ -237,6 +238,7 @@ public abstract interface class okio/BufferedSink : java/nio/channels/WritableBy
 	public abstract fun flush ()V
 	public abstract fun getBuffer ()Lokio/Buffer;
 	public abstract fun outputStream ()Ljava/io/OutputStream;
+	public abstract fun utf8Appendable ()Ljava/lang/Appendable;
 	public abstract fun write (Lokio/ByteString;)Lokio/BufferedSink;
 	public abstract fun write (Lokio/ByteString;II)Lokio/BufferedSink;
 	public abstract fun write (Lokio/Source;J)Lokio/BufferedSink;

--- a/okio/src/commonMain/kotlin/okio/internal/-Utf16.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/-Utf16.kt
@@ -1,0 +1,35 @@
+// ktlint-disable filename
+/*
+ * Copyright (c) 2026 Okio Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio.internal
+
+/*
+ * UTF-16 high surrogate: 110110xxxxxxxxxx (10 bits)
+ * UTF-16 low surrogate:  110111yyyyyyyyyy (10 bits)
+ * Unicode code point:    00010000000000000000 + xxxxxxxxxxyyyyyyyyyy (21 bits)
+ */
+
+internal val Int.isSurrogate: Boolean
+  inline get() = this in 0xd800..0xdfff
+
+internal val Int.isHighSurrogate: Boolean
+  inline get() = this in 0xd800..0xdbff
+
+internal val Int.isLowSurrogate: Boolean
+  inline get() = this in 0xdc00..0xdfff
+
+internal fun combineSurrogates(high: Int, low: Int): Int =
+  0x010000 + (high and 0x03ff shl 10 or (low and 0x03ff))

--- a/okio/src/commonMain/kotlin/okio/internal/Buffer.kt
+++ b/okio/src/commonMain/kotlin/okio/internal/Buffer.kt
@@ -928,7 +928,7 @@ internal inline fun Buffer.commonReadUtf8CodePoint(): Int {
     codePoint > 0x10ffff -> {
       REPLACEMENT_CODE_POINT // Reject code points larger than the Unicode maximum.
     }
-    codePoint in 0xd800..0xdfff -> {
+    codePoint.isSurrogate -> {
       REPLACEMENT_CODE_POINT // Reject partial surrogates.
     }
     codePoint < min -> {
@@ -983,32 +983,15 @@ internal inline fun Buffer.commonWriteUtf8(string: String, beginIndex: Int, endI
         i++
       }
 
-      c < 0xd800 || c > 0xdfff -> {
-        // Emit a 16-bit character with 3 bytes.
-        val tail = writableSegment(3)
-        /* ktlint-disable no-multi-spaces */
-        tail.data[tail.limit    ] = (c shr 12          or 0xe0).toByte() // 1110xxxx
-        tail.data[tail.limit + 1] = (c shr  6 and 0x3f or 0x80).toByte() // 10xxxxxx
-        tail.data[tail.limit + 2] = (c        and 0x3f or 0x80).toByte() // 10xxxxxx
-        /* ktlint-enable no-multi-spaces */
-        tail.limit += 3
-        size += 3L
-        i++
-      }
-
-      else -> {
-        // c is a surrogate. Make sure it is a high surrogate & that its successor is a low
-        // surrogate. If not, the UTF-16 is invalid, in which case we emit a replacement
-        // character.
+      c.isHighSurrogate -> {
+        // c is a high surrogate. Make sure its successor is a low surrogate. If not, the UTF-16 is
+        // invalid, in which case we emit a replacement character.
         val low = (if (i + 1 < endIndex) string[i + 1].code else 0)
-        if (c > 0xdbff || low !in 0xdc00..0xdfff) {
+        if (!low.isLowSurrogate) {
           writeByte('?'.code)
           i++
         } else {
-          // UTF-16 high surrogate: 110110xxxxxxxxxx (10 bits)
-          // UTF-16 low surrogate:  110111yyyyyyyyyy (10 bits)
-          // Unicode code point:    00010000000000000000 + xxxxxxxxxxyyyyyyyyyy (21 bits)
-          val codePoint = 0x010000 + (c and 0x03ff shl 10 or (low and 0x03ff))
+          val codePoint = combineSurrogates(c, low)
 
           // Emit a 21-bit character with 4 bytes.
           val tail = writableSegment(4)
@@ -1022,6 +1005,25 @@ internal inline fun Buffer.commonWriteUtf8(string: String, beginIndex: Int, endI
           size += 4L
           i += 2
         }
+      }
+
+      c.isLowSurrogate -> {
+        // Low surrogate should have followed a high surrogate. Emit a replacement character.
+        writeByte('?'.code)
+        i++
+      }
+
+      else -> {
+        // Emit a 16-bit character with 3 bytes.
+        val tail = writableSegment(3)
+        /* ktlint-disable no-multi-spaces */
+        tail.data[tail.limit    ] = (c shr 12          or 0xe0).toByte() // 1110xxxx
+        tail.data[tail.limit + 1] = (c shr  6 and 0x3f or 0x80).toByte() // 10xxxxxx
+        tail.data[tail.limit + 2] = (c        and 0x3f or 0x80).toByte() // 10xxxxxx
+        /* ktlint-enable no-multi-spaces */
+        tail.limit += 3
+        size += 3L
+        i++
       }
     }
   }
@@ -1045,7 +1047,7 @@ internal inline fun Buffer.commonWriteUtf8CodePoint(codePoint: Int): Buffer {
       tail.limit += 2
       size += 2L
     }
-    codePoint in 0xd800..0xdfff -> {
+    codePoint.isSurrogate -> {
       // Emit a replacement character for a partial surrogate.
       writeByte('?'.code)
     }

--- a/okio/src/jvmMain/kotlin/okio/Buffer.kt
+++ b/okio/src/jvmMain/kotlin/okio/Buffer.kt
@@ -27,6 +27,7 @@ import java.security.InvalidKeyException
 import java.security.MessageDigest
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
+import okio.internal.combineSurrogates
 import okio.internal.commonClear
 import okio.internal.commonClose
 import okio.internal.commonCompleteSegmentByteCount
@@ -72,6 +73,8 @@ import okio.internal.commonWriteLong
 import okio.internal.commonWriteShort
 import okio.internal.commonWriteUtf8
 import okio.internal.commonWriteUtf8CodePoint
+import okio.internal.isHighSurrogate
+import okio.internal.isLowSurrogate
 
 actual class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
   @JvmField internal actual var head: Segment? = null
@@ -99,6 +102,70 @@ actual class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
       override fun close() {}
 
       override fun toString(): String = "${this@Buffer}.outputStream()"
+    }
+  }
+
+  override fun utf8Appendable(): Appendable {
+    return object : Appendable {
+      private var savedHighSurrogate: Int = 0
+
+      override fun append(charSequence: CharSequence?) =
+        append(charSequence, 0, charSequence?.length ?: "null".length)
+
+      override fun append(
+        charSequence: CharSequence?,
+        beginIndex: Int,
+        endIndex: Int,
+      ) = apply {
+        val string = charSequence?.toString() ?: "null"
+
+        require(beginIndex >= 0) { "beginIndex < 0: $beginIndex" }
+        require(endIndex >= beginIndex) { "endIndex < beginIndex: $endIndex < $beginIndex" }
+        require(endIndex <= string.length) { "endIndex > string.length: $endIndex > ${string.length}" }
+
+        if (beginIndex == endIndex) return@apply
+
+        // If we have a saved high surrogate, check if the first character is a low surrogate.
+        var beginIndex = beginIndex
+        if (savedHighSurrogate != 0) {
+          if (string[beginIndex].code.isLowSurrogate) {
+            writeUtf8CodePoint(combineSurrogates(savedHighSurrogate, string[beginIndex++].code))
+          } else {
+            writeByte('?'.code) // Our high surrogate was unmatched.
+          }
+          savedHighSurrogate = 0
+        }
+
+        // If the last character is a high surrogate, save it for later.
+        var endIndex = endIndex
+        if (beginIndex < endIndex && string[endIndex - 1].code.isHighSurrogate) {
+          savedHighSurrogate = string[--endIndex].code
+        }
+
+        writeUtf8(string, beginIndex, endIndex)
+      }
+
+      override fun append(c: Char) = apply {
+        var c = c.code
+
+        // If we have a saved high surrogate, check if c is a low surrogate.
+        if (savedHighSurrogate != 0) {
+          if (c.isLowSurrogate) {
+            c = combineSurrogates(savedHighSurrogate, c)
+          } else {
+            writeByte('?'.code) // Our high surrogate was unmatched.
+          }
+          savedHighSurrogate = 0
+        }
+
+        // If c is a high surrogate, save it for later.
+        if (c.isHighSurrogate) {
+          savedHighSurrogate = c
+          return@apply
+        }
+
+        writeUtf8CodePoint(c)
+      }
     }
   }
 

--- a/okio/src/jvmMain/kotlin/okio/BufferedSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/BufferedSink.kt
@@ -102,4 +102,12 @@ actual sealed interface BufferedSink : Sink, WritableByteChannel {
 
   /** Returns an output stream that writes to this sink. */
   fun outputStream(): OutputStream
+
+  /**
+   * Returns an appendable that encodes strings as UTF-8 and writes them to this sink.
+   *
+   * If the last character of any [Appendable.append] call is an unpaired high surrogate, that
+   * character will be saved in an attempt to pair it with a low surrogate in the following call.
+   */
+  fun utf8Appendable(): Appendable
 }

--- a/okio/src/jvmMain/kotlin/okio/RealBufferedSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/RealBufferedSink.kt
@@ -131,6 +131,31 @@ internal actual class RealBufferedSink actual constructor(
     }
   }
 
+  override fun utf8Appendable(): Appendable {
+    return object : Appendable {
+      private val delegate = buffer.utf8Appendable()
+
+      override fun append(charSequence: CharSequence?) = apply {
+        delegate.append(charSequence)
+        emitCompleteSegments()
+      }
+
+      override fun append(
+        charSequence: CharSequence?,
+        start: Int,
+        end: Int,
+      ) = apply {
+        delegate.append(charSequence, start, end)
+        emitCompleteSegments()
+      }
+
+      override fun append(c: Char) = apply {
+        delegate.append(c)
+        emitCompleteSegments()
+      }
+    }
+  }
+
   actual override fun flush() = commonFlush()
 
   override fun isOpen() = !closed

--- a/okio/src/jvmTest/kotlin/okio/BufferedSinkAppendableTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferedSinkAppendableTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Okio Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio
+
+import app.cash.burst.Burst
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+@Burst
+class BufferedSinkAppendableTest(
+  factory: BufferedSinkFactory = BufferedSinkFactory.BasicBuffer,
+) {
+  private val data = Buffer()
+  private val sink = factory.create(data)
+  private val appendable = sink.utf8Appendable()
+
+  @Test
+  fun sizeBoundsCheck() {
+    assertFailsWith<IllegalArgumentException> {
+      appendable.append("abc", -1, 2)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      appendable.append("abc", 2, 1)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      appendable.append("abc", 1, 4)
+    }
+  }
+
+  @Test
+  fun appendNulls() {
+    appendable.append("abc")
+    appendable.append(null)
+    appendable.append("def")
+    sink.emit()
+    assertThat(data.readUtf8()).isEqualTo("abcnulldef")
+  }
+
+  @Test
+  fun appendNullsWithRanges() {
+    appendable.append("abcde", 1, 3)
+    appendable.append(null, 1, 3)
+    appendable.append("fghij", 1, 3)
+    sink.emit()
+    assertThat(data.readUtf8()).isEqualTo("bculgh")
+  }
+
+  @Test
+  fun charCallsWithMatchedSurrogates() {
+    appendable.append("donut ")
+    appendable.append('\ud83c')
+    appendable.append('\udf69')
+    appendable.append(" sprinkles")
+    sink.emit()
+    assertThat(data.readUtf8()).isEqualTo("donut \ud83c\udf69 sprinkles")
+  }
+
+  @Test
+  fun charCallsWithBrokenLowHighSurrogates() {
+    appendable.append("donut ")
+    appendable.append('\udf69')
+    appendable.append('\ud83c')
+    appendable.append(" sprinkles")
+    sink.emit()
+    assertThat(data.readUtf8()).isEqualTo("donut ?? sprinkles")
+  }
+
+  @Test
+  fun stringCallsWithMatchedSurrogates() {
+    appendable.append("donut \ud83c")
+    appendable.append("\udf69 sprinkles")
+    sink.emit()
+    assertThat(data.readUtf8()).isEqualTo("donut \ud83c\udf69 sprinkles")
+  }
+
+  @Test
+  fun stringCallsWithEmpty() {
+    appendable.append("donut \ud83c")
+    appendable.append("")
+    appendable.append("\udf69 sprinkles")
+    sink.emit()
+    assertThat(data.readUtf8()).isEqualTo("donut \ud83c\udf69 sprinkles")
+  }
+
+  @Test
+  fun stringCallsWithLowAndHigh() {
+    appendable.append("two \ud83c")
+    appendable.append("\udf69\ud83c")
+    appendable.append("\udf69 donuts")
+    sink.emit()
+    assertThat(data.readUtf8()).isEqualTo("two \ud83c\udf69\ud83c\udf69 donuts")
+  }
+
+  @Test
+  fun stringCallsWithBrokenLowHighSurrogates() {
+    appendable.append("donut \udf69")
+    appendable.append("\ud83c sprinkles")
+    sink.emit()
+    assertThat(data.readUtf8()).isEqualTo("donut ?? sprinkles")
+  }
+
+  @Test
+  fun savedHighSurrogateIsDropped() {
+    appendable.append("donut \ud83c")
+    sink.emit()
+    assertThat(data.readUtf8()).isEqualTo("donut ")
+  }
+
+  @Test
+  fun stringCallsWithBrokenHighSurrogateAndNull() {
+    appendable.append("donut \ud83c")
+    appendable.append(null)
+    sink.emit()
+    assertThat(data.readUtf8()).isEqualTo("donut ?null")
+  }
+}

--- a/okio/src/jvmTest/kotlin/okio/Utf8Test.kt
+++ b/okio/src/jvmTest/kotlin/okio/Utf8Test.kt
@@ -15,7 +15,11 @@
  */
 package okio
 
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
 import java.io.EOFException
+import kotlin.test.assertFailsWith
 import kotlin.text.Charsets.UTF_8
 import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.of
@@ -23,7 +27,6 @@ import okio.TestUtil.SEGMENT_SIZE
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Test
 
 class Utf8Test {
@@ -117,10 +120,8 @@ class Utf8Test {
   @Test
   fun readEmptyBufferThrowsEofException() {
     val buffer = Buffer()
-    try {
+    assertFailsWith<EOFException> {
       buffer.readUtf8CodePoint()
-      fail()
-    } catch (expected: EOFException) {
     }
   }
 
@@ -136,10 +137,8 @@ class Utf8Test {
   fun readMissingContinuationBytesThrowsEofException() {
     val buffer = Buffer()
     buffer.writeByte(0xdf)
-    try {
+    assertFailsWith<EOFException> {
       buffer.readUtf8CodePoint()
-      fail()
-    } catch (expected: EOFException) {
     }
     assertFalse(buffer.exhausted()) // Prefix byte wasn't consumed.
   }
@@ -207,12 +206,10 @@ class Utf8Test {
   @Test
   fun writeCodePointBeyondUnicodeMaximum() {
     val buffer = Buffer()
-    try {
+    val expected = assertFailsWith<IllegalArgumentException> {
       buffer.writeUtf8CodePoint(0x110000)
-      fail()
-    } catch (expected: IllegalArgumentException) {
-      assertEquals("Unexpected code point: 0x110000", expected.message)
     }
+    assertThat(expected).hasMessage("Unexpected code point: 0x110000")
   }
 
   @Test
@@ -235,25 +232,17 @@ class Utf8Test {
 
   @Test
   fun sizeBoundsCheck() {
-    try {
+    assertFailsWith<NullPointerException> {
       null!!.utf8Size(0, 0)
-      fail()
-    } catch (expected: NullPointerException) {
     }
-    try {
+    assertFailsWith<IllegalArgumentException> {
       "abc".utf8Size(-1, 2)
-      fail()
-    } catch (expected: IllegalArgumentException) {
     }
-    try {
+    assertFailsWith<IllegalArgumentException> {
       "abc".utf8Size(2, 1)
-      fail()
-    } catch (expected: IllegalArgumentException) {
     }
-    try {
+    assertFailsWith<IllegalArgumentException> {
       "abc".utf8Size(1, 4)
-      fail()
-    } catch (expected: IllegalArgumentException) {
     }
   }
 
@@ -303,5 +292,69 @@ class Utf8Test {
     // Confirm we are consistent when measuring lengths.
     assertEquals(expectedUtf8.size.toLong(), string.utf8Size())
     assertEquals(expectedUtf8.size.toLong(), string.utf8Size(0, string.length))
+
+    // Confirm Appendable APIs works.
+    assertBufferAppendableWriteString(string, expectedUtf8)
+    assertBufferAppendableWriteChars(string, expectedUtf8)
+    assertBufferedSinkAppendableWriteString(string, expectedUtf8)
+    assertBufferedSinkAppendableWriteChars(string, expectedUtf8)
+  }
+
+  private fun assertBufferAppendableWriteString(string: String, expectedUtf8: ByteString) {
+    val buffer = Buffer()
+    buffer.utf8Appendable().append("abc${string}xyz")
+
+    assertThat(buffer.readUtf8(3)).isEqualTo("abc")
+    assertThat(buffer.readByteString(buffer.size - 3)).isEqualTo(expectedUtf8)
+    assertThat(buffer.readUtf8(3)).isEqualTo("xyz")
+  }
+
+  private fun assertBufferAppendableWriteChars(string: String, expectedUtf8: ByteString) {
+    val buffer = Buffer()
+    val appendable = buffer.utf8Appendable()
+    appendable.append('a')
+    appendable.append('b')
+    appendable.append('c')
+    for (c in string) {
+      appendable.append(c)
+    }
+    appendable.append('x')
+    appendable.append('y')
+    appendable.append('z')
+
+    assertThat(buffer.readUtf8(3)).isEqualTo("abc")
+    assertThat(buffer.readByteString(buffer.size - 3)).isEqualTo(expectedUtf8)
+    assertThat(buffer.readUtf8(3)).isEqualTo("xyz")
+  }
+
+  private fun assertBufferedSinkAppendableWriteString(string: String, expectedUtf8: ByteString) {
+    val data = Buffer()
+    val sink = (data as Sink).buffer()
+    sink.utf8Appendable().append("abc${string}xyz")
+    sink.emit()
+
+    assertThat(data.readUtf8(3)).isEqualTo("abc")
+    assertThat(data.readByteString(data.size - 3)).isEqualTo(expectedUtf8)
+    assertThat(data.readUtf8(3)).isEqualTo("xyz")
+  }
+
+  private fun assertBufferedSinkAppendableWriteChars(string: String, expectedUtf8: ByteString) {
+    val data = Buffer()
+    val sink = (data as Sink).buffer()
+    val appendable = sink.utf8Appendable()
+    appendable.append('a')
+    appendable.append('b')
+    appendable.append('c')
+    for (c in string) {
+      appendable.append(c)
+    }
+    appendable.append('x')
+    appendable.append('y')
+    appendable.append('z')
+    sink.emit()
+
+    assertThat(data.readUtf8(3)).isEqualTo("abc")
+    assertThat(data.readByteString(data.size - 3)).isEqualTo(expectedUtf8)
+    assertThat(data.readUtf8(3)).isEqualTo("xyz")
   }
 }


### PR DESCRIPTION
This is unreasonably painful because I'm committed to writing UTF-8 to the buffer, but the input string is UTF-16 and we might need to save a high surrogate for a follow-up call.

Closes: https://github.com/lysine-dev/okio/issues/1615
Closes: https://github.com/lysine-dev/okio/issues/1441