### PR TITLE
fix: apply Throttler.bytesPerSecond rate changes immediately (#1822)

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/Throttler.kt
+++ b/okio/src/jvmMain/kotlin/okio/Throttler.kt
@@ -49,6 +49,13 @@ class Throttler internal constructor(
   private var waitByteCount: Long = 8 * 1024 // 8 KiB.
   private var maxByteCount: Long = 256 * 1024 // 256 KiB.
 
+  /**
+   * When true, the next call to [byteCountOrWaitNanos] discards any future allocation and
+   * restarts the schedule at the supplied `now`. This makes [bytesPerSecond] rate changes take
+   * effect immediately instead of waiting out bytes allocated under a previous rate.
+   */
+  private var resetAllocation = false
+
   val lock: ReentrantLock = ReentrantLock()
   val condition: Condition = lock.newCondition()
 
@@ -69,6 +76,9 @@ class Throttler internal constructor(
       this.bytesPerSecond = bytesPerSecond
       this.waitByteCount = waitByteCount
       this.maxByteCount = maxByteCount
+      // Drop any allocation scheduled into the future under the previous rate so the new
+      // throughput applies on the next take instead of waiting out the old schedule.
+      resetAllocation = true
       condition.signalAll()
     }
   }
@@ -96,6 +106,11 @@ class Throttler internal constructor(
    * nanos; if it is positive it should be interpreted as a byte count.
    */
   internal fun byteCountOrWaitNanos(now: Long, byteCount: Long): Long {
+    if (resetAllocation) {
+      allocatedUntil = now
+      resetAllocation = false
+    }
+
     if (bytesPerSecond == 0L) return byteCount // No limits.
 
     val idleInNanos = maxOf(allocatedUntil - now, 0L)

--- a/okio/src/jvmTest/kotlin/okio/ThrottlerTakeTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ThrottlerTakeTest.kt
@@ -108,6 +108,29 @@ class ThrottlerTakeTest {
     assertElapsed(1000L)
   }
 
+  /**
+   * Increasing the rate used to leave the previous allocation schedule in place, so reads kept
+   * waiting for bytes scheduled under the old (slower) rate. Rate changes should apply immediately.
+   * https://github.com/square/okio/issues/1822
+   */
+  @Test fun bytesPerSecondIncreaseAppliesImmediately() {
+    throttler.bytesPerSecond(bytesPerSecond = 10, waitByteCount = 5, maxByteCount = 10)
+
+    // Exhaust the bucket; further takes would wait under the 10 B/s schedule.
+    assertThat(take(100L)).isEqualTo(10L)
+    assertElapsed(0L)
+
+    // Raise the rate substantially. The new limit must apply without waiting out the old schedule.
+    throttler.bytesPerSecond(bytesPerSecond = 20, waitByteCount = 5, maxByteCount = 10)
+
+    assertThat(take(100L)).isEqualTo(10L)
+    assertElapsed(0L)
+
+    // Subsequent takes still honor the new sustained rate (20 B/s → 250 ms per 5 bytes).
+    assertThat(take(100L)).isEqualTo(5L)
+    assertElapsed(250L)
+  }
+
   /** Take at least the minimum and up to `byteCount` bytes, sleeping once if necessary. */
   private fun take(byteCount: Long): Long {
     val byteCountOrWaitNanos = throttler.byteCountOrWaitNanos(nowNanos, byteCount)


### PR DESCRIPTION
## Summary

`Throttler.bytesPerSecond()` updated the configured rate but left any allocation already scheduled into the future under the previous rate. After a slow rate had pushed `allocatedUntil` far ahead, increasing the rate still waited on that old schedule — so throughput changes did not take effect promptly (e.g. download managers).

On rate reconfiguration, mark the allocation schedule for reset. The next `byteCountOrWaitNanos` / `take` restarts at the current time so the new throughput applies immediately, then normal sustained throttling continues at the new rate.

Fixes #1822

## Test plan

- [x] Added `ThrottlerTakeTest.bytesPerSecondIncreaseAppliesImmediately` (deterministic fake clock, same style as existing take tests)
- [x] `./gradlew :okio:jvmTest --tests 'okio.ThrottlerTakeTest' --tests 'okio.ThrottlerTest'` (Temurin 21): all `ThrottlerTakeTest` cases **PASSED** (6/6 including new); `ThrottlerTest` skipped (`@Ignore` flaky)