### PR TITLE
Enforce that Socket.cancel() does not throw

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/internal/DefaultSocket.kt
+++ b/okio/src/jvmMain/kotlin/okio/internal/DefaultSocket.kt
@@ -42,7 +42,17 @@ internal class DefaultSocket(val socket: JavaNetSocket) : Socket {
   override val sink: Sink = SocketSink()
 
   override fun cancel() {
-    socket.close()
+    try {
+      socket.close()
+    } catch (rethrown: RuntimeException) {
+      if (rethrown.message == "bio == null") {
+        // Conscrypt in Android 10 and 11 may throw closing an SSLSocket. This is safe to ignore.
+        // https://issuetracker.google.com/issues/177450597
+        return
+      }
+      throw rethrown
+    } catch (_: IOException) {
+    }
   }
 
   override fun toString() = socket.toString()

--- a/okio/src/jvmTest/kotlin/okio/SocketTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/SocketTest.kt
@@ -35,6 +35,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
 import okio.internal.DefaultSocket
 import org.junit.After
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -270,6 +271,46 @@ class SocketTest(val factory: Factory = Factory.Default) {
     assertFailsWith<SocketException> {
       unconnected.asOkioSocket()
     }
+  }
+
+  @Test
+  fun cancelIsQuiet() {
+    assumeTrue(factory == Factory.Default)
+
+    val (socketA, socketB) = createSocketPairThatThrowsOnClose(IOException("boom!"))
+    socketA.cancel()
+    socketB.cancel()
+  }
+
+  @Test
+  fun conscryptCrashIsQuiet() {
+    assumeTrue(factory == Factory.Default)
+
+    val (socketA, socketB) = createSocketPairThatThrowsOnClose(RuntimeException("bio == null"))
+    socketA.cancel()
+    socketB.cancel()
+  }
+
+  private fun createSocketPairThatThrowsOnClose(e: Throwable): Array<Socket> {
+    val localhost = InetAddress.getByName("localhost")
+
+    val serverSocket = ServerSocket()
+    serverSocket.bind(InetSocketAddress(localhost, 0))
+
+    val socketBFuture = CompletableFuture<java.net.Socket>()
+    thread(name = "createSocketPair") {
+      socketBFuture.complete(serverSocket.accept())
+    }
+
+    val socketA = object : java.net.Socket() {
+      override fun close() {
+        throw e
+      }
+    }
+    socketA.connect(InetSocketAddress(localhost, serverSocket.localPort))
+
+    val socketB = socketBFuture.get()
+    return arrayOf(socketA.asOkioSocket(), socketB.asOkioSocket())
   }
 
   @Suppress("ktlint:trailing-comma-on-declaration-site")


### PR DESCRIPTION
It doesn't throw in practice for java.net.Socket sockets, but that type is documented to throw IOException.

Also recover from a Conscrypt bug, as currently implemented in OkHttp.